### PR TITLE
fix(notebook-cloud): guard imperative store actions against stale completion, encode store doctrine

### DIFF
--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -201,6 +201,47 @@ Use this subsection when editing RxJS or shared-store code such as
   runtime WASM artifacts with the repo xtask flow before trusting TypeScript
   results.
 
+### Module-Singleton Source Stores
+
+For non-CRDT async sources (auth, catalog, access requests, workstations) held
+in a module-level `ObservableStore` singleton, follow Decision 8
+(`docs/adr/frontend-sync-bridge.md`). The store outlives every component, so
+each async completion is a stale-write risk:
+
+- **Domain hooks are the API; the binding is plumbing.** Components import
+  `useCloudAuthState`/`useHostedCatalogAuth`/`useCloudWorkstations`, never
+  `store.select(...)` inline in a render body and never
+  `observable-binding.ts` directly. One binding, shared desktop and cloud.
+- **Capture at issue, drop at apply — for every completion.** Poll ticks AND
+  imperative actions capture `{epoch, auth reference, endpoint}` when the
+  request starts; after every `await` (success, error, and any follow-up
+  refetch), the result is discarded if the identity moved. A guarded first
+  await followed by an unguarded second await is the recurring hole.
+- **Invalidation covers bookkeeping, not just visible state.** `dispose`,
+  `reset`, and a closed gate bump the activation epoch so captured issues die
+  with them; a dropped completion also clears any indicator it wrote (by
+  object-reference ownership, so it can never clobber a newer identity's own
+  state).
+- **After-settle loops re-arm on settle, never on emission.** A self-scheduling
+  poll re-arms via `repeat()` on completion, so a swallowed inner rejection
+  cannot kill the loop. Keep `catchError` on the inner fetch.
+- **One in-flight guard, one `exhaustMap`.** Triggers that must not overlap
+  (interval tick, visibility rise, manual wakeup) feed a single `exhaustMap`;
+  do not give each trigger its own guard.
+- **Inject every clock.** `scheduler`, `now`, and the network operations are
+  `activate(deps)` arguments, so tests run entirely on virtual time and the
+  suite proves cadence, gates, aborts, and stale drops deterministically.
+- **Named comparators with the manifest tripwire.** `distinctUntilChanged`
+  uses a named `fooEquals(a, b)` with a colocated
+  `satisfies Record<keyof T, true>` manifest. The manifest forces every key to
+  be *listed* when the type grows; it does not prove every key is *compared* -
+  treat a break as a prompt to revisit the comparator body, not proof of
+  correctness.
+- **`loaded$` gates readiness, not state.** The state subject emits its seeded
+  default before the gate opens (state emits first, then the gate); a consumer
+  that must tell "loading" from "loaded empty" reads `loaded$`, never infers
+  from an empty snapshot.
+
 ## Hot Reload
 
 Best for UI/React development. Start the dev daemon and Vite from agent terminals; let the human launch the Tauri GUI from their own terminal.

--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -138,8 +138,9 @@ Use this subsection when editing RxJS or shared-store code such as
 `packages/runtimed/src/sync-engine.ts`,
 `packages/runtimed/src/*store*.ts`,
 `src/components/notebook/state/*`,
-`apps/notebook/src/lib/notebook-sync-store-bridge.ts`, or
-`apps/notebook-cloud/viewer/*facts*.ts`.
+`apps/notebook/src/lib/notebook-sync-store-bridge.ts`,
+`apps/notebook-cloud/viewer/*facts*.ts`, or
+`apps/notebook-cloud/viewer/*store*.ts`.
 
 ### State Boundary
 
@@ -209,7 +210,7 @@ in a module-level `ObservableStore` singleton, follow Decision 8
 each async completion is a stale-write risk:
 
 - **Domain hooks are the API; the binding is plumbing.** Components import
-  `useCloudAuthState`/`useHostedCatalogAuth`/`useCloudWorkstations`, never
+  `useCloudAuthState`/`useHostedCatalogAuth`/`useCloudWorkstationsRegistry`, never
   `store.select(...)` inline in a render body and never
   `observable-binding.ts` directly. One binding, shared desktop and cloud.
 - **Capture at issue, drop at apply — for every completion.** Poll ticks AND
@@ -218,16 +219,20 @@ each async completion is a stale-write risk:
   refetch), the result is discarded if the identity moved. A guarded first
   await followed by an unguarded second await is the recurring hole.
 - **Invalidation covers bookkeeping, not just visible state.** `dispose`,
-  `reset`, and a closed gate bump the activation epoch so captured issues die
-  with them; a dropped completion also clears any indicator it wrote (by
-  object-reference ownership, so it can never clobber a newer identity's own
-  state).
+  `reset`, and a signed-out closed gate bump the activation epoch so captured
+  issues die with them (a transient `loading` gate is a recoverable dip and
+  keeps in-flight work alive); a dropped completion also clears any indicator
+  it wrote (by object-reference ownership, so it can never clobber a newer
+  identity's own state).
 - **After-settle loops re-arm on settle, never on emission.** A self-scheduling
   poll re-arms via `repeat()` on completion, so a swallowed inner rejection
   cannot kill the loop. Keep `catchError` on the inner fetch.
-- **One in-flight guard, one `exhaustMap`.** Triggers that must not overlap
-  (interval tick, visibility rise, manual wakeup) feed a single `exhaustMap`;
-  do not give each trigger its own guard.
+- **One in-flight guard, one `exhaustMap`.** Fixed-rate triggers that must
+  not overlap (interval tick, visibility rise, manual wakeup) feed a single
+  `exhaustMap`; do not give each trigger its own guard. After-settle stores
+  instead serialize manual refresh and mutation refetches through a dedicated
+  `concatMap` action stream off the poll loop, so the coupling stays ordered
+  and the cadence unperturbed.
 - **Inject every clock.** `scheduler`, `now`, and the network operations are
   `activate(deps)` arguments, so tests run entirely on virtual time and the
   suite proves cadence, gates, aborts, and stale drops deterministically.
@@ -236,7 +241,11 @@ each async completion is a stale-write risk:
   `satisfies Record<keyof T, true>` manifest. The manifest forces every key to
   be *listed* when the type grows; it does not prove every key is *compared* -
   treat a break as a prompt to revisit the comparator body, not proof of
-  correctness.
+  correctness. A projection that allocates an array or object each tick needs
+  a structural comparator (length plus per-element identity/fields); a
+  reference check on a re-allocated value dedups nothing. The manifest break
+  surfaces as a tsc error (`pnpm --dir apps/notebook-cloud typecheck`); the
+  node test script alone will not catch it.
 - **`loaded$` gates readiness, not state.** The state subject emits its seeded
   default before the gate opens (state emits first, then the gate); a consumer
   that must tell "loading" from "loaded empty" reads `loaded$`, never infers

--- a/.claude/rules/notebook-state.md
+++ b/.claude/rules/notebook-state.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - src/components/notebook/state/**
+---
+
+@src/components/notebook/AGENTS.md

--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -70,6 +70,26 @@ stores, not from using document boundaries as a rerender workaround.
   authenticated notebook APIs. Do not serve user blobs from the renderer asset
   origin.
 
+### Viewer async state
+
+- The four source stores (`cloud-auth-store.ts`,
+  `cloud-access-request-store.ts`, `cloud-catalog-store.ts`,
+  `cloud-workstations-store.ts` in `viewer/`) extend `ObservableStore` and hold
+  cloud host policy per `docs/adr/frontend-sync-bridge.md` Decision 8.
+  Mechanism (`ObservableStore`/`select`/`createPoll`/`fetchLatest`) stays
+  DOM-free in `packages/runtimed`; these stores stay viewer-side per the
+  convergence memo's do-not-converge list.
+- Components consume named domain hooks (`useCloudAuthState`,
+  `useHostedCatalogAuth`, `useCloudWorkstations`, ...), never
+  `store.select(...)` in a render body and never a second React binding.
+- The stores are module singletons shared across surfaces, so every async
+  completion - poll tick, imperative action, and any follow-up refetch - is
+  captured at issue and dropped at apply against an activation epoch plus the
+  auth reference; `dispose`, `reset`, and a closed gate bump the epoch.
+  Comparators are named field-by-field functions with a colocated completeness
+  manifest, never deep-equal or JSON. Full pattern: frontend-dev skill,
+  "Module-Singleton Source Stores".
+
 ## Verification
 
 Use the narrowest relevant command:

--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -72,22 +72,27 @@ stores, not from using document boundaries as a rerender workaround.
 
 ### Viewer async state
 
-- The four source stores (`cloud-auth-store.ts`,
-  `cloud-access-request-store.ts`, `cloud-catalog-store.ts`,
-  `cloud-workstations-store.ts` in `viewer/`) extend `ObservableStore` and hold
-  cloud host policy per `docs/adr/frontend-sync-bridge.md` Decision 8.
+- The four source stores in `viewer/` hold cloud host policy per
+  `docs/adr/frontend-sync-bridge.md` Decision 8: `cloud-access-request-store.ts`,
+  `cloud-catalog-store.ts`, and `cloud-workstations-store.ts` extend
+  `ObservableStore`; `cloud-auth-store.ts` is deliberately a multi-subject
+  module store (synchronously seeded so instant paint can read it before React
+  mounts).
   Mechanism (`ObservableStore`/`select`/`createPoll`/`fetchLatest`) stays
   DOM-free in `packages/runtimed`; these stores stay viewer-side per the
   convergence memo's do-not-converge list.
 - Components consume named domain hooks (`useCloudAuthState`,
-  `useHostedCatalogAuth`, `useCloudWorkstations`, ...), never
+  `useHostedCatalogAuth`, `useCloudWorkstationsRegistry`, ...), never
   `store.select(...)` in a render body and never a second React binding.
 - The stores are module singletons shared across surfaces, so every async
   completion - poll tick, imperative action, and any follow-up refetch - is
   captured at issue and dropped at apply against an activation epoch plus the
-  auth reference; `dispose`, `reset`, and a closed gate bump the epoch.
-  Comparators are named field-by-field functions with a colocated completeness
-  manifest, never deep-equal or JSON. Full pattern: frontend-dev skill,
+  auth reference; `dispose`, `reset`, and a signed-out closed gate bump the
+  epoch (a transient `loading` gate is a recoverable dip and keeps in-flight
+  work alive). Comparators are named field-by-field functions with a colocated
+  completeness manifest, never deep-equal or JSON; the manifest break surfaces
+  as a tsc error via `pnpm --dir apps/notebook-cloud typecheck` - the node
+  `test` script will not catch it. Full pattern: frontend-dev skill,
   "Module-Singleton Source Stores".
 
 ## Verification

--- a/apps/notebook-cloud/test/cloud-access-request-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-store.test.ts
@@ -7,9 +7,10 @@
  * virtual-time total while fetch resolution stays under test control.
  *
  * The load-bearing cases: the fixed-rate poll shares one in-flight guard across
- * the interval and the visibility rise (F4), and a `pending -> granted`
- * transition settles the poll with no infinite re-arm (the reactive-cycle
- * convergence guard).
+ * the interval and the visibility rise (F4), a `pending -> granted` transition
+ * settles the poll with no infinite re-arm (the reactive-cycle convergence
+ * guard), and a `requestEditAccess` POST resolving after a reset or an auth flip
+ * drops its completion rather than applying it to a superseded identity.
  */
 
 import assert from "node:assert/strict";
@@ -567,6 +568,82 @@ describe("CloudAccessRequestStore edit-access request", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it("drops a POST completion issued before reset (no applyLoaded, no side effects)", async () => {
+    const store = new CloudAccessRequestStore({ readSelectedMode: () => "edit" });
+    const inputs$ = new BehaviorSubject<CloudAccessRequestInputs>(inputsFrom(baseSource()));
+    let retries = 0;
+    let refreshes = 0;
+    const scopes: string[] = [];
+    const postCalls: Array<{ resolve: (value: CloudAccessRequestPostResult) => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        onRetryLiveConnection: () => (retries += 1),
+        onRefreshAuth: () => (refreshes += 1),
+        storeRequestedScope: (scope) => scopes.push(scope),
+        postEditAccessRequest: () =>
+          new Promise<CloudAccessRequestPostResult>((resolve) => {
+            postCalls.push({ resolve });
+          }),
+      }),
+    );
+
+    // Issue the request, then reset before the POST resolves.
+    store.requestEditAccess();
+    assert.equal(store.snapshot.requestedByUser, true);
+    store.reset();
+    assert.equal(store.snapshot.selectedMode, "view");
+
+    // The stale granted response resolves after the reset: it must not restore
+    // `latest`, force edit mode, or fire any transition side effect.
+    postCalls[0].resolve({ access_status: "granted" });
+    await drainMicrotasks();
+    assert.equal(store.snapshot.latest, null);
+    assert.equal(store.snapshot.selectedMode, "view");
+    assert.equal(retries, 0);
+    assert.equal(refreshes, 0);
+    assert.deepEqual(scopes, []);
+
+    dispose();
+  });
+
+  it("drops a POST completion when browser auth flips mid-flight", async () => {
+    const store = new CloudAccessRequestStore({ readSelectedMode: () => "edit" });
+    const inputs$ = new BehaviorSubject<CloudAccessRequestInputs>(inputsFrom(baseSource()));
+    let retries = 0;
+    const scopes: string[] = [];
+    const postCalls: Array<{ resolve: (value: CloudAccessRequestPostResult) => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        onRetryLiveConnection: () => (retries += 1),
+        storeRequestedScope: (scope) => scopes.push(scope),
+        postEditAccessRequest: () =>
+          new Promise<CloudAccessRequestPostResult>((resolve) => {
+            postCalls.push({ resolve });
+          }),
+      }),
+    );
+
+    store.requestEditAccess();
+    await drainMicrotasks();
+
+    // Browser auth flips while the POST is in flight; the gate is not load-eligible
+    // (view-only source), so only the fetch identity changes.
+    const rotated = { ...browserAuth(), token: "rotated-token" };
+    inputs$.next(inputsFrom(baseSource(), { browserAuth: rotated }));
+    await drainMicrotasks();
+
+    // The stale granted response resolves under the superseded identity: dropped.
+    postCalls[0].resolve({ access_status: "granted" });
+    await drainMicrotasks();
+    assert.equal(store.snapshot.latest, null);
+    assert.equal(retries, 0);
+    assert.deepEqual(scopes, []);
+
+    dispose();
   });
 });
 

--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -10,8 +10,10 @@
  * mutation kind, the after-settle poll cannot overlap and swallows failures while
  * the initial load surfaces them, the pairing poll auto-stops and drops a
  * stale-id response, the expiry clock reads `deps.now()` (never `Date.now`), the
- * attach mutation clears on a cross-channel runtime confirm, and the auth-flip
- * wipe is scoped to the surface's closed-gate.
+ * attach mutation clears on a cross-channel runtime confirm, the auth-flip wipe
+ * is scoped to the surface's closed-gate, an imperative mutation resolving after
+ * an auth flip or dispose drops its completion, and a closed gate clears the
+ * pairing and mutation.
  */
 
 import assert from "node:assert/strict";
@@ -25,7 +27,10 @@ import {
   type CloudWorkstationsStoreDeps,
 } from "../viewer/cloud-workstations-store";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
-import type { CloudWorkstationPairingStatusState } from "../viewer/workstations-client";
+import type {
+  CloudWorkstationPairingStatusState,
+  MintedCloudWorkstationPairing,
+} from "../viewer/workstations-client";
 
 /** Advance the virtual clock by `ms`, stopping at the target frame. */
 function advanceBy(scheduler: VirtualTimeScheduler, ms: number): void {
@@ -801,6 +806,171 @@ describe("CloudWorkstationsStore pairing", () => {
     await drainMicrotasks();
     assert.equal(store.snapshot.pairing?.status, "pending");
     assert.equal(store.snapshot.pairing?.workstationId, null);
+
+    dispose();
+  });
+});
+
+describe("CloudWorkstationsStore stale-completion guards", () => {
+  it("drops an attach completion when auth flips mid-flight (no refetch, registry kept)", async () => {
+    const scheduler = newScheduler();
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const { loadWorkstations, calls } = deferredLoad();
+    const attachCalls: Array<{ resolve: () => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        scheduler,
+        loadWorkstations,
+        attachWorkstation: () =>
+          new Promise<void>((resolve) => {
+            attachCalls.push({ resolve: () => resolve() });
+          }),
+      }),
+    );
+
+    // Settle the initial gate load under the first identity.
+    await drainMicrotasks();
+    assert.equal(calls.length, 1);
+    calls[0].resolve(registry({ workstations: [workstation("ws-1", "Lab")] }));
+    await drainMicrotasks();
+    assert.equal(store.snapshot.registry.workstations[0]?.id, "ws-1");
+
+    // Start an attach; it hangs in flight under the first identity.
+    void store.attach("ws-1");
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.kind, "attach");
+
+    // Auth flips: the gate driver reloads under the new identity (calls[1]), but
+    // the attach fetch keeps its first-identity request in flight.
+    inputs$.next(baseInputs({ auth: ROTATED_AUTH }));
+    await drainMicrotasks();
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].auth, ROTATED_AUTH);
+
+    // The stale attach resolves after the flip: no clearError, no refetch dispatch
+    // (the refetch would push a third load), and the registry stays untouched.
+    attachCalls[0].resolve();
+    await drainMicrotasks();
+    assert.equal(calls.length, 2);
+    assert.equal(store.snapshot.registry.workstations[0]?.id, "ws-1");
+
+    dispose();
+  });
+
+  it("drops a startPairing mint completion after dispose (pairing stays null)", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const mintCalls: Array<{ resolve: (value: MintedCloudWorkstationPairing) => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        mintPairing: () =>
+          new Promise<MintedCloudWorkstationPairing>((resolve) => {
+            mintCalls.push({ resolve });
+          }),
+      }),
+    );
+    await drainMicrotasks();
+
+    // The mint is in flight when the store is disposed.
+    void store.startPairing();
+    await drainMicrotasks();
+    dispose();
+
+    // The mint resolves after dispose: the pairing card must not be written.
+    mintCalls[0].resolve({
+      id: "pair-1",
+      code: "AAAA-BBBB",
+      expiresAt: new Date(600_000).toISOString(),
+    });
+    await drainMicrotasks();
+    assert.equal(store.snapshot.pairing, null);
+  });
+
+  it("drops a setDefault completion when auth flips mid-flight (no optimistic patch)", async () => {
+    const scheduler = newScheduler();
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const { loadWorkstations, calls } = deferredLoad();
+    const defaultCalls: Array<{ resolve: (value: string | null) => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        scheduler,
+        loadWorkstations,
+        setDefaultWorkstation: () =>
+          new Promise<string | null>((resolve) => {
+            defaultCalls.push({ resolve });
+          }),
+      }),
+    );
+
+    // Settle the initial gate load with a known default.
+    await drainMicrotasks();
+    assert.equal(calls.length, 1);
+    calls[0].resolve(
+      registry({
+        defaultWorkstationId: "ws-1",
+        workstations: [workstation("ws-1", "Lab"), workstation("ws-2", "Hub")],
+      }),
+    );
+    await drainMicrotasks();
+    assert.equal(store.snapshot.registry.defaultWorkstationId, "ws-1");
+
+    // Start a set-default; it hangs in flight under the first identity.
+    void store.setDefault("ws-2");
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.kind, "default");
+
+    // Auth flips: the gate driver reloads under the new identity (calls[1]).
+    inputs$.next(baseInputs({ auth: ROTATED_AUTH }));
+    await drainMicrotasks();
+    assert.equal(calls.length, 2);
+
+    // The stale set-default resolves after the flip: no optimistic default patch
+    // and no reconciling refetch (which would push a third load).
+    defaultCalls[0].resolve("ws-2");
+    await drainMicrotasks();
+    assert.equal(store.snapshot.registry.defaultWorkstationId, "ws-1");
+    assert.equal(calls.length, 2);
+
+    dispose();
+  });
+
+  it("clears the pairing and mutation when the gate closes", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        loadWorkstations: async () => registry({ workstations: [workstation("ws-1", "Lab")] }),
+        mintPairing: async () => ({
+          id: "pair-1",
+          code: "ABCD-EFGH",
+          expiresAt: new Date(600_000).toISOString(),
+        }),
+        // Hangs so the attach mutation stays in flight across the gate close.
+        attachWorkstation: () => new Promise<void>(() => {}),
+      }),
+    );
+    await drainMicrotasks();
+
+    await store.startPairing();
+    void store.attach("ws-1");
+    await drainMicrotasks();
+    assert.notEqual(store.snapshot.pairing, null);
+    assert.equal(store.snapshot.mutation.kind, "attach");
+
+    // The gate closes on a lost identity: the singleton clears the pairing card
+    // and the in-flight mutation the way the unmounted manager hook used to.
+    inputs$.next(
+      baseInputs({ canFetch: false, closedGate: { status: "signed_out", wipeRegistry: true } }),
+    );
+    await drainMicrotasks();
+    assert.equal(store.snapshot.pairing, null);
+    assert.equal(store.snapshot.mutation.kind, "idle");
 
     dispose();
   });

--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -986,6 +986,91 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
     dispose();
   });
 
+  it("clears the mutation when identity flips during the post-success refetch", async () => {
+    const scheduler = newScheduler();
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const { loadWorkstations, calls } = deferredLoad();
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        scheduler,
+        loadWorkstations,
+        setDefaultWorkstation: async () => "ws-2",
+      }),
+    );
+
+    // Settle the initial gate load under the first identity.
+    await drainMicrotasks();
+    calls[0].resolve(
+      registry({
+        defaultWorkstationId: "ws-1",
+        workstations: [workstation("ws-1", "Lab"), workstation("ws-2", "Hub")],
+      }),
+    );
+    await drainMicrotasks();
+
+    // The PATCH resolves while still current, so the reconciling refetch
+    // (calls[1]) is issued - and hangs while auth flips.
+    void store.setDefault("ws-2");
+    await drainMicrotasks();
+    assert.equal(calls.length, 2);
+    assert.equal(store.snapshot.mutation.kind, "default");
+    inputs$.next(baseInputs({ auth: ROTATED_AUTH }));
+    await drainMicrotasks();
+
+    // The superseded refetch settles: the finally may not write idle over the
+    // new identity, but the "default" indicator this action owns cannot stay
+    // stuck either.
+    calls[1].resolve(registry({ defaultWorkstationId: "ws-2" }));
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.kind, "idle");
+
+    dispose();
+  });
+
+  it("keeps the pairing and mutation through a transient loading gate", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const mintCalls: Array<{ resolve: (value: MintedCloudWorkstationPairing) => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        loadWorkstations: async () => registry({ workstations: [workstation("ws-1", "Lab")] }),
+        mintPairing: () =>
+          new Promise<MintedCloudWorkstationPairing>((resolve) => {
+            mintCalls.push({ resolve });
+          }),
+        attachWorkstation: () => new Promise<void>(() => {}),
+      }),
+    );
+    await drainMicrotasks();
+
+    void store.startPairing();
+    void store.attach("ws-1");
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.kind, "attach");
+
+    // A recoverable eligibility dip (user still signed in) is not the unmount
+    // analog: the pairing card, the mutation, and in-flight issues survive it.
+    inputs$.next(
+      baseInputs({ canFetch: false, closedGate: { status: "loading", wipeRegistry: false } }),
+    );
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.kind, "attach");
+
+    // The in-flight mint also completes normally across the dip.
+    mintCalls[0].resolve({
+      id: "pair-1",
+      code: "AAAA-BBBB",
+      expiresAt: new Date(600_000).toISOString(),
+    });
+    await drainMicrotasks();
+    assert.equal(store.snapshot.pairing?.status, "pending");
+
+    dispose();
+  });
+
   it("drops a mint completion that resolves after the gate closes", async () => {
     const store = new CloudWorkstationsStore();
     const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());

--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -855,6 +855,50 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
     await drainMicrotasks();
     assert.equal(calls.length, 2);
     assert.equal(store.snapshot.registry.workstations[0]?.id, "ws-1");
+    // The superseded action's own indicator cannot stay stuck under the new
+    // identity: dropping the completion also clears the mutation it wrote.
+    assert.equal(store.snapshot.mutation.kind, "idle");
+
+    dispose();
+  });
+
+  it("leaves a newer identity's mutation intact when a stale completion clears its own", async () => {
+    const scheduler = newScheduler();
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const { loadWorkstations } = deferredLoad();
+    const attachCalls: Array<{ resolve: () => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        scheduler,
+        loadWorkstations,
+        attachWorkstation: () =>
+          new Promise<void>((resolve) => {
+            attachCalls.push({ resolve: () => resolve() });
+          }),
+      }),
+    );
+    await drainMicrotasks();
+
+    // First identity starts an attach that hangs.
+    void store.attach("ws-1");
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.workstationId, "ws-1");
+
+    // Auth flips and the new identity starts its own attach.
+    inputs$.next(baseInputs({ auth: ROTATED_AUTH }));
+    await drainMicrotasks();
+    void store.attach("ws-2");
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.workstationId, "ws-2");
+
+    // The stale first attach resolves: it may clear only the mutation object it
+    // wrote, and that object was already replaced by the new identity's attach.
+    attachCalls[0].resolve();
+    await drainMicrotasks();
+    assert.equal(store.snapshot.mutation.kind, "attach");
+    assert.equal(store.snapshot.mutation.workstationId, "ws-2");
 
     dispose();
   });
@@ -935,6 +979,82 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
     await drainMicrotasks();
     assert.equal(store.snapshot.registry.defaultWorkstationId, "ws-1");
     assert.equal(calls.length, 2);
+    // The dropped completion clears the indicator it owns rather than leaving a
+    // stuck "default" mutation under the new identity.
+    assert.equal(store.snapshot.mutation.kind, "idle");
+
+    dispose();
+  });
+
+  it("drops a mint completion that resolves after the gate closes", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const mintCalls: Array<{ resolve: (value: MintedCloudWorkstationPairing) => void }> = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        mintPairing: () =>
+          new Promise<MintedCloudWorkstationPairing>((resolve) => {
+            mintCalls.push({ resolve });
+          }),
+      }),
+    );
+    await drainMicrotasks();
+
+    // The mint hangs while the gate closes under the SAME auth reference and
+    // endpoint - only the closed gate itself invalidates the captured issue.
+    void store.startPairing();
+    await drainMicrotasks();
+    inputs$.next(
+      baseInputs({ canFetch: false, closedGate: { status: "signed_out", wipeRegistry: true } }),
+    );
+    await drainMicrotasks();
+    assert.equal(store.snapshot.pairing, null);
+
+    // The mint resolves after the close: the pairing card must not come back.
+    mintCalls[0].resolve({
+      id: "pair-1",
+      code: "AAAA-BBBB",
+      expiresAt: new Date(600_000).toISOString(),
+    });
+    await drainMicrotasks();
+    assert.equal(store.snapshot.pairing, null);
+
+    dispose();
+  });
+
+  it("drops a stale refetch response that lands after an auth flip", async () => {
+    const scheduler = newScheduler();
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const { loadWorkstations, calls } = deferredLoad();
+    const dispose = store.activate(inputs$, baseDeps({ scheduler, loadWorkstations }));
+
+    // Settle the initial gate load under the first identity.
+    await drainMicrotasks();
+    calls[0].resolve(registry({ workstations: [workstation("ws-a", "Old")] }));
+    await drainMicrotasks();
+
+    // A manual refresh issues a refetch under the first identity and hangs.
+    void store.refreshNow();
+    await drainMicrotasks();
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].auth, STABLE_AUTH);
+
+    // Auth flips; the gate driver loads and lands the new identity's registry.
+    inputs$.next(baseInputs({ auth: ROTATED_AUTH }));
+    await drainMicrotasks();
+    assert.equal(calls.length, 3);
+    assert.equal(calls[2].auth, ROTATED_AUTH);
+    calls[2].resolve(registry({ workstations: [workstation("ws-b", "New")] }));
+    await drainMicrotasks();
+    assert.equal(store.snapshot.registry.workstations[0]?.id, "ws-b");
+
+    // The first identity's refetch resolves last: its response is dropped, so
+    // the superseded registry cannot overwrite the current one.
+    calls[1].resolve(registry({ workstations: [workstation("ws-a", "Old")] }));
+    await drainMicrotasks();
+    assert.equal(store.snapshot.registry.workstations[0]?.id, "ws-b");
 
     dispose();
   });

--- a/apps/notebook-cloud/viewer/cloud-access-request-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-store.ts
@@ -161,6 +161,17 @@ function accessRequestLoadGateEquals(a: AccessRequestLoadGate, b: AccessRequestL
   return a.shouldLoad === b.shouldLoad && a.auth === b.auth && a.endpoint === b.endpoint;
 }
 
+/**
+ * The identity a `requestEditAccess` POST captured at issue. Its post-await guard
+ * drops the completion when the activation epoch, browser auth reference, or
+ * endpoint no longer matches the live activation.
+ */
+interface AccessRequestIssue {
+  epoch: number;
+  auth: CloudPrototypeAuthState;
+  endpoint: string;
+}
+
 function defaultSelectedMode(): CloudNotebookUrlMode {
   if (typeof window === "undefined") {
     return "view";
@@ -245,6 +256,14 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
 
   private latestInputs: CloudAccessRequestInputs | null = null;
   private resolvedDeps: ResolvedAccessRequestDeps | null = null;
+  /**
+   * Monotonic activation counter, bumped on every `activate`, its disposer, and
+   * `reset`. A `requestEditAccess` POST captures the epoch it was issued under so
+   * a completion that lands after a reset, sign-out, or dispose/re-activate drops
+   * itself rather than restoring `latest`, forcing edit mode, and firing the
+   * transition side effects for a context that is no longer live.
+   */
+  private activationEpoch = 0;
 
   constructor(options: CloudAccessRequestStoreOptions = {}) {
     const readSelectedMode = options.readSelectedMode ?? defaultSelectedMode;
@@ -272,6 +291,7 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
 
   /** Sign-out reset: drop the request, the error, and fall back to view mode. */
   reset(): void {
+    this.activationEpoch += 1;
     this.setState({ latest: null, error: null, requestedByUser: false, selectedMode: "view" });
   }
 
@@ -286,6 +306,11 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
     if (!inputs || !deps) {
       return;
     }
+    const issue: AccessRequestIssue = {
+      epoch: this.activationEpoch,
+      auth: inputs.browserAuth,
+      endpoint: inputs.endpoint,
+    };
     this.updateState((state) => ({ ...state, requestedByUser: true, error: null }));
     void (async () => {
       try {
@@ -293,6 +318,13 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
           endpoint: inputs.endpoint,
           auth: inputs.browserAuth,
         });
+        // A reset, sign-out, or dispose/re-activate can land while the POST is in
+        // flight; the store is a shared singleton, so drop the completion rather
+        // than restore `latest`, force edit mode, and fire the transition side
+        // effects for a superseded identity.
+        if (!this.requestStillCurrent(issue)) {
+          return;
+        }
         if (result.access_status === "granted") {
           const stamp = new Date(deps.now()).toISOString();
           this.applyLoaded(
@@ -314,12 +346,29 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
         }
         this.applyLoaded(result.access_request ?? null, { overrideSelectedMode: "edit" });
       } catch (error) {
+        if (!this.requestStillCurrent(issue)) {
+          return;
+        }
         this.updateState((state) => ({
           ...state,
           error: error instanceof Error ? error.message : String(error),
         }));
       }
     })();
+  }
+
+  /**
+   * Whether a `requestEditAccess` POST issued under `issue` may still apply its
+   * completion. A bumped epoch (reset or dispose/re-activate) or a changed browser
+   * auth reference or endpoint means a fresh identity took over while the POST was
+   * in flight, so both the state writes and the transition side effects drop.
+   */
+  private requestStillCurrent(issue: AccessRequestIssue): boolean {
+    return (
+      this.activationEpoch === issue.epoch &&
+      this.latestInputs?.browserAuth === issue.auth &&
+      this.latestInputs?.endpoint === issue.endpoint
+    );
   }
 
   /**
@@ -331,6 +380,7 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
     inputs$: Observable<CloudAccessRequestInputs>,
     deps: CloudAccessRequestStoreDeps,
   ): () => void {
+    const epoch = (this.activationEpoch += 1);
     const resolved: ResolvedAccessRequestDeps = {
       notebookId: deps.notebookId,
       now: deps.now ?? (() => Date.now()),
@@ -416,6 +466,9 @@ export class CloudAccessRequestStore extends ObservableStore<CloudAccessRequestS
     );
 
     return () => {
+      if (this.activationEpoch === epoch) {
+        this.activationEpoch += 1;
+      }
       subscription.unsubscribe();
       this.resolvedDeps = null;
       this.latestInputs = null;

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -646,7 +646,6 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
         workstationId,
       });
       if (!this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
-        this.clearMutationIfOwned(mutation);
         return;
       }
       this.updateState((state) => ({
@@ -661,15 +660,16 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     } catch (error) {
       if (this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
         this.setError(errorMessage(error));
-      } else {
-        this.clearMutationIfOwned(mutation);
       }
     } finally {
       // A still-current action clears to idle unconditionally. A superseded one
-      // must not write idle over a mutation the new identity started; it clears
-      // only the object it owns (already done on its drop path above).
+      // must not write idle over a mutation the new identity started, so it
+      // clears only the object it owns - covering the drop paths above AND an
+      // identity flip that lands during the post-success refetch await.
       if (this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
         this.setMutation({ kind: "idle", message: null, workstationId: null });
+      } else {
+        this.clearMutationIfOwned(mutation);
       }
     }
   }
@@ -854,24 +854,32 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
 
   /**
    * Apply the surface's closed-gate outcome: flip status, wipe the registry only
-   * when asked (rail lost-identity), clear the error, and drop the mutation and
-   * pairing. A closed gate is the singleton's stand-in for the manager hook
-   * unmounting, so the pairing card and any in-flight mutation bookkeeping cannot
-   * survive it into the next identity.
+   * when asked (rail lost-identity), and clear the error. A `signed_out` gate is
+   * the singleton's stand-in for the manager hook unmounting, so it also drops
+   * the mutation and pairing and invalidates in-flight issues; a `loading` gate
+   * is a recoverable eligibility dip and keeps them.
    */
   private applyClosedGate(gate: CloudWorkstationsClosedGate): void {
-    // Captured mutation issues die with the gate: a mint/attach/set-default
-    // resolving after the close must stay dropped even when the auth reference
-    // and endpoint are unchanged, so clearing the visible card below is not
-    // enough on its own.
-    this.activationEpoch += 1;
+    // Only a lost identity is the unmount analog. A transient `loading` gate
+    // (eligibility dip with the user still signed in) keeps the pairing card,
+    // the mutation, and in-flight issues alive, matching the per-component
+    // hooks that stayed mounted through it. On `signed_out`, captured mutation
+    // issues die with the gate: a mint/attach/set-default resolving after the
+    // close must stay dropped even when the auth reference and endpoint are
+    // unchanged, so clearing the visible card below is not enough on its own.
+    const identityLost = gate.status === "signed_out";
+    if (identityLost) {
+      this.activationEpoch += 1;
+    }
     this.updateState((state) => ({
       ...state,
       status: gate.status,
       registry: gate.wipeRegistry ? EMPTY_REGISTRY : state.registry,
       error: null,
-      mutation: { kind: "idle", message: null, workstationId: null },
-      pairing: null,
+      mutation: identityLost
+        ? { kind: "idle", message: null, workstationId: null }
+        : state.mutation,
+      pairing: identityLost ? null : state.pairing,
     }));
   }
 

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -485,11 +485,18 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
           concatMap((done) =>
             defer(() => {
               this.beginLoad();
+              // The refetch runs under whichever identity is current when its
+              // turn in the queue comes, but its response can land after a
+              // later flip - so it is tagged and dropped at apply exactly like
+              // a background tick, and its error write is guarded the same way.
+              const auth = this.latestInputs?.auth ?? null;
               const controller = new AbortController();
               return from(this.runCurrentLoad(controller.signal)).pipe(
-                map((registry) => ({ registry })),
+                // `runCurrentLoad` rejects when inputs (and thus auth) are
+                // missing, so a resolved registry always carries an identity.
+                map((registry) => ({ auth: auth as CloudPrototypeAuthState, registry })),
                 catchError((error) => {
-                  if (error !== POLL_SKIP) {
+                  if (error !== POLL_SKIP && this.latestInputs?.auth === auth) {
                     this.applyRegistryError(errorMessage(error));
                   }
                   return EMPTY;
@@ -502,7 +509,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
             }),
           ),
         )
-        .subscribe((result) => this.applyRegistrySuccess(result.registry)),
+        .subscribe((tick) => this.applyRegistryTickIfCurrent(tick)),
     );
 
     // Pairing redemption poll: chases {pending, redeemed} at 2s, stops on
@@ -626,7 +633,12 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       return;
     }
     const issue = this.captureMutationIssue(inputs.auth, inputs.defaultEndpoint);
-    this.setMutation({ kind: "default", message: null, workstationId });
+    const mutation: CloudWorkstationMutationState = {
+      kind: "default",
+      message: null,
+      workstationId,
+    };
+    this.setMutation(mutation);
     try {
       const defaultWorkstationId = await deps.setDefaultWorkstation({
         endpoint: inputs.defaultEndpoint,
@@ -634,6 +646,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
         workstationId,
       });
       if (!this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
+        this.clearMutationIfOwned(mutation);
         return;
       }
       this.updateState((state) => ({
@@ -648,11 +661,13 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     } catch (error) {
       if (this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
         this.setError(errorMessage(error));
+      } else {
+        this.clearMutationIfOwned(mutation);
       }
     } finally {
-      // Only clear the mutation the still-current action owns: a superseded
-      // identity's `idle` write would clobber a fresh mutation the new identity
-      // started, and its own stale indicator is cleared by `applyClosedGate`.
+      // A still-current action clears to idle unconditionally. A superseded one
+      // must not write idle over a mutation the new identity started; it clears
+      // only the object it owns (already done on its drop path above).
       if (this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
         this.setMutation({ kind: "idle", message: null, workstationId: null });
       }
@@ -675,11 +690,12 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       return false;
     }
     const issue = this.captureMutationIssue(inputs.auth, inputs.attachEndpoint);
-    this.setMutation({
+    const mutation: CloudWorkstationMutationState = {
       kind: "attach",
       message: options.message ?? DEFAULT_ATTACH_MESSAGE,
       workstationId,
-    });
+    };
+    this.setMutation(mutation);
     try {
       await deps.attachWorkstation({
         endpoint: inputs.attachEndpoint,
@@ -688,6 +704,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
         replaceExisting: options.replaceExisting === true,
       });
       if (!this.mutationStillCurrent(issue, this.latestInputs?.attachEndpoint)) {
+        this.clearMutationIfOwned(mutation);
         return false;
       }
       this.clearError();
@@ -695,6 +712,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       return true;
     } catch (error) {
       if (!this.mutationStillCurrent(issue, this.latestInputs?.attachEndpoint)) {
+        this.clearMutationIfOwned(mutation);
         return false;
       }
       this.setError(errorMessage(error));
@@ -842,6 +860,11 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
    * survive it into the next identity.
    */
   private applyClosedGate(gate: CloudWorkstationsClosedGate): void {
+    // Captured mutation issues die with the gate: a mint/attach/set-default
+    // resolving after the close must stay dropped even when the auth reference
+    // and endpoint are unchanged, so clearing the visible card below is not
+    // enough on its own.
+    this.activationEpoch += 1;
     this.updateState((state) => ({
       ...state,
       status: gate.status,
@@ -931,6 +954,19 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
 
   private setMutation(mutation: CloudWorkstationMutationState): void {
     this.updateState((state) => ({ ...state, mutation }));
+  }
+
+  /**
+   * Clear a mutation indicator written by a now-superseded action. Ownership is
+   * the exact object the action wrote: a newer identity's `setMutation` has
+   * replaced the object, so a stale clear can never clobber a mutation the
+   * current identity started, while a stuck indicator from the old identity
+   * cannot outlive its dropped completion.
+   */
+  private clearMutationIfOwned(owned: CloudWorkstationMutationState): void {
+    if (this.snapshot.mutation === owned) {
+      this.setMutation({ kind: "idle", message: null, workstationId: null });
+    }
   }
 
   private setError(message: string): void {

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -364,6 +364,14 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
   private readonly _inputs$ = new BehaviorSubject<CloudWorkstationsInputs | null>(null);
   private latestInputs: CloudWorkstationsInputs | null = null;
   private resolvedDeps: ResolvedWorkstationsDeps | null = null;
+  /**
+   * Monotonic activation counter, bumped on every `activate` and its disposer.
+   * An imperative mutation captures the epoch it was issued under so a completion
+   * that lands after a dispose/re-activate drops itself rather than writing into
+   * the current mount. This is the mint/attach/set-default analogue of the poll
+   * paths' `RegistryTick`/`PairingStatusTick` auth tag.
+   */
+  private activationEpoch = 0;
   /** Ordered refetch action stream; each carries a settle callback. */
   private readonly refetchRequests$ = new Subject<() => void>();
 
@@ -392,6 +400,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     inputs$: Observable<CloudWorkstationsInputs>,
     deps: CloudWorkstationsStoreDeps,
   ): () => void {
+    const epoch = (this.activationEpoch += 1);
     this.resetState(EMPTY_STATE);
     const resolved = this.resolveDeps(deps);
     this.resolvedDeps = resolved;
@@ -542,6 +551,9 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     }
 
     return () => {
+      if (this.activationEpoch === epoch) {
+        this.activationEpoch += 1;
+      }
       subscription.unsubscribe();
       this.resolvedDeps = null;
       this.latestInputs = null;
@@ -556,8 +568,12 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       return;
     }
     const endpoint = inputs.workstationsEndpoint;
+    const issue = this.captureMutationIssue(inputs.auth, endpoint);
     try {
       const minted = await deps.mintPairing({ endpoint, auth: inputs.auth });
+      if (!this.mutationStillCurrent(issue, this.latestInputs?.workstationsEndpoint)) {
+        return;
+      }
       this.updateState((state) => ({
         ...state,
         pairing: {
@@ -573,6 +589,9 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
         },
       }));
     } catch (error) {
+      if (!this.mutationStillCurrent(issue, this.latestInputs?.workstationsEndpoint)) {
+        return;
+      }
       this.updateState((state) => ({
         ...state,
         pairing: {
@@ -606,6 +625,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     if (!inputs || !deps || !inputs.defaultEndpoint) {
       return;
     }
+    const issue = this.captureMutationIssue(inputs.auth, inputs.defaultEndpoint);
     this.setMutation({ kind: "default", message: null, workstationId });
     try {
       const defaultWorkstationId = await deps.setDefaultWorkstation({
@@ -613,6 +633,9 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
         auth: inputs.auth,
         workstationId,
       });
+      if (!this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
+        return;
+      }
       this.updateState((state) => ({
         ...state,
         registry: {
@@ -623,9 +646,16 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       this.clearError();
       await this.refreshNow();
     } catch (error) {
-      this.setError(errorMessage(error));
+      if (this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
+        this.setError(errorMessage(error));
+      }
     } finally {
-      this.setMutation({ kind: "idle", message: null, workstationId: null });
+      // Only clear the mutation the still-current action owns: a superseded
+      // identity's `idle` write would clobber a fresh mutation the new identity
+      // started, and its own stale indicator is cleared by `applyClosedGate`.
+      if (this.mutationStillCurrent(issue, this.latestInputs?.defaultEndpoint)) {
+        this.setMutation({ kind: "idle", message: null, workstationId: null });
+      }
     }
   }
 
@@ -644,6 +674,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     if (!inputs || !deps || !inputs.attachEndpoint) {
       return false;
     }
+    const issue = this.captureMutationIssue(inputs.auth, inputs.attachEndpoint);
     this.setMutation({
       kind: "attach",
       message: options.message ?? DEFAULT_ATTACH_MESSAGE,
@@ -656,10 +687,16 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
         workstationId,
         replaceExisting: options.replaceExisting === true,
       });
+      if (!this.mutationStillCurrent(issue, this.latestInputs?.attachEndpoint)) {
+        return false;
+      }
       this.clearError();
       await this.refreshNow();
       return true;
     } catch (error) {
+      if (!this.mutationStillCurrent(issue, this.latestInputs?.attachEndpoint)) {
+        return false;
+      }
       this.setError(errorMessage(error));
       this.setMutation({ kind: "idle", message: null, workstationId: null });
       await this.refreshNow();
@@ -799,7 +836,10 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
 
   /**
    * Apply the surface's closed-gate outcome: flip status, wipe the registry only
-   * when asked (rail lost-identity), and always clear the error.
+   * when asked (rail lost-identity), clear the error, and drop the mutation and
+   * pairing. A closed gate is the singleton's stand-in for the manager hook
+   * unmounting, so the pairing card and any in-flight mutation bookkeeping cannot
+   * survive it into the next identity.
    */
   private applyClosedGate(gate: CloudWorkstationsClosedGate): void {
     this.updateState((state) => ({
@@ -807,6 +847,8 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       status: gate.status,
       registry: gate.wipeRegistry ? EMPTY_REGISTRY : state.registry,
       error: null,
+      mutation: { kind: "idle", message: null, workstationId: null },
+      pairing: null,
     }));
   }
 
@@ -860,6 +902,33 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     }
   }
 
+  /** Snapshot the identity an imperative mutation is issued under. */
+  private captureMutationIssue(
+    auth: CloudPrototypeAuthState,
+    endpoint: string,
+  ): WorkstationsMutationIssue {
+    return { epoch: this.activationEpoch, auth, endpoint };
+  }
+
+  /**
+   * Whether a mutation issued under `issue` may still apply its completion. The
+   * store is one singleton shared by the rail and `/workstations`, so a sign-out,
+   * auth flip, or dispose/re-activate can land while a mint/attach/set-default is
+   * in flight. A bumped epoch or a changed auth reference or endpoint means the
+   * resolved (or rejected) response belongs to a superseded identity, so its
+   * state writes and refetch dispatches drop, mirroring the poll paths' auth tag.
+   */
+  private mutationStillCurrent(
+    issue: WorkstationsMutationIssue,
+    currentEndpoint: string | undefined,
+  ): boolean {
+    return (
+      this.activationEpoch === issue.epoch &&
+      this.latestInputs?.auth === issue.auth &&
+      currentEndpoint === issue.endpoint
+    );
+  }
+
   private setMutation(mutation: CloudWorkstationMutationState): void {
     this.updateState((state) => ({ ...state, mutation }));
   }
@@ -896,6 +965,17 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
           fetchCloudWorkstationPairingStatus(endpoint, auth, pairingId, signal)),
     };
   }
+}
+
+/**
+ * The identity an imperative mutation captured at issue. Its post-await guard
+ * drops the completion when the activation epoch, auth reference, or endpoint no
+ * longer matches the live activation.
+ */
+interface WorkstationsMutationIssue {
+  epoch: number;
+  auth: CloudPrototypeAuthState;
+  endpoint: string;
 }
 
 /** One background registry poll result, tagged with the auth it was fetched under. */

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -220,7 +220,7 @@ The same three-layer shape now applies to these sources:
    `select(project, equals)` projections deduped by named field-by-field
    comparators.
 3. **React bridge.** Each store exposes named domain hooks
-   (`useCloudAuthState`, `useHostedCatalogAuth`, `useCloudWorkstations`, ...)
+   (`useCloudAuthState`, `useHostedCatalogAuth`, `useCloudWorkstationsRegistry`, ...)
    defined next to its module-level projections. The hooks share one internal
    tearing-safe binding (`src/components/notebook/state/observable-binding.ts`,
    extracted from the runtime-state binding) but the binding is plumbing, not

--- a/packages/runtimed/AGENTS.md
+++ b/packages/runtimed/AGENTS.md
@@ -1,9 +1,10 @@
 # runtimed TypeScript store primitives
 
 Scope: the DOM-free store mechanism in `packages/runtimed/src`
-(`observable-store.ts`, `poll.ts`, the free `select`, and store subclasses like
-`runtime-state-store.ts`). Mechanism only - no React and no `document`/
-`window`/`Date.now()` in this layer. The React binding is
+(`observable-store.ts`, `poll.ts`, the free `select`, and the stores built on
+them; `runtime-state-store.ts` predates the base and is the pending
+`ObservableStore` retrofit target, frontend-sync-bridge FSB-2). Mechanism
+only - no React and no `document`/`window`/`Date.now()` in this layer. The React binding is
 `src/components/notebook/state/observable-binding.ts`; host-policy stores
 (cloud auth/access-request/catalog/workstations) live in
 `apps/notebook-cloud/viewer/` per the convergence memo's do-not-converge list.

--- a/packages/runtimed/AGENTS.md
+++ b/packages/runtimed/AGENTS.md
@@ -1,0 +1,37 @@
+# runtimed TypeScript store primitives
+
+Scope: the DOM-free store mechanism in `packages/runtimed/src`
+(`observable-store.ts`, `poll.ts`, the free `select`, and store subclasses like
+`runtime-state-store.ts`). Mechanism only - no React and no `document`/
+`window`/`Date.now()` in this layer. The React binding is
+`src/components/notebook/state/observable-binding.ts`; host-policy stores
+(cloud auth/access-request/catalog/workstations) live in
+`apps/notebook-cloud/viewer/` per the convergence memo's do-not-converge list.
+
+## Invariants
+
+- **`ObservableStore` emission order is load-bearing.** `setState` emits state
+  before the `loaded$` gate; `resetState` flips the gate false before the
+  default state lands. A subscriber combining the two must never see
+  `loaded=true` alongside a not-yet-applied state.
+- **`createPoll` after-settle re-arms on completion (`repeat`), never on
+  emission.** A rejected fetch is swallowed to `EMPTY` and emits nothing; if
+  re-arm depended on emission, one transient error would kill the loop.
+- **`createPoll` fixed-rate funnels every trigger through ONE `exhaustMap`.**
+  Interval tick, gate rise, and wakeups share a single in-flight guard; a
+  trigger landing mid-fetch is dropped, never a concurrent request.
+- **`interval$` is the teardown lever.** A new cadence (or `null`) tears down
+  the running loop and aborts the in-flight fetch via `finalize`. Model dynamic
+  cadence policy as this stream; do not add a second stop mechanism.
+- **Every timer takes an injectable `SchedulerLike`.** New pipelines here must
+  be virtual-time-total; tests never sleep on the wall clock.
+- **Comparators are named and manifest-backed.** `distinctUntilChanged` uses
+  named field-by-field `fooEquals` functions carrying a colocated
+  `satisfies Record<keyof T, true>` manifest (keys listed, not proven
+  compared). Never deep-equal or JSON in a dedup position.
+- **The barrel uses explicit re-exports.** A new export must be added to
+  `src/index.ts` or the `pnpm --dir apps/notebook build` tsc gate fails.
+
+Decision record: `docs/adr/frontend-sync-bridge.md` Decision 8. How-to depth:
+frontend-dev skill, "Module-Singleton Source Stores". Rust daemon guidance is
+separate: `crates/runtimed/AGENTS.md`.

--- a/src/components/notebook/AGENTS.md
+++ b/src/components/notebook/AGENTS.md
@@ -1,0 +1,28 @@
+# Notebook state stores
+
+Scope: `src/components/notebook/state/**` - the shared store layer between
+WASM/host sources and notebook UI. Two store idioms live here; the boundary is
+a Decision 8 call, not an accident (`docs/adr/frontend-sync-bridge.md`).
+
+## Two store idioms
+
+- **Hand-rolled `Map`/`Set` pub/sub** (`cell-store.ts`, `execution-store.ts`,
+  `output-store.ts`, `rail-ui-state.ts`, ...): synchronous per-entity fan-out
+  where per-subscriber granularity is the point and nothing cancels. Keep them
+  as they are; do not convert them to RxJS.
+- **RxJS-bound** (`runtime-state.ts`, `runtime-store-projection.ts`,
+  `view-store-projection.ts`): anything holding time, async, or an
+  `AbortController`. `runtime-state-store.ts` in `packages/runtimed` is the
+  pending `ObservableStore` retrofit target (frontend-sync-bridge FSB-2).
+
+## Binding is plumbing
+
+- `observable-binding.ts` is the single tearing-safe `useSyncExternalStore`
+  binding, shared by desktop and cloud store-hook modules. Its file header is
+  authoritative: components never import it and never call `store.select(...)`
+  inline in a render body; they consume named domain hooks
+  (`useRuntimeState`, `useCloudAuthState`, ...). Inline `select()` creates a
+  fresh Observable per render and defeats the binding cache.
+- Reset/reconnect paths invalidate stale async writes by epoch, not just
+  visible state. How-to depth: frontend-dev skill, "Module-Singleton Source
+  Stores".


### PR DESCRIPTION
Follow-up to #3906. The store refactor gave poll ticks capture-and-drop guards, but the imperative actions (`startPairing`, `attach`, `setDefault`, `requestEditAccess`) still applied their completions unconditionally - and module-singleton stores outlive the component unmounts that used to garbage-collect in-flight work. This closes that class end to end and encodes the store doctrine where it auto-loads.

## Stale-completion guards

Both stores gain an activation epoch. Every imperative action captures `{epoch, auth reference, endpoint}` at issue and re-checks after every await - success, error, and the follow-up refetch - so a completion landing after sign-out, an auth flip, dispose, or reset drops its state writes and side-effect dispatches (localStorage scope write, `retryLiveConnection`, `refreshAuthState`, mode override included).

The second-order holes got the same treatment:

- A dropped completion clears the mutation indicator it owns, by object reference, so it can neither stay stuck under the new identity nor clobber a mutation the new identity started - including a flip that lands during the post-success reconciling refetch.
- Refetch responses are auth-tagged and dropped at apply like background ticks; error writes are guarded the same way.
- A `signed_out` closed gate is the unmount analog: it clears the pairing card and mutation and bumps the epoch so pending mints stay dead even under an unchanged auth reference. A transient `loading` gate (eligibility dip, user still signed in) keeps in-flight work alive, matching the per-component hooks it replaced.

Every guard has a regression test verified to fail against the unguarded code (deferred fakes, virtual time, side-effect deps asserted not-called).

## Doctrine encoding

The RxJS store expertise now lives where it auto-loads, one depth home per audience:

- `frontend-dev` skill gains "Module-Singleton Source Stores": domain hooks over the internal binding, capture-at-issue/drop-at-apply for every completion, invalidation covers bookkeeping not just visible state, settle re-arm, the one-`exhaustMap` rule with the after-settle `concatMap` carve-out, injected clocks, and the comparator manifest's honest limits.
- New `packages/runtimed/AGENTS.md` carries the primitive contracts (emission order, settle re-arm, `interval$` as the teardown lever, explicit barrel exports).
- New `src/components/notebook/AGENTS.md` plus a path-scoped rule close the auto-load gap for the state layer and record the two-idioms boundary (Map/Set fan-out stores stay; RxJS where time/async/cancellation lives).
- `apps/notebook-cloud/AGENTS.md` gets the terse viewer invariants, cross-referenced to Decision 8.

The encoding was validated by a fresh-context Sonnet grok test: five maintenance scenarios (design a polled store, grow a projection type, debug a dead poll, review an inline `select()`, place cross-host vs cloud-only facts) scored 9-10/10 working from the repo docs alone, and the graded misses fed directly back into the doc text. Three doctrine claims the code falsified (auth store shape, the FSB-2 retrofit status, a hook name that never existed) are corrected, including the phantom hook in Decision 8 itself.

A sweep for stale state/store docs found nothing to delete: the only pre-refactor symbol references in `docs/` are Decision 8's own deliberate "what this replaced" framing.
