### PR TITLE
feat(notebook-cloud): store layer consolidation - FSB-2 retrofit, CI tripwires, context seam

### DIFF
--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -213,6 +213,15 @@ each async completion is a stale-write risk:
   `useCloudAuthState`/`useHostedCatalogAuth`/`useCloudWorkstationsRegistry`, never
   `store.select(...)` inline in a render body and never
   `observable-binding.ts` directly. One binding, shared desktop and cloud.
+- **Singletons for lifetime, context for consumption.** The store stays a module
+  singleton (boot, drivers, instant-paint snapshot reads), but each domain hook
+  resolves its instance from `useCloudStores()` (`cloud-stores-context.ts`),
+  whose default is the singleton bundle. Production mounts no provider, so it is
+  byte-identical; a test or Elements fixture mounts `CloudStoresProvider` with
+  its own instances and the subtree reads those. The provider overrides
+  consumption, never activation - its owner activates the instances it supplies.
+  A controller that dispatches actions on the same store reads it from the same
+  context too, so an override gets a coherent store.
 - **Capture at issue, drop at apply — for every completion.** Poll ticks AND
   imperative actions capture `{epoch, auth reference, endpoint}` when the
   request starts; after every `await` (success, error, and any follow-up

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -494,6 +494,13 @@ jobs:
       - name: Type-check runtimed tests
         run: pnpm --dir packages/runtimed typecheck
 
+      # Same enforcement for the cloud viewer stores' equality manifests and
+      # store typing: no other lane runs the notebook-cloud tsc pass. Its
+      # wasm-ensure-runtime pretypecheck is satisfied by the artifact build
+      # above.
+      - name: Type-check notebook-cloud
+        run: pnpm --dir apps/notebook-cloud typecheck
+
       - name: Run JS tests
         run: vp test run
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,6 +486,14 @@ jobs:
       # Build wasm + renderer plugins (gitignored; tests import them)
       - uses: ./.github/actions/build-runtime-artifacts
 
+      # tsc over packages/runtimed/tests, whose `satisfies Record<keyof T, true>`
+      # equality manifests only trip the build when the tests are type-checked.
+      # vitest transpiles without type-checking and `vp check` is fmt+lint only,
+      # so this is the lane that enforces them. Needs the wasm .d.ts the artifact
+      # build above generates.
+      - name: Type-check runtimed tests
+        run: pnpm --dir packages/runtimed typecheck
+
       - name: Run JS tests
         run: vp test run
 

--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -84,6 +84,11 @@ stores, not from using document boundaries as a rerender workaround.
 - Components consume named domain hooks (`useCloudAuthState`,
   `useHostedCatalogAuth`, `useCloudWorkstationsRegistry`, ...), never
   `store.select(...)` in a render body and never a second React binding.
+- Each domain hook resolves its store from `useCloudStores()`
+  (`cloud-stores-context.ts`), whose default is the singleton bundle: production
+  mounts no provider and stays byte-identical, while a test or fixture mounts
+  `CloudStoresProvider` to override consumption (not activation, which the
+  singletons keep owning for boot and instant paint).
 - The stores are module singletons shared across surfaces, so every async
   completion - poll tick, imperative action, and any follow-up refetch - is
   captured at issue and dropped at apply against an activation epoch plus the

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -235,7 +235,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   // transition itself lives in the store, not the viewer entry.
   assert.match(
     sourceText,
-    /const requestCloudEditAccess = useCallback\(\(\) => \{[\s\S]*cloudAccessRequestStore\.requestEditAccess\(\);/,
+    /const requestCloudEditAccess = useCallback\(\(\) => \{[\s\S]*accessRequest\.requestEditAccess\(\);/,
   );
   // The connection/identity slot is filled by the shared quiet component:
   // avatar + connectivity dot, driven by the stable status bridge. It must

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -760,7 +760,7 @@ test("cloud notebook list refresh re-establishes app sessions before listing not
   assert.match(routeSourceText, /import \{ clearCloudAppSession, establishCloudAppSession \}/);
   assert.match(
     routeSourceText,
-    /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*establishCloudAppSession\(authState\)[\s\S]*cloudAuthStore\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
+    /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*establishCloudAppSession\(authState\)[\s\S]*auth\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
     "manual notebook-list refresh should re-run the trusted session exchange so pending invites can resolve",
   );
 });
@@ -812,11 +812,11 @@ test("cloud app-session live sync uses streamed catalog access facts without awa
   assert.match(sourceText, /createCloudNotebookCatalogAccessLoader\(\{/);
   assert.match(sourceText, /loadCatalogAccess: async \(\) => \{/);
   assert.match(sourceText, /config\.catalogEndpoint/);
-  assert.match(sourceText, /cloudCatalogStore\.catalogAccessFactsSnapshot/);
+  assert.match(sourceText, /catalog\.catalogAccessFactsSnapshot/);
   assert.match(sourceText, /cloudNotebookSyncScopeForCatalogAccess\(\{/);
   assert.match(
     sourceText,
-    /const requestedScope = resolveCloudAppSessionSyncScope\([\s\S]*cloudCatalogStore\.catalogAccessFactsSnapshot,[\s\S]*cloudAccessRequestStore\.selectedModeSnapshot,[\s\S]*\)/,
+    /const requestedScope = resolveCloudAppSessionSyncScope\([\s\S]*catalog\.catalogAccessFactsSnapshot,[\s\S]*accessRequest\.selectedModeSnapshot,[\s\S]*\)/,
   );
   assert.doesNotMatch(sourceText, /new URL\("api\/n\?limit=100"/);
   assert.doesNotMatch(sourceText, /\.\.\.\(await loadCatalogAccess\(\)\)/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -357,8 +357,13 @@ test("cloud workstation registry state lives in the workstations store", () => {
 
   // The manager hook delegates the registry poll, mutations, and pairing to the
   // store; it only shapes the presentational workstation surface for the rail.
+  // The store instance is resolved from context (singleton by default) so an
+  // override consumes a coherent store for both reads and action dispatch.
   assert.match(hookSourceText, /useCloudWorkstationsController/);
-  assert.match(hookSourceText, /cloudWorkstationsStore/);
+  assert.match(hookSourceText, /const \{ workstations \} = useCloudStores\(\)/);
+  assert.match(hookSourceText, /workstations\.attach\(/);
+  assert.match(hookSourceText, /workstations\.setDefault\(/);
+  assert.doesNotMatch(hookSourceText, /cloudWorkstationsStore/);
   assert.match(hookSourceText, /projectNotebookWorkstationSurface/);
   assert.doesNotMatch(hookSourceText, /fetchCloudWorkstations/);
   assert.doesNotMatch(hookSourceText, /setCloudDefaultWorkstation/);

--- a/apps/notebook-cloud/viewer/__tests__/cloud-stores-context.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/cloud-stores-context.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { cloudAccessRequestStore, CloudAccessRequestStore } from "../cloud-access-request-store";
+import { cloudAuthStore } from "../cloud-auth-store";
+import { cloudCatalogStore } from "../cloud-catalog-store";
+import { CloudStoresProvider, type CloudStores } from "../cloud-stores-context";
+import { cloudWorkstationsStore } from "../cloud-workstations-store";
+import { useCloudSelectedMode } from "../use-cloud-access-request-controller";
+
+// The seam's whole contract in one probe: a domain hook resolves its store from
+// context, which is the module singleton by default and an override under a
+// provider. `useCloudSelectedMode` reads `accessRequest.selectedMode$`; the
+// singleton seeds that mode from the URL (no ?mode= in jsdom, so "view") while
+// the fixture seeds "edit", so the read tells unambiguously which instance won.
+describe("CloudStoresProvider", () => {
+  it("routes a domain hook to the provider's store instance", () => {
+    expect(cloudAccessRequestStore.selectedModeSnapshot).toBe("view");
+
+    const fixtureAccessRequest = new CloudAccessRequestStore({ readSelectedMode: () => "edit" });
+    const fixtureStores: CloudStores = {
+      auth: cloudAuthStore,
+      accessRequest: fixtureAccessRequest,
+      catalog: cloudCatalogStore,
+      workstations: cloudWorkstationsStore,
+    };
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(CloudStoresProvider, { stores: fixtureStores, children });
+
+    const { result } = renderHook(() => useCloudSelectedMode(), { wrapper });
+
+    // The fixture won: the hook read the override, not the singleton.
+    expect(result.current).toBe("edit");
+    expect(result.current).not.toBe(cloudAccessRequestStore.selectedModeSnapshot);
+  });
+
+  it("falls back to the singleton bundle with no provider", () => {
+    const { result } = renderHook(() => useCloudSelectedMode());
+
+    expect(result.current).toBe("view");
+    expect(result.current).toBe(cloudAccessRequestStore.selectedModeSnapshot);
+  });
+});

--- a/apps/notebook-cloud/viewer/cloud-stores-context.ts
+++ b/apps/notebook-cloud/viewer/cloud-stores-context.ts
@@ -1,0 +1,72 @@
+/**
+ * Consumption seam for the four cloud viewer source stores (auth,
+ * access-request, catalog, workstations).
+ *
+ * The stores stay module singletons - that is the boot and instant-paint
+ * reality, not something this seam changes. `cloud-auth-store.ts` MUST live at
+ * module scope because `instant-paint.ts` reads `authSnapshot` synchronously
+ * before React mounts, and every store's drivers activate once at viewer boot,
+ * outside any React subtree. Decision 8 (`docs/adr/frontend-sync-bridge.md`)
+ * records why.
+ *
+ * What this adds is an override of CONSUMPTION, never of activation. The context
+ * defaults to the singleton bundle, so a viewer with no provider resolves every
+ * domain hook to the same singletons the drivers booted - no provider is mounted
+ * on any production path and behavior stays byte-identical. A test, an Elements
+ * fixture, or a future embedded viewer can mount `CloudStoresProvider` with its
+ * own store instances and every domain hook downstream reads them instead. The
+ * override's owner activates its own instances (calls `activate`/`seedFromSsr`);
+ * the provider swaps which stores are read, not which stores are driven.
+ */
+
+import { createContext, createElement, useContext, type ReactElement, type ReactNode } from "react";
+import {
+  cloudAccessRequestStore,
+  type CloudAccessRequestStore,
+} from "./cloud-access-request-store";
+import { cloudAuthStore, type CloudAuthStore } from "./cloud-auth-store";
+import { cloudCatalogStore, type CloudCatalogStore } from "./cloud-catalog-store";
+import { cloudWorkstationsStore, type CloudWorkstationsStore } from "./cloud-workstations-store";
+
+/** The four cloud viewer source stores a subtree consumes. */
+export interface CloudStores {
+  auth: CloudAuthStore;
+  accessRequest: CloudAccessRequestStore;
+  catalog: CloudCatalogStore;
+  workstations: CloudWorkstationsStore;
+}
+
+/**
+ * The module singletons, bundled. This is the context default, so a subtree with
+ * no provider consumes exactly the instances the boot drivers activate.
+ */
+const singletonCloudStores: CloudStores = {
+  auth: cloudAuthStore,
+  accessRequest: cloudAccessRequestStore,
+  catalog: cloudCatalogStore,
+  workstations: cloudWorkstationsStore,
+};
+
+/**
+ * Defaulted to the singleton bundle, so `useCloudStores()` needs no provider and
+ * no null check. A provider overrides consumption for its subtree only.
+ */
+const CloudStoresContext = createContext<CloudStores>(singletonCloudStores);
+
+export interface CloudStoresProviderProps {
+  stores: CloudStores;
+  children: ReactNode;
+}
+
+/**
+ * Override the stores a subtree consumes. Production mounts none of these; the
+ * owner that supplies `stores` is responsible for activating those instances.
+ */
+export function CloudStoresProvider({ stores, children }: CloudStoresProviderProps): ReactElement {
+  return createElement(CloudStoresContext.Provider, { value: stores }, children);
+}
+
+/** The stores the current subtree consumes; the singleton bundle by default. */
+export function useCloudStores(): CloudStores {
+  return useContext(CloudStoresContext);
+}

--- a/apps/notebook-cloud/viewer/home-view.tsx
+++ b/apps/notebook-cloud/viewer/home-view.tsx
@@ -14,12 +14,13 @@ import { cloudNotebookSignInLabel } from "./cloud-auth-controls";
 import { clearCloudPrototypeDevAuth, prepareCloudOidcViewerLogin } from "./collaborator-auth";
 import { beginOidcLogin } from "./oidc-auth";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
-import { cloudAuthStore } from "./cloud-auth-store";
+import { useCloudStores } from "./cloud-stores-context";
 import { useCloudAppSession, useCloudAuthRenewal, useCloudAuthState } from "./use-cloud-auth-store";
 import type { CloudViewerAuthConfig } from "./cloud-viewer-types";
 
 export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { auth } = useCloudStores();
   const appSessionStatus = useCloudAppSession();
   const authState = useCloudAuthState();
   const authRenewal = useCloudAuthRenewal();
@@ -64,15 +65,15 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
   };
 
   const resetAuth = () => {
-    cloudAuthStore.clearAppSessionStatus();
+    auth.clearAppSessionStatus();
     void clearCloudAppSession()
       .catch((error: unknown) => {
         console.warn("[notebook-cloud] app session clear failed", error);
       })
-      .finally(() => cloudAuthStore.refreshAppSessionStatus());
+      .finally(() => auth.refreshAppSessionStatus());
     clearCloudPrototypeDevAuth(window.localStorage);
     setFormError(null);
-    cloudAuthStore.refreshAuthState();
+    auth.refreshAuthState();
   };
 
   const hasExplicitAuth = authState.mode === "oidc";
@@ -145,14 +146,14 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
               <button
                 type="button"
                 onClick={() => {
-                  cloudAuthStore.clearAppSessionStatus();
+                  auth.clearAppSessionStatus();
                   void clearCloudAppSession()
                     .catch((error: unknown) => {
                       console.warn("[notebook-cloud] app session clear failed", error);
                     })
-                    .finally(() => cloudAuthStore.refreshAppSessionStatus());
+                    .finally(() => auth.refreshAppSessionStatus());
                   clearCloudPrototypeDevAuth(window.localStorage);
-                  cloudAuthStore.refreshAuthState();
+                  auth.refreshAuthState();
                 }}
               >
                 <LogOut aria-hidden="true" />

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -23,11 +23,18 @@ import { CloudHomeView } from "./home-view";
 import { CloudNotebookListView } from "./notebook-list-view";
 import { loadNotebookRouteModule } from "./notebook-route-preload";
 import { OidcCallbackView } from "./oidc-callback-view";
-import { CloudWorkstationsView } from "./workstations-view";
 import "./index.css";
 
 const NotebookRoute = lazy(() =>
   loadNotebookRouteModule().then((module) => ({ default: module.NotebookRoute })),
+);
+
+// Boot-path discipline: only the auth store may ride the entry chunk (its
+// synchronous seed is what instant paint reads). The workstations surface -
+// store, hooks, and the management page UI - belongs to its route's chunk, so
+// notebook and dashboard visitors never download it.
+const CloudWorkstationsView = lazy(() =>
+  import("./workstations-view").then((module) => ({ default: module.CloudWorkstationsView })),
 );
 
 setLoggerHost({
@@ -105,7 +112,11 @@ function App() {
   }
 
   if (isWorkstationsPath()) {
-    return <CloudWorkstationsView authConfig={authConfig} />;
+    return (
+      <Suspense fallback={<ViewerStartupLoading title="Workstations" />}>
+        <CloudWorkstationsView authConfig={authConfig} />
+      </Suspense>
+    );
   }
 
   if (isOidcCallbackPath()) {

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -38,7 +38,7 @@ import {
   useCloudAuthState,
   useHostedCatalogAuth,
 } from "./use-cloud-auth-store";
-import { cloudAuthStore } from "./cloud-auth-store";
+import { useCloudStores } from "./cloud-stores-context";
 import { loadCloudNotebookListBootstrap } from "./cloud-viewer-config";
 import type { CloudAppSession } from "./app-session";
 import type {
@@ -66,6 +66,7 @@ import { preloadNotebookRoute } from "./notebook-route-preload";
 
 export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { auth } = useCloudStores();
   const [bootstrap, setBootstrap] = useState<CloudNotebookListBootstrap | null>(() =>
     loadCloudNotebookListBootstrap(),
   );
@@ -184,7 +185,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
           console.warn("[notebook-cloud] app session refresh before notebook list failed", error);
         })
         .finally(() => {
-          cloudAuthStore.refreshAppSessionStatus();
+          auth.refreshAppSessionStatus();
           setRefreshIndex((value) => value + 1);
         });
       return;
@@ -325,15 +326,15 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   const signOut = () => {
     setBootstrap(null);
     setDashboardQuery("");
-    cloudAuthStore.clearAppSessionStatus();
+    auth.clearAppSessionStatus();
     clearCachedCloudNotebookListFromWindow();
     void clearCloudAppSession()
       .catch((error: unknown) => {
         console.warn("[notebook-cloud] app session clear failed", error);
       })
-      .finally(() => cloudAuthStore.refreshAppSessionStatus());
+      .finally(() => auth.refreshAppSessionStatus());
     clearCloudPrototypeDevAuth(window.localStorage);
-    cloudAuthStore.refreshAuthState();
+    auth.refreshAuthState();
   };
 
   const headerDetail = cloudNotebookListHeaderDetail(authState, hasAppSession, authConfig);

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -167,7 +167,7 @@ import type {
   CloudViewerAuthConfig,
   ViewerRuntime,
 } from "./cloud-viewer-types";
-import { cloudAuthStore } from "./cloud-auth-store";
+import { useCloudStores } from "./cloud-stores-context";
 import {
   useBrowserApiAuthState,
   useCloudAppSession,
@@ -175,13 +175,11 @@ import {
   useCloudAuthState,
   useCloudSyncAuthConnectionKey,
 } from "./use-cloud-auth-store";
-import { cloudAccessRequestStore } from "./cloud-access-request-store";
 import {
   useCloudAccessRequestController,
   useCloudAccessRequestFacts,
   useCloudSelectedMode,
 } from "./use-cloud-access-request-controller";
-import { cloudCatalogStore } from "./cloud-catalog-store";
 import {
   useCloudCatalogAccessFacts,
   useCloudCatalogController,
@@ -244,6 +242,10 @@ export function NotebookViewer({
   authConfig: CloudViewerAuthConfig;
 }) {
   const { config } = runtime;
+  // Store actions and snapshot reads below resolve through this context bundle
+  // (the singletons by default) so a CloudStoresProvider override drives the
+  // same instances this component reads and mutates.
+  const { auth, accessRequest, catalog } = useCloudStores();
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
   const [notebookTitleSaving, setNotebookTitleSaving] = useState(false);
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
@@ -255,16 +257,19 @@ export function NotebookViewer({
   // writes them through store actions (setSelectedMode, requestEditAccess, reset).
   const selectedInteractionMode = useCloudSelectedMode();
   const accessRequestFacts = useCloudAccessRequestFacts();
-  const handleSelectInteractionMode = useCallback((mode: NotebookInteractionMode) => {
-    cloudAccessRequestStore.setSelectedMode(mode);
-  }, []);
+  const handleSelectInteractionMode = useCallback(
+    (mode: NotebookInteractionMode) => {
+      accessRequest.setSelectedMode(mode);
+    },
+    [accessRequest],
+  );
   const appSessionStatus = useCloudAppSession();
   const hasAppSession = Boolean(appSessionStatus.session);
   const authState = useCloudAuthState();
   const authRenewal = useCloudAuthRenewal();
   const refreshAuthState = useCallback(() => {
-    cloudAuthStore.refreshAuthState();
-  }, []);
+    auth.refreshAuthState();
+  }, [auth]);
   // Cell focus is owned by the shared cell-ui-state store, not host React state.
   // NotebookView already writes and synchronously flushes the interaction target
   // on user focus (publishInteractionTarget, which carries the real
@@ -386,7 +391,7 @@ export function NotebookViewer({
     : null;
   const resolveSyncAuth = useCallback(
     async (sessionId: string) => {
-      const currentAppSessionStatus = cloudAuthStore.appSessionSnapshot;
+      const currentAppSessionStatus = auth.appSessionSnapshot;
       const appSession =
         currentAppSessionStatus.session ??
         (currentAppSessionStatus.status === "loading"
@@ -394,17 +399,17 @@ export function NotebookViewer({
           : null);
       if (appSession) {
         const requestedScope = resolveCloudAppSessionSyncScope(
-          cloudCatalogStore.catalogAccessFactsSnapshot,
-          cloudAccessRequestStore.selectedModeSnapshot,
+          catalog.catalogAccessFactsSnapshot,
+          accessRequest.selectedModeSnapshot,
         );
         return cloudSyncAuthFromAppSessionCookie({
           requestedScope,
           sessionId,
         });
       }
-      return cloudSyncAuthFromPrototypeAuthState(cloudAuthStore.authSnapshot);
+      return cloudSyncAuthFromPrototypeAuthState(auth.authSnapshot);
     },
-    [config.notebookId, syncAuthConnectionKey],
+    [accessRequest, auth, catalog, config.notebookId, syncAuthConnectionKey],
   );
   const {
     connectionActorLabel,
@@ -729,7 +734,7 @@ export function NotebookViewer({
 
       try {
         setNotebookTitleSaving(true);
-        cloudCatalogStore.clearTitleError();
+        catalog.clearTitleError();
         const response = await fetchWithCloudPrototypeAuth(
           config.catalogEndpoint,
           {
@@ -752,7 +757,7 @@ export function NotebookViewer({
         if (body.ok !== true || body.notebook_id !== config.notebookId) {
           throw new Error("Unable to rename notebook: response shape was invalid");
         }
-        cloudCatalogStore.applyTitleSaved(body.title ?? null);
+        catalog.applyTitleSaved(body.title ?? null);
         if (body.viewer_url) {
           const nextHref = cloudNotebookUrlAfterRename(window.location.href, body.viewer_url);
           if (nextHref !== window.location.href) {
@@ -761,9 +766,7 @@ export function NotebookViewer({
         }
         return true;
       } catch (error) {
-        cloudCatalogStore.applyTitleSaveFailure(
-          error instanceof Error ? error.message : String(error),
-        );
+        catalog.applyTitleSaveFailure(error instanceof Error ? error.message : String(error));
         return false;
       } finally {
         setNotebookTitleSaving(false);
@@ -772,6 +775,7 @@ export function NotebookViewer({
     [
       browserApiAuthState,
       canUseAuthenticatedCloudApi,
+      catalog,
       catalogGrantsDocumentEdit,
       config.catalogEndpoint,
       config.notebookId,
@@ -1473,9 +1477,9 @@ export function NotebookViewer({
       console.warn("[notebook-cloud] app session clear failed", error);
     });
     clearCloudPrototypeDevAuth(window.localStorage);
-    cloudAccessRequestStore.reset();
+    accessRequest.reset();
     refreshAuthState();
-  }, [refreshAuthState]);
+  }, [accessRequest, refreshAuthState]);
   const beginNotebookAuth = useCallback(async () => {
     const localDevAuth = authConfig.localDev;
     if (localDevAuth) {
@@ -1498,8 +1502,8 @@ export function NotebookViewer({
     }
   }, [authConfig.localDev, authConfig.oidc, resetPrototypeAuth]);
   const requestCloudEditAccess = useCallback(() => {
-    cloudAccessRequestStore.requestEditAccess();
-  }, []);
+    accessRequest.requestEditAccess();
+  }, [accessRequest]);
   const shouldShowPackageEnvironmentSummary =
     shellCapabilities.canExecute || shellCapabilities.canManagePackages;
   const shouldShowCloudWorkstationsPanel =

--- a/apps/notebook-cloud/viewer/use-cloud-access-request-controller.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-access-request-controller.ts
@@ -19,10 +19,8 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { BehaviorSubject } from "rxjs";
 import { useObservableProjection } from "@/components/notebook/state/observable-binding";
-import {
-  cloudAccessRequestStore,
-  type CloudAccessRequestInputs,
-} from "./cloud-access-request-store";
+import { useCloudStores } from "./cloud-stores-context";
+import type { CloudAccessRequestInputs } from "./cloud-access-request-store";
 import type { CloudAccessFactsProjection, CloudAccessRequestFacts } from "./cloud-access-facts";
 import type { CloudNotebookCatalogAccessScope } from "./cloud-notebook-catalog-access";
 import type { CloudNotebookUrlMode } from "./cloud-notebook-mode";
@@ -30,12 +28,14 @@ import type { CloudPrototypeAuthState } from "./collaborator-auth";
 
 /** The selected interaction mode, corrected by access. */
 export function useCloudSelectedMode(): CloudNotebookUrlMode {
-  return useObservableProjection(cloudAccessRequestStore.selectedMode$);
+  const { accessRequest } = useCloudStores();
+  return useObservableProjection(accessRequest.selectedMode$);
 }
 
 /** The user's own edit-access request sub-facts, for reprojection. */
 export function useCloudAccessRequestFacts(): CloudAccessRequestFacts {
-  return useObservableProjection(cloudAccessRequestStore.requestFacts$);
+  const { accessRequest } = useCloudStores();
+  return useObservableProjection(accessRequest.requestFacts$);
 }
 
 export interface UseCloudAccessRequestControllerParams {
@@ -95,6 +95,7 @@ export function useCloudAccessRequestController({
   onRetryLiveConnection,
   onRefreshAuth,
 }: UseCloudAccessRequestControllerParams): void {
+  const { accessRequest } = useCloudStores();
   const inputs$ = useLiveInputs<CloudAccessRequestInputs>({
     facts,
     browserAuth,
@@ -110,11 +111,11 @@ export function useCloudAccessRequestController({
 
   useEffect(
     () =>
-      cloudAccessRequestStore.activate(inputs$, {
+      accessRequest.activate(inputs$, {
         notebookId,
         onRetryLiveConnection: () => callbacksRef.current.onRetryLiveConnection(),
         onRefreshAuth: () => callbacksRef.current.onRefreshAuth(),
       }),
-    [inputs$, notebookId],
+    [inputs$, notebookId, accessRequest],
   );
 }

--- a/apps/notebook-cloud/viewer/use-cloud-auth-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-auth-store.ts
@@ -6,13 +6,15 @@
  * and the component tree.
  *
  * The store's drivers own the auth/app-session sources (they run from boot via
- * `cloudAuthStore.activate`), so each hook binds a store-owned projection
- * through the shared `useObservableProjection`. The projections are stable
- * module-level observables, so the binding cache stays hot across renders.
+ * `auth.activate`), so each hook binds a store-owned projection through the
+ * shared `useObservableProjection`. The projections are stable per store
+ * instance, so the binding cache stays hot across renders. The store instance
+ * comes from `useCloudStores()`, which is the singleton by default and an
+ * override under `CloudStoresProvider`.
  */
 
 import { useObservableProjection } from "@/components/notebook/state/observable-binding";
-import { cloudAuthStore } from "./cloud-auth-store";
+import { useCloudStores } from "./cloud-stores-context";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import type { HostedCatalogAuthProjection } from "./hosted-catalog-auth";
 import type { CloudAuthRenewalState } from "./notice-types";
@@ -20,30 +22,36 @@ import type { CloudAppSessionViewState } from "./use-cloud-auth";
 
 /** Deduped prototype auth state (mode/token/user/scope/oidc subject). */
 export function useCloudAuthState(): CloudPrototypeAuthState {
-  return useObservableProjection(cloudAuthStore.authState$);
+  const { auth } = useCloudStores();
+  return useObservableProjection(auth.authState$);
 }
 
 /** Full app-session view (status/session/error), reference-stable session. */
 export function useCloudAppSession(): CloudAppSessionViewState {
-  return useObservableProjection(cloudAuthStore.appSessionView$);
+  const { auth } = useCloudStores();
+  return useObservableProjection(auth.appSessionView$);
 }
 
 /** OIDC renewal notice. */
 export function useCloudAuthRenewal(): CloudAuthRenewalState {
-  return useObservableProjection(cloudAuthStore.renewal$);
+  const { auth } = useCloudStores();
+  return useObservableProjection(auth.renewal$);
 }
 
 /** Stable auth object for host-owned browser API and blob fetches. */
 export function useBrowserApiAuthState(): CloudPrototypeAuthState {
-  return useObservableProjection(cloudAuthStore.browserApiAuthState$);
+  const { auth } = useCloudStores();
+  return useObservableProjection(auth.browserApiAuthState$);
 }
 
 /** Stable connection key for the live-room reconnect dependency. */
 export function useCloudSyncAuthConnectionKey(): string {
-  return useObservableProjection(cloudAuthStore.syncAuthConnectionKey$);
+  const { auth } = useCloudStores();
+  return useObservableProjection(auth.syncAuthConnectionKey$);
 }
 
 /** Hosted catalog auth projection for the current auth/app-session state. */
 export function useHostedCatalogAuth(): HostedCatalogAuthProjection {
-  return useObservableProjection(cloudAuthStore.hostedAuth$);
+  const { auth } = useCloudStores();
+  return useObservableProjection(auth.hostedAuth$);
 }

--- a/apps/notebook-cloud/viewer/use-cloud-catalog-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-catalog-store.ts
@@ -17,32 +17,33 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { BehaviorSubject } from "rxjs";
 import { useObservableProjection } from "@/components/notebook/state/observable-binding";
-import {
-  cloudCatalogStore,
-  type CloudCatalogInputs,
-  type CloudCatalogSeed,
-} from "./cloud-catalog-store";
+import { useCloudStores } from "./cloud-stores-context";
+import type { CloudCatalogInputs, CloudCatalogSeed } from "./cloud-catalog-store";
 import type { CloudCatalogAccessFacts } from "./cloud-access-facts";
 import type { CloudNotebookLiveRoomConnectionPolicy } from "./cloud-notebook-catalog-access";
 
 /** Catalog access facts (status + scope) for the current identity. */
 export function useCloudCatalogAccessFacts(): CloudCatalogAccessFacts {
-  return useObservableProjection(cloudCatalogStore.catalogAccessFacts$);
+  const { catalog } = useCloudStores();
+  return useObservableProjection(catalog.catalogAccessFacts$);
 }
 
 /** Live-room connection policy derived from the catalog facts. */
 export function useCloudCatalogLiveRoomPolicy(): CloudNotebookLiveRoomConnectionPolicy {
-  return useObservableProjection(cloudCatalogStore.catalogLiveRoomPolicy$);
+  const { catalog } = useCloudStores();
+  return useObservableProjection(catalog.catalogLiveRoomPolicy$);
 }
 
 /** Loaded catalog title (undefined until a load carries one). */
 export function useCloudNotebookTitle(): string | null | undefined {
-  return useObservableProjection(cloudCatalogStore.title$);
+  const { catalog } = useCloudStores();
+  return useObservableProjection(catalog.title$);
 }
 
 /** Catalog-load / rename error for the title chrome. */
 export function useCloudNotebookTitleError(): string | null {
-  return useObservableProjection(cloudCatalogStore.titleError$);
+  const { catalog } = useCloudStores();
+  return useObservableProjection(catalog.titleError$);
 }
 
 export interface UseCloudCatalogControllerParams {
@@ -80,9 +81,11 @@ export function useCloudCatalogController({
   loadCatalogAccess,
   initialCatalogAccess,
 }: UseCloudCatalogControllerParams): void {
+  const { catalog } = useCloudStores();
+
   // Seed synchronously on first render, before any title/facts projection read.
   useState(() => {
-    cloudCatalogStore.seedFromSsr(initialCatalogAccess, canUseAuthenticatedCloudApi);
+    catalog.seedFromSsr(initialCatalogAccess, canUseAuthenticatedCloudApi);
     return null;
   });
 
@@ -91,5 +94,5 @@ export function useCloudCatalogController({
     loadCatalogAccess,
   });
 
-  useEffect(() => cloudCatalogStore.activate(inputs$), [inputs$]);
+  useEffect(() => catalog.activate(inputs$), [inputs$, catalog]);
 }

--- a/apps/notebook-cloud/viewer/use-cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations-store.ts
@@ -18,38 +18,43 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { BehaviorSubject } from "rxjs";
 import { runtimeStateStore } from "@/components/notebook/state/runtime-state";
 import { useObservableProjection } from "@/components/notebook/state/observable-binding";
-import {
-  cloudWorkstationsStore,
-  type CloudWorkstationMutationState,
-  type CloudWorkstationPairing,
-  type CloudWorkstationsInputs,
-  type CloudWorkstationsRegistry,
-  type CloudWorkstationsRegistryStatus,
+import { useCloudStores } from "./cloud-stores-context";
+import type {
+  CloudWorkstationMutationState,
+  CloudWorkstationPairing,
+  CloudWorkstationsInputs,
+  CloudWorkstationsRegistry,
+  CloudWorkstationsRegistryStatus,
 } from "./cloud-workstations-store";
 
 /** The registered workstations + default id. */
 export function useCloudWorkstationsRegistry(): CloudWorkstationsRegistry {
-  return useObservableProjection(cloudWorkstationsStore.registry$);
+  const { workstations } = useCloudStores();
+  return useObservableProjection(workstations.registry$);
 }
 
 /** Registry lifecycle status (loading / signed-out / error / ready). */
 export function useCloudWorkstationsStatus(): CloudWorkstationsRegistryStatus {
-  return useObservableProjection(cloudWorkstationsStore.status$);
+  const { workstations } = useCloudStores();
+  return useObservableProjection(workstations.status$);
 }
 
 /** Last surfaced registry error. */
 export function useCloudWorkstationsError(): string | null {
-  return useObservableProjection(cloudWorkstationsStore.error$);
+  const { workstations } = useCloudStores();
+  return useObservableProjection(workstations.error$);
 }
 
 /** The in-flight mutation for the toolbar/panel. */
 export function useCloudWorkstationMutation(): CloudWorkstationMutationState {
-  return useObservableProjection(cloudWorkstationsStore.mutation$);
+  const { workstations } = useCloudStores();
+  return useObservableProjection(workstations.mutation$);
 }
 
 /** The pairing with its registered workstation's display name resolved. */
 export function useCloudWorkstationPairing(): CloudWorkstationPairing | null {
-  return useObservableProjection(cloudWorkstationsStore.pairingWithName$);
+  const { workstations } = useCloudStores();
+  return useObservableProjection(workstations.pairingWithName$);
 }
 
 /**
@@ -74,10 +79,10 @@ function useLiveInputs<T>(value: T): BehaviorSubject<T> {
  * live workstation-attachment projection feeds the attach cross-channel confirm.
  */
 export function useCloudWorkstationsController(inputs: CloudWorkstationsInputs): void {
+  const { workstations } = useCloudStores();
   const inputs$ = useLiveInputs(inputs);
   useEffect(
-    () =>
-      cloudWorkstationsStore.activate(inputs$, { workstation$: runtimeStateStore.workstation$ }),
-    [inputs$],
+    () => workstations.activate(inputs$, { workstation$: runtimeStateStore.workstation$ }),
+    [inputs$, workstations],
   );
 }

--- a/apps/notebook-cloud/viewer/use-cloud-workstations.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations.ts
@@ -7,9 +7,9 @@ import {
   type NotebookShellCapabilities,
 } from "@/components/notebook";
 
+import { useCloudStores } from "./cloud-stores-context";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import type { CloudViewerConfig } from "./cloud-viewer-session";
-import { cloudWorkstationsStore } from "./cloud-workstations-store";
 import {
   useCloudWorkstationMutation,
   useCloudWorkstationPairing,
@@ -48,6 +48,7 @@ export function useCloudWorkstationManager({
   panelIsOpen,
   onOpenWorkstationsRail,
 }: UseCloudWorkstationManagerInput) {
+  const { workstations } = useCloudStores();
   const canChooseHostedWorkstation =
     capabilities.access.source === "cloud" &&
     capabilities.auth.canUseAuthenticatedIdentity &&
@@ -77,8 +78,8 @@ export function useCloudWorkstationManager({
   const pairingWithName = useCloudWorkstationPairing();
 
   const handleSetDefaultWorkstation = useCallback(
-    (workstationId: string) => cloudWorkstationsStore.setDefault(workstationId),
-    [],
+    (workstationId: string) => workstations.setDefault(workstationId),
+    [workstations],
   );
 
   const handleAttachWorkstation = useCallback(
@@ -89,16 +90,16 @@ export function useCloudWorkstationManager({
       if (options.revealPanel) {
         onOpenWorkstationsRail();
       }
-      return cloudWorkstationsStore.attach(workstationId, {
+      return workstations.attach(workstationId, {
         message: options.message,
         replaceExisting: options.replaceExisting,
       });
     },
-    [config.workstationAttachEndpoint, onOpenWorkstationsRail],
+    [config.workstationAttachEndpoint, onOpenWorkstationsRail, workstations],
   );
 
-  const handleStartPairing = useCallback(() => cloudWorkstationsStore.startPairing(), []);
-  const handleCancelPairing = useCallback(() => cloudWorkstationsStore.cancelPairing(), []);
+  const handleStartPairing = useCallback(() => workstations.startPairing(), [workstations]);
+  const handleCancelPairing = useCallback(() => workstations.cancelPairing(), [workstations]);
 
   const workstationSurface = useMemo(
     () =>

--- a/apps/notebook-cloud/viewer/workstations-view.tsx
+++ b/apps/notebook-cloud/viewer/workstations-view.tsx
@@ -12,7 +12,7 @@ import {
   useHostedCatalogAuth,
 } from "./use-cloud-auth-store";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
-import { cloudWorkstationsStore } from "./cloud-workstations-store";
+import { useCloudStores } from "./cloud-stores-context";
 import {
   useCloudWorkstationPairing,
   useCloudWorkstationsController,
@@ -31,6 +31,7 @@ const WORKSTATIONS_ENDPOINT = "/api/workstations";
  */
 export function CloudWorkstationsView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { workstations: workstationsStore } = useCloudStores();
   const authState = useCloudAuthState();
   const authRenewal = useCloudAuthRenewal();
   const hostedAuth = useHostedCatalogAuth();
@@ -69,10 +70,10 @@ export function CloudWorkstationsView({ authConfig }: { authConfig: CloudViewerA
   const defaultWorkstationId = isReady ? registry.defaultWorkstationId : null;
 
   const refreshRegistry = useCallback(() => {
-    void cloudWorkstationsStore.refreshNow();
-  }, []);
-  const startPairing = useCallback(() => cloudWorkstationsStore.startPairing(), []);
-  const cancelPairing = useCallback(() => cloudWorkstationsStore.cancelPairing(), []);
+    void workstationsStore.refreshNow();
+  }, [workstationsStore]);
+  const startPairing = useCallback(() => workstationsStore.startPairing(), [workstationsStore]);
+  const cancelPairing = useCallback(() => workstationsStore.cancelPairing(), [workstationsStore]);
 
   const pageView = useMemo(() => {
     const selection = projectNotebookWorkstationSelection({

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -288,8 +288,6 @@ machinery.
 
 ### Follow-ups
 
-- FSB-2: retrofit `RuntimeStateStore extends ObservableStore` once the four
-  cloud stores have proven the base; gated by `runtime-state-store.test.ts`.
 - FSB-3: collapse the `useLiveInputs`/render-source straddle when connection
   facts become store-backed, deleting the two-phase
   `set(notify:false)`/`flush()` adapter in `cloud-facts-react.ts`.

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -280,6 +280,13 @@ stores are driven. Context is a consumption override with a singleton default,
 never a requirement: the default keeps `useCloudStores()` provider-free, and the
 singleton keeps owning boot and instant paint.
 
+Boot-path discipline follows from the same split: only the auth store may be
+module-evaluated on the entry chunk (its synchronous seed is what instant paint
+reads). Every other store rides its route's chunk - the workstations surface
+loads with the lazy `/workstations` route, not with the notebook or dashboard
+entry. A new store landing in the entry chunk needs an instant-paint-grade
+reason recorded here.
+
 ### The convention layer stays a convention layer
 
 The generic surface is deliberately small: `ObservableStore`, `select`,

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -263,6 +263,23 @@ module-level `BehaviorSubject` seeded synchronously from
 `cloudPrototypeAuthFromWindow()`, activated once at viewer boot (skipped on
 the OIDC callback route, which consumes no store hooks).
 
+### Singletons for lifetime, context for consumption
+
+The module singletons are the boot and instant-paint reality: the drivers
+activate them once at viewer boot, and `instant-paint.ts` reads `authSnapshot`
+before React mounts. Neither can go through a React provider, so the singletons
+stay. What the hook layer adds is a consumption override, not an activation
+override: `cloud-stores-context.ts` creates a context whose default value is the
+singleton bundle, and every domain hook reads its store from `useCloudStores()`.
+No provider is mounted on any production path, so production resolves to the
+singletons and behavior is byte-identical. A test, an Elements fixture, or a
+future embedded viewer mounts `CloudStoresProvider` with its own instances and
+the subtree's hooks read those instead; that override's owner activates its own
+instances, because the provider swaps which stores are consumed, not which
+stores are driven. Context is a consumption override with a singleton default,
+never a requirement: the default keeps `useCloudStores()` provider-free, and the
+singleton keeps owning boot and instant paint.
+
 ### The convention layer stays a convention layer
 
 The generic surface is deliberately small: `ObservableStore`, `select`,

--- a/packages/runtimed/AGENTS.md
+++ b/packages/runtimed/AGENTS.md
@@ -2,9 +2,9 @@
 
 Scope: the DOM-free store mechanism in `packages/runtimed/src`
 (`observable-store.ts`, `poll.ts`, the free `select`, and the stores built on
-them; `runtime-state-store.ts` predates the base and is the pending
-`ObservableStore` retrofit target, frontend-sync-bridge FSB-2). Mechanism
-only - no React and no `document`/`window`/`Date.now()` in this layer. The React binding is
+them; `runtime-state-store.ts` extends the base with the runtime-state
+projections). Mechanism only - no React and no
+`document`/`window`/`Date.now()` in this layer. The React binding is
 `src/components/notebook/state/observable-binding.ts`; host-policy stores
 (cloud auth/access-request/catalog/workstations) live in
 `apps/notebook-cloud/viewer/` per the convergence memo's do-not-converge list.

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -9,6 +9,9 @@
     ".": "./src/index.ts",
     "./src/*": "./src/*"
   },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.test.json --noEmit"
+  },
   "dependencies": {
     "rxjs": "^7.8.2"
   },

--- a/packages/runtimed/src/runtime-state-store.ts
+++ b/packages/runtimed/src/runtime-state-store.ts
@@ -21,6 +21,7 @@
 
 import {
   Observable,
+  type SchedulerLike,
   defer,
   distinctUntilChanged,
   map,
@@ -70,7 +71,7 @@ export const BUSY_THROTTLE_MS = 60;
  * production callers omit it.
  */
 export function throttleBusyStatus(
-  scheduler?: Parameters<typeof timer>[1],
+  scheduler?: SchedulerLike,
 ): (source: Observable<RuntimeStatusKey>) => Observable<RuntimeStatusKey> {
   return (source) =>
     source.pipe(

--- a/packages/runtimed/src/runtime-state-store.ts
+++ b/packages/runtimed/src/runtime-state-store.ts
@@ -1,13 +1,14 @@
 /**
- * Reactive runtime-state store — framework-agnostic projections over the
+ * Reactive runtime-state store: framework-agnostic projections over the
  * daemon's RuntimeStateDoc snapshots.
  *
- * One BehaviorSubject of `RuntimeState` plus fluent, deduplicated
- * projections. Hosts (desktop bridge, cloud viewer session) push snapshots
- * with `set()`; consumers subscribe to a projection observable or read the
- * synchronous snapshot. React bindings stay in the apps — this module has
- * no framework dependency, so projections are testable headlessly and any
- * future host (CLI, MCP surface) consumes the same streams.
+ * `RuntimeStateStore` extends `ObservableStore<RuntimeState>` for the state
+ * spine (`state$`/`loaded$`/`select`/`snapshot`) and adds the runtime-specific
+ * projections and comparators. Hosts (desktop bridge, cloud viewer session)
+ * push snapshots with `set()`; consumers subscribe to a projection observable
+ * or read the synchronous snapshot. React bindings stay in the apps, so this
+ * module has no framework dependency and projections are testable headlessly;
+ * any future host (CLI, MCP surface) consumes the same streams.
  *
  * Why projections live here and not in `useMemo` chains: a `useMemo` on the
  * whole `RuntimeState` recomputes (and re-renders its component) on every
@@ -19,7 +20,6 @@
  */
 
 import {
-  BehaviorSubject,
   Observable,
   defer,
   distinctUntilChanged,
@@ -30,6 +30,7 @@ import {
   switchMap,
   timer,
 } from "rxjs";
+import { ObservableStore } from "./observable-store";
 import {
   deriveEnvSyncState,
   deriveKernelInfo,
@@ -89,20 +90,10 @@ export function throttleBusyStatus(
  * viewer session both `set()` snapshots from `SyncEngine.runtimeState$`,
  * and both apps' React hooks subscribe to the same projections.
  */
-export class RuntimeStateStore {
-  private readonly _state$ = new BehaviorSubject<RuntimeState>(DEFAULT_RUNTIME_STATE);
-  private readonly _loaded$ = new BehaviorSubject<boolean>(false);
-
-  /** Every snapshot pushed by the host, starting with the default state. */
-  readonly state$: Observable<RuntimeState> = this._state$.asObservable();
-
-  /**
-   * Whether the daemon has pushed at least one snapshot since
-   * connect/reset. While false, the current snapshot is
-   * `DEFAULT_RUNTIME_STATE` and fields like `trust.status` must not be
-   * treated as authoritative (the default would fail-open trust gates).
-   */
-  readonly loaded$: Observable<boolean> = this._loaded$.pipe(distinctUntilChanged());
+export class RuntimeStateStore extends ObservableStore<RuntimeState> {
+  constructor() {
+    super(DEFAULT_RUNTIME_STATE);
+  }
 
   /** Kernel type + env source. Emits only when the projection changes. */
   readonly kernelInfo$: Observable<KernelInfo> = this.select(deriveKernelInfo, kernelInfoEquals);
@@ -163,38 +154,14 @@ export class RuntimeStateStore {
       notebookShellWorkstationAttachmentCacheKey(b),
   );
 
-  /**
-   * Fluent projection builder: derive a slice of `RuntimeState` and emit it
-   * only when it changes. `equals` defaults to `Object.is`; pass a
-   * structural comparator when the projector allocates.
-   */
-  select<T>(
-    project: (state: RuntimeState) => T,
-    equals: (a: T, b: T) => boolean = Object.is,
-  ): Observable<T> {
-    return this._state$.pipe(map(project), distinctUntilChanged(equals));
-  }
-
-  /** Current snapshot (synchronous, non-reactive). */
-  get snapshot(): RuntimeState {
-    return this._state$.getValue();
-  }
-
-  /** Whether a real snapshot has been applied since connect/reset. */
-  get isLoaded(): boolean {
-    return this._loaded$.getValue();
-  }
-
   /** Push a new daemon snapshot. Host bridges call this. */
   set(state: RuntimeState): void {
-    this._loaded$.next(true);
-    this._state$.next(state);
+    this.setState(state);
   }
 
   /** Reset to the default state (disconnect, room change). */
   reset(): void {
-    this._loaded$.next(false);
-    this._state$.next(DEFAULT_RUNTIME_STATE);
+    this.resetState(DEFAULT_RUNTIME_STATE);
   }
 }
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -134,6 +134,7 @@ function makeRuntimeState(
     kernel: {
       lifecycle: { lifecycle: "Running", activity: "Idle" },
       error_reason: null,
+      error_details: null,
       name: "python3",
       language: "python",
       env_source: "",
@@ -158,6 +159,10 @@ function makeRuntimeState(
       approved_pixi_pypi_dependencies: [],
       approved_pixi_channels: [],
     },
+    runtime_state_doc_id: null,
+    path: null,
+    project_context: { state: "Pending" },
+    workstation: null,
     last_saved: null,
     executions: executions as RuntimeState["executions"],
     comms: {},
@@ -782,6 +787,7 @@ describe("SyncEngine", () => {
         kernel: {
           lifecycle: { lifecycle: "Running", activity: "Busy" },
           error_reason: null,
+          error_details: null,
           name: "python3",
           language: "python",
           env_source: "",
@@ -806,6 +812,10 @@ describe("SyncEngine", () => {
           approved_pixi_pypi_dependencies: [],
           approved_pixi_channels: [],
         },
+        runtime_state_doc_id: null,
+        path: null,
+        project_context: { state: "Pending" },
+        workstation: null,
         last_saved: null,
         executions: {},
         comms: {},
@@ -869,6 +879,7 @@ describe("SyncEngine", () => {
         kernel: {
           lifecycle: { lifecycle: "Running", activity: "Busy" },
           error_reason: null,
+          error_details: null,
           name: "python3",
           language: "python",
           env_source: "",
@@ -893,6 +904,10 @@ describe("SyncEngine", () => {
           approved_pixi_pypi_dependencies: [],
           approved_pixi_channels: [],
         },
+        runtime_state_doc_id: null,
+        path: null,
+        project_context: { state: "Pending" },
+        workstation: null,
         last_saved: null,
         executions: {
           "exec-1": {

--- a/packages/runtimed/tsconfig.test.json
+++ b/packages/runtimed/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src", "tests"]
+}

--- a/src/components/notebook/AGENTS.md
+++ b/src/components/notebook/AGENTS.md
@@ -12,8 +12,8 @@ a Decision 8 call, not an accident (`docs/adr/frontend-sync-bridge.md`).
   as they are; do not convert them to RxJS.
 - **RxJS-bound** (`runtime-state.ts`, `runtime-store-projection.ts`,
   `view-store-projection.ts`): anything holding time, async, or an
-  `AbortController`. `runtime-state-store.ts` in `packages/runtimed` is the
-  pending `ObservableStore` retrofit target (frontend-sync-bridge FSB-2).
+  `AbortController`. `runtime-state-store.ts` in `packages/runtimed` extends
+  `ObservableStore` (frontend-sync-bridge Decision 8).
 
 ## Binding is plumbing
 


### PR DESCRIPTION
Consolidates the store layer to its intended end-state: the FSB-2 retrofit, CI enforcement for the equality-manifest tripwires, and the singleton-vs-context question answered in code. Follow-up to #3906/#3909.

## FSB-2: RuntimeStateStore extends ObservableStore

The base was extracted from RuntimeStateStore's spine; with four stores proving it, the original now extends it and the duplicated `_state$`/`_loaded$`/`select`/`snapshot` plumbing is deleted. Public API is name/type/semantics compatible; every runtime projection and comparator is byte-identical. One deliberate behavioral alignment: `set()` now emits state before the loaded gate (the base's documented invariant - a `loaded$` subscriber can no longer read the default snapshot as authoritative in the emission window). FSB-2 comes off the ADR follow-up list.

## The manifest tripwire now trips in CI

`satisfies Record<keyof T, true>` manifests only work if a tsc pass covers them, and neither `packages/runtimed/tests/` nor the notebook-cloud app had one in CI. The js-tests lane (which already builds the wasm artifacts both need) now runs `pnpm --dir packages/runtimed typecheck` (a tests-included tsconfig) and `pnpm --dir apps/notebook-cloud typecheck`. Proven by breaking a manifest and watching TS1360 fail the command. Turning the gate on surfaced and fixed five latent type drifts in existing tests, including a real `src` fix: `throttleBusyStatus`'s scheduler parameter typed as `SchedulerLike` instead of a `Parameters<typeof timer>[1]` alias that resolved to `undefined`.

## Context seam: provider-overridable consumption, singleton defaults

Module singletons remain the production reality - auth must exist before React mounts for instant paint, and drivers run outside the tree - but the hook layer no longer hardwires them. `cloud-stores-context.ts` provides the four stores through a context whose **default value is the singleton bundle**: no provider anywhere in production, behavior byte-identical, and a test, Elements fixture, or future embedded viewer can mount `CloudStoresProvider` with its own instances and every domain hook, action dispatch, and snapshot read downstream coherently uses them. The provider swaps which stores are consumed, never which are driven; an override's owner activates its own instances. Views were swept so actions resolve from the same context instance the hooks read - a review-caught incoherence where an override would render state from fixture stores while buttons mutated the singletons.

Decision 8 records the pattern: context as consumption override with singleton default, never context as requirement.

## Boot-path discipline + workstations route split

Only the auth store may be module-evaluated on the entry chunk (its synchronous seed is what instant paint reads); every other store rides its route's chunk. The workstations surface (store, hooks, management page UI) was riding the entry into every route - it now loads with a lazy `/workstations` route like the notebook route already does. Entry chunk: 84.68 -> 77.37 kB gzip. The discipline is recorded in Decision 8 so the next store needs an instant-paint-grade reason to land in the entry.

## Out of scope

`cloud-viewer-session.ts` reads auth snapshots singleton-direct by design (non-component scope; Phase 6 territory). Before/after runtime measurements are a separate follow-up. Comments and connection stores stay behind their ADR triggers.
