### PR TITLE
fix(notebook-cloud): resolve session-hook store reads through useCloudStores

### DIFF
--- a/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
+++ b/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
@@ -59,18 +59,16 @@ describe("cloud projection flicker wiring", () => {
       sessionSource,
       /const syncAuthConnectionKey = cloudSyncAuthConnectionKey\(authState, \{ hasAppSession \}\);/,
     );
-    // The connect/diagnostic paths read the latest auth from the store snapshot,
-    // not from a dependency, so the effect stays keyed by the credential shape.
-    assert.match(
-      sessionSource,
-      /cloudSyncAuthFromPrototypeAuthState\(cloudAuthStore\.authSnapshot\)/,
-    );
+    // The connect/diagnostic paths read the latest auth snapshot from the store
+    // resolved through useCloudStores, not from a rekeying dependency, so the
+    // effect stays keyed by the credential shape.
+    assert.match(sessionSource, /cloudSyncAuthFromPrototypeAuthState\(auth\.authSnapshot\)/);
     assert.match(
       sessionSource,
       /const hasAppSessionRef = useRef\(hasAppSession\);\s*hasAppSessionRef\.current = hasAppSession;/,
     );
     const liveRoomDependencies = sessionSource.match(
-      /\[\s*blobResolver,[\s\S]*?widgetStore,\s*\]\);/,
+      /\[\s*auth,\s*blobResolver,[\s\S]*?widgetStore,\s*\]\);/,
     )?.[0];
     assert.ok(liveRoomDependencies, "live-room dependency list should be identifiable");
     assert.match(

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -38,7 +38,7 @@ import {
   type CloudPrototypeAuthState,
   type CloudSyncAuth,
 } from "./collaborator-auth";
-import { cloudAuthStore } from "./cloud-auth-store";
+import { useCloudStores } from "./cloud-stores-context";
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudLivePresenceStore } from "./live-presence";
 import {
@@ -228,6 +228,13 @@ export function useCloudViewerSession({
   resolveSyncAuth,
   widgetStore,
 }: UseCloudViewerSessionOptions): CloudViewerSession {
+  // Auth snapshot reads below (connection diagnostics, the instant-paint
+  // principal gate, the sync-auth fallback) resolve through this context bundle
+  // so a CloudStoresProvider override drives the same store this hook reads. The
+  // context default is the singleton, a stable reference, so the `auth` entries
+  // added to the effect deps below cannot retrigger a connect in production;
+  // each read still takes the latest snapshot at read time.
+  const { auth } = useCloudStores();
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
     message: loadingPolicy.initialStatusMessage,
@@ -341,7 +348,7 @@ export function useCloudViewerSession({
       diagnose: () =>
         diagnoseCloudConnectionAccess({
           accessRequestsEndpoint: config.accessRequestsEndpoint,
-          authState: cloudAuthStore.authSnapshot,
+          authState: auth.authSnapshot,
           hasAppSession: hasAppSessionRef.current,
         }),
       onDiagnostic: (diagnostic) => {
@@ -361,7 +368,7 @@ export function useCloudViewerSession({
       subscription.unsubscribe();
       tracker.dispose();
     };
-  }, [connectionStatusBridge, config.accessRequestsEndpoint]);
+  }, [auth, connectionStatusBridge, config.accessRequestsEndpoint]);
 
   useEffect(() => {
     const previousKind = previousAuthRenewalKindRef.current;
@@ -878,7 +885,7 @@ export function useCloudViewerSession({
         ranConnectionDiagnostics = true;
         void diagnoseCloudConnectionAccess({
           accessRequestsEndpoint: config.accessRequestsEndpoint,
-          authState: cloudAuthStore.authSnapshot,
+          authState: auth.authSnapshot,
           hasAppSession: hasAppSessionRef.current,
         })
           .then((diagnostic) => {
@@ -1083,7 +1090,7 @@ export function useCloudViewerSession({
       // null (no derivable principal) skips the paint. Shared with the
       // storage bindings, which use it to pick the matching principal's
       // chunk sub-range.
-      const instantPaintMatcher = cloudInstantPaintPrincipalMatcher(cloudAuthStore.authSnapshot, {
+      const instantPaintMatcher = cloudInstantPaintPrincipalMatcher(auth.authSnapshot, {
         hasAppSession: hasAppSessionRef.current,
       });
       await runCloudInstantPaint({
@@ -1200,7 +1207,7 @@ export function useCloudViewerSession({
         resolveAuth: (attemptSessionId) =>
           resolveSyncAuth
             ? resolveSyncAuth(attemptSessionId)
-            : cloudSyncAuthFromPrototypeAuthState(cloudAuthStore.authSnapshot),
+            : cloudSyncAuthFromPrototypeAuthState(auth.authSnapshot),
       }),
       runtimedWasmModulePath: config.runtimedWasmModulePath,
       runtimedWasmPath: config.runtimedWasmPath,
@@ -1475,7 +1482,7 @@ export function useCloudViewerSession({
         if (cloudConnectionErrorAcceptsAccessDiagnostic(message)) {
           void diagnoseCloudConnectionAccess({
             accessRequestsEndpoint: config.accessRequestsEndpoint,
-            authState: cloudAuthStore.authSnapshot,
+            authState: auth.authSnapshot,
             hasAppSession: hasAppSessionRef.current,
           })
             .then((diagnostic) => {
@@ -1567,6 +1574,7 @@ export function useCloudViewerSession({
       setConnectionPeerLabel(null);
     };
   }, [
+    auth,
     blobResolver,
     config.accessRequestsEndpoint,
     config.blobBasePath,

--- a/packages/runtimed/src/runtime-state-store.ts
+++ b/packages/runtimed/src/runtime-state-store.ts
@@ -7,8 +7,11 @@
  * projections and comparators. Hosts (desktop bridge, cloud viewer session)
  * push snapshots with `set()`; consumers subscribe to a projection observable
  * or read the synchronous snapshot. React bindings stay in the apps, so this
- * module has no framework dependency and projections are testable headlessly;
- * any future host (CLI, MCP surface) consumes the same streams.
+ * module has no framework dependency and projections are testable headlessly.
+ * Consumers are the React shells (desktop and cloud viewer, through the shared
+ * observable binding) and runtimed-node; a non-React shell would bind these
+ * same streams directly. The MCP surface is Rust (`runt-mcp`) by design and
+ * does not consume this module.
  *
  * Why projections live here and not in `useMemo` chains: a `useMemo` on the
  * whole `RuntimeState` recomputes (and re-renders its component) on every


### PR DESCRIPTION
Stacked on #3910. Extends the store-consumption coherence sweep to the last surface reading singletons from React scope: `useCloudViewerSession` had five `cloudAuthStore.authSnapshot` reads (connection diagnostics, the instant-paint principal gate, the sync-auth fallback, terminal-failure diagnostics) that now resolve through `useCloudStores()`, so a `CloudStoresProvider` override drives the same store the session hook reads.

The load-bearing detail is the dep arrays: the diagnostics effect and the live-room effect gain the `auth` store instance as a dependency. The context default is the singleton - a stable reference for the page lifetime - so the added deps cannot retrigger a connect in production; the effect stays keyed by `syncAuthConnectionKey`, and every read still takes the latest snapshot at read time. That reasoning is recorded as an invariant comment at the destructure site.

Module-scope code keeps no singleton references (there were none below the hook). The `cloud-projection-flicker.test.ts` source pins are updated to the context form, including re-anchoring the live-room dep-array regex so it now also pins `auth` as the stable lead dep.
