### PR TITLE
docs: store refactor measurements + speculative-claim review lens

### DIFF
--- a/.agents/reviewers/nteract-code-review-rubric.md
+++ b/.agents/reviewers/nteract-code-review-rubric.md
@@ -59,6 +59,13 @@ Prefer at most 12 findings.
   equivalent guards.
 - Tests: require focused tests at the changed boundary. Treat deleted tests as
   suspicious unless the behavior was removed and replacement coverage exists.
+- Comment and doc claims: module headers and doc comments state what is true
+  now. Flag past-tense history narration AND speculative future-consumer
+  claims - naming hosts, surfaces, or integrations that do not consume the
+  module. Claims about other subsystems deserve extra suspicion because the
+  diff cannot verify them (example: the MCP surface is Rust by design, so TS
+  store docs must never list it as a consumer). Carried-forward prose in a
+  touched header is in scope, not grandfathered.
 
 ## Finding Contract
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -20,6 +20,7 @@
     "test:renderer-parity": "playwright test -c playwright.render-parity.config.ts",
     "test:renderer-parity:update": "playwright test -c playwright.render-parity.config.ts --update-snapshots",
     "dev": "node scripts/dev.mjs",
+    "profile:local": "node scripts/profile-local.mjs",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",

--- a/apps/notebook-cloud/scripts/profile-local.mjs
+++ b/apps/notebook-cloud/scripts/profile-local.mjs
@@ -1,0 +1,659 @@
+import { pathToFileURL } from "node:url";
+
+import { chromium } from "@playwright/test";
+
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
+
+// Local-wrangler profiling harness for the cloud viewer. Given NTERACT_CLOUD_URL
+// (falling back to the per-worktree wrangler port), it visits /n and
+// /workstations cold and records, per route: cloud viewer performance marks,
+// navigation timing, a long-task total (TBT proxy) across load + a settle
+// window, event-timing for one scripted interaction (INP proxy), JS transfer
+// bytes from network events, opened WebSockets, and React commit counts from
+// the ?profile=1 render hook. It then runs a reconnect-stability check on a
+// freshly created notebook room (loopback dev auth), or on /n when a room
+// cannot be created. One JSON report goes to stdout; a human table to stderr.
+//
+// Auth is loopback dev-token only. The worker trusts these localStorage keys and
+// the matching x-notebook-cloud-dev-token header on loopback hosts when started
+// with NOTEBOOK_CLOUD_TRUST_LOOPBACK_HEADERS:true (scripts/dev.mjs sets it). The
+// three storage keys mirror src/dev-auth-storage.ts and the header mirrors
+// src/auth-shared.ts DEV_AUTH_TOKEN_HEADER; those files are the source of truth.
+const DEV_TOKEN = "local-loopback-dev-token";
+const DEV_USER = "browser-editor";
+const DEV_SCOPE = "owner";
+const DEV_TOKEN_STORAGE_KEY = "nteract:notebook-cloud:dev-token";
+const DEV_USER_STORAGE_KEY = "nteract:notebook-cloud:user";
+const DEV_SCOPE_STORAGE_KEY = "nteract:notebook-cloud:scope";
+const DEV_TOKEN_HEADER = "x-notebook-cloud-dev-token";
+
+const SETTLE_MS = parsePositiveInteger(process.env.NOTEBOOK_CLOUD_PROFILE_SETTLE_MS, 10_000);
+const NOTEBOOK_SETTLE_MS = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_PROFILE_NOTEBOOK_SETTLE_MS,
+  4_000,
+);
+const NAV_TIMEOUT_MS = parsePositiveInteger(process.env.NOTEBOOK_CLOUD_PROFILE_TIMEOUT_MS, 45_000);
+const READY_TIMEOUT_MS = 15_000;
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  const baseUrl = notebookCloudBaseUrl();
+  const origin = new URL(baseUrl).origin;
+  logStderr(`Profiling cloud viewer at ${baseUrl}`);
+
+  await waitForWorkerReady(baseUrl);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await context.addInitScript(profileInitScript, {
+    devTokenKey: DEV_TOKEN_STORAGE_KEY,
+    devToken: DEV_TOKEN,
+    userKey: DEV_USER_STORAGE_KEY,
+    user: DEV_USER,
+    scopeKey: DEV_SCOPE_STORAGE_KEY,
+    scope: DEV_SCOPE,
+  });
+
+  const limitations = [];
+  let created = null;
+  try {
+    created = await createLoopbackNotebook(context, baseUrl, origin);
+    logStderr(`Created probe notebook ${created.notebookId}`);
+  } catch (error) {
+    limitations.push(
+      `loopback notebook creation failed (${errorText(error)}); reconnect check ran on /n instead`,
+    );
+    logStderr(`Notebook creation failed: ${errorText(error)}`);
+  }
+
+  const routes = {};
+  try {
+    routes["/n"] = await profileRoute(context, {
+      baseUrl,
+      routePath: "/n",
+      label: "notebook-list",
+      settleMs: SETTLE_MS,
+      readySelector: 'main.nb-app, [data-kind="error"]',
+      interactionCandidates: [
+        { label: "refresh-notebooks", selector: 'button[aria-label="Refresh notebooks"]' },
+        { label: "new-notebook", selector: 'button:has-text("New notebook")' },
+      ],
+    });
+    routes["/workstations"] = await profileRoute(context, {
+      baseUrl,
+      routePath: "/workstations",
+      label: "workstations",
+      settleMs: SETTLE_MS,
+      readySelector: 'main.nb-app, [data-kind="error"]',
+      interactionCandidates: [
+        { label: "workstation-row", selector: "[data-workstation-id]" },
+        { label: "refresh-workstations", selector: 'button[aria-label="Refresh workstations"]' },
+      ],
+    });
+
+    const notebook = created
+      ? await profileNotebookReconnect(context, { origin, created })
+      : await profileListReconnect(context, { baseUrl });
+
+    // A ?profile=1 load creates window.__nteractRenderCounts eagerly, so an
+    // empty object across every surface means the Profiler mounted but onRender
+    // never fired: the standard production react-dom build makes Profiler timing
+    // inert. Rebuild with NOTEBOOK_CLOUD_PROFILE_REACT=1 to record real counts.
+    const sawRenderCounts = [
+      ...Object.values(routes).map((route) => route.renderCounts),
+      notebook.renderCounts,
+    ].some((counts) => counts && Object.keys(counts).length > 0);
+    if (!sawRenderCounts) {
+      limitations.push(
+        "render counts empty: React <Profiler> onRender is inert in the default production build; rebuild with NOTEBOOK_CLOUD_PROFILE_REACT=1 pnpm build:viewer for real counts",
+      );
+    }
+
+    const report = {
+      ok: true,
+      baseUrl,
+      settleMs: SETTLE_MS,
+      generatedAt: new Date().toISOString(),
+      createdNotebookId: created?.notebookId ?? null,
+      routes,
+      notebook,
+      limitations,
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    writeHumanTable(report);
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+// Runs before the viewer bundle on every document load: seeds loopback dev auth
+// so cold navigations are authenticated, then installs buffered observers whose
+// results the metric reader drains after settle. A full reload creates a fresh
+// window, so these collectors reset per document by design.
+function profileInitScript(seed) {
+  try {
+    localStorage.setItem(seed.devTokenKey, seed.devToken);
+    localStorage.setItem(seed.userKey, seed.user);
+    localStorage.setItem(seed.scopeKey, seed.scope);
+  } catch {
+    // Storage may be unavailable on error pages; auth simply stays unset.
+  }
+  const store = (window.__nteractProfile = window.__nteractProfile || {
+    longTasks: [],
+    events: [],
+  });
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        store.longTasks.push({ startTime: entry.startTime, duration: entry.duration });
+      }
+    }).observe({ type: "longtask", buffered: true });
+  } catch {
+    // longtask timing is Chromium-only; absence degrades to an empty TBT proxy.
+  }
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        store.events.push({
+          name: entry.name,
+          startTime: entry.startTime,
+          duration: entry.duration,
+          interactionId: entry.interactionId ?? 0,
+        });
+      }
+    }).observe({ type: "event", buffered: true, durationThreshold: 16 });
+  } catch {
+    // event timing is Chromium-only; absence degrades to a null INP proxy.
+  }
+}
+
+async function profileRoute(
+  context,
+  { baseUrl, routePath, label, settleMs, readySelector, interactionCandidates },
+) {
+  const page = await context.newPage();
+  const network = attachNetworkCollectors(page);
+  const url = new URL(routePath, baseUrl);
+  url.searchParams.set("profile", "1");
+
+  const startedAt = Date.now();
+  await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+  await page
+    .waitForSelector(readySelector, { timeout: READY_TIMEOUT_MS })
+    .catch(() =>
+      logStderr(`${label}: ready selector ${readySelector} not seen; collecting anyway`),
+    );
+  await page.waitForTimeout(settleMs);
+
+  const interaction = await runInteractionProbe(page, interactionCandidates);
+  await page.waitForTimeout(1_000);
+
+  const metrics = await page.evaluate(collectPageMetrics, interaction.clickStart);
+  const renderCounts = await page.evaluate(() => window.__nteractRenderCounts ?? null);
+  await network.settle();
+  await page.close();
+
+  return {
+    route: routePath,
+    label,
+    wallClockMs: Date.now() - startedAt,
+    marks: metrics.marks,
+    navigationTiming: metrics.navigationTiming,
+    paint: metrics.paint,
+    longTasks: metrics.longTasks,
+    interaction: {
+      target: interaction.target,
+      inpProxyMs: metrics.interaction.maxDurationMs,
+      eventCount: metrics.interaction.count,
+      sampleEvents: metrics.interaction.sample,
+    },
+    jsTransferBytes: {
+      networkBodyBytes: network.jsBodyBytes(),
+      networkContentLengthBytes: network.jsContentLengthBytes(),
+      resourceTimingEncodedBytes: metrics.jsResourceTimingBytes,
+      jsResponseCount: network.jsResponseCount(),
+    },
+    webSockets: network.webSockets(),
+    renderCounts,
+  };
+}
+
+async function profileNotebookReconnect(context, { origin, created }) {
+  const page = await context.newPage();
+  const network = attachNetworkCollectors(page);
+  const viewerUrl = rebaseUrl(created.viewerUrl, origin);
+  viewerUrl.searchParams.set("profile", "1");
+
+  const startedAt = Date.now();
+  await page.goto(viewerUrl.href, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+  await page
+    .waitForSelector('[data-testid="notebook-toolbar"], main.nb-app', { timeout: READY_TIMEOUT_MS })
+    .catch(() => logStderr("notebook: toolbar not seen; collecting anyway"));
+  await page.waitForTimeout(NOTEBOOK_SETTLE_MS);
+
+  const marks = await page.evaluate(collectMarks);
+  const navigationTiming = await page.evaluate(collectNavigationTiming);
+  const wsBefore = network.webSockets().length;
+  const nonce = await page.evaluate(() => {
+    const value = Math.random().toString(36).slice(2);
+    window.__nteractReloadNonce = value;
+    return value;
+  });
+
+  // Exercise the window focus / visibility path twice, ~2s apart, the way a
+  // tab-switch would. onFocusChange in cloud-notebook-host.ts and the
+  // browser-signals visibility subject listen for these; a stable session must
+  // not dial a new WebSocket or reload the document in response.
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("blur"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await page.waitForTimeout(500);
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await page.waitForTimeout(2_000);
+  }
+
+  const wsAfter = network.webSockets().length;
+  const nonceSurvived = await page.evaluate(
+    (value) => window.__nteractReloadNonce === value,
+    nonce,
+  );
+  const renderCounts = await page.evaluate(() => window.__nteractRenderCounts ?? null);
+  await page.close();
+
+  const reloaded = !nonceSurvived;
+  const openedNewWebSocket = wsAfter > wsBefore;
+  return {
+    mode: "notebook-room",
+    notebookId: created.notebookId,
+    viewerUrl: viewerUrl.href,
+    wallClockMs: Date.now() - startedAt,
+    marks,
+    navigationTiming,
+    webSockets: network.webSockets(),
+    reconnect: {
+      webSocketsBefore: wsBefore,
+      webSocketsAfter: wsAfter,
+      openedNewWebSocket,
+      reloaded,
+      stable: !openedNewWebSocket && !reloaded,
+    },
+    renderCounts,
+  };
+}
+
+async function profileListReconnect(context, { baseUrl }) {
+  const page = await context.newPage();
+  const network = attachNetworkCollectors(page);
+  const url = new URL("/n", baseUrl);
+  url.searchParams.set("profile", "1");
+
+  await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+  await page.waitForSelector("main.nb-app", { timeout: READY_TIMEOUT_MS }).catch(() => {});
+  await page.waitForTimeout(NOTEBOOK_SETTLE_MS);
+
+  const wsBefore = network.webSockets().length;
+  const nonce = await page.evaluate(() => {
+    const value = Math.random().toString(36).slice(2);
+    window.__nteractReloadNonce = value;
+    return value;
+  });
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("blur"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await page.waitForTimeout(500);
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await page.waitForTimeout(2_000);
+  }
+  const wsAfter = network.webSockets().length;
+  const nonceSurvived = await page.evaluate(
+    (value) => window.__nteractReloadNonce === value,
+    nonce,
+  );
+  await page.close();
+
+  const reloaded = !nonceSurvived;
+  const openedNewWebSocket = wsAfter > wsBefore;
+  return {
+    mode: "notebook-list",
+    wallClockMs: null,
+    marks: [],
+    navigationTiming: null,
+    webSockets: network.webSockets(),
+    reconnect: {
+      webSocketsBefore: wsBefore,
+      webSocketsAfter: wsAfter,
+      openedNewWebSocket,
+      reloaded,
+      stable: !openedNewWebSocket && !reloaded,
+    },
+    renderCounts: null,
+  };
+}
+
+async function runInteractionProbe(page, candidates) {
+  for (const candidate of candidates) {
+    const locator = page.locator(candidate.selector).first();
+    const count = await locator.count().catch(() => 0);
+    if (count === 0) {
+      continue;
+    }
+    const visible = await locator.isVisible().catch(() => false);
+    if (!visible) {
+      continue;
+    }
+    const clickStart = await page.evaluate(() => performance.now());
+    await locator.click({ timeout: 5_000 }).catch(() => {});
+    return { target: candidate.label, selector: candidate.selector, clickStart };
+  }
+  return { target: null, selector: null, clickStart: 0 };
+}
+
+function attachNetworkCollectors(page) {
+  const responses = [];
+  const sockets = [];
+  const bodyPromises = [];
+  page.on("response", (response) => {
+    const request = response.request();
+    const type = request.resourceType();
+    const entry = {
+      url: response.url(),
+      resourceType: type,
+      status: response.status(),
+      contentLength: Number(response.headers()["content-length"] ?? 0),
+      bodyBytes: null,
+    };
+    responses.push(entry);
+    // Wrangler dev serves assets chunked without content-length, so read the
+    // decoded body length to get real transfer bytes from the network events.
+    if (type === "script") {
+      bodyPromises.push(
+        response
+          .body()
+          .then((buffer) => {
+            entry.bodyBytes = buffer.length;
+          })
+          .catch(() => {}),
+      );
+    }
+  });
+  page.on("websocket", (socket) => {
+    sockets.push(socket.url());
+  });
+  const scripts = () => responses.filter((entry) => entry.resourceType === "script");
+  return {
+    settle: () => Promise.all(bodyPromises),
+    jsBodyBytes: () => scripts().reduce((sum, entry) => sum + (entry.bodyBytes ?? 0), 0),
+    jsContentLengthBytes: () =>
+      scripts().reduce(
+        (sum, entry) => sum + (Number.isFinite(entry.contentLength) ? entry.contentLength : 0),
+        0,
+      ),
+    jsResponseCount: () => scripts().length,
+    webSockets: () => [...sockets],
+  };
+}
+
+// Evaluated in the page. `clickStart` scopes the event-timing entries to the one
+// scripted interaction so the INP proxy is that interaction's worst event.
+function collectPageMetrics(clickStart) {
+  const store = window.__nteractProfile || { longTasks: [], events: [] };
+
+  const marks = performance
+    .getEntriesByType("mark")
+    .filter((mark) => mark.name.startsWith("nteract:notebook-cloud:"))
+    .map((mark) => ({
+      name: mark.name.replace("nteract:notebook-cloud:", ""),
+      startTimeMs: Math.round(mark.startTime),
+    }));
+
+  const nav = performance.getEntriesByType("navigation")[0];
+  const navigationTiming = nav
+    ? {
+        responseEndMs: Math.round(nav.responseEnd),
+        domContentLoadedMs: Math.round(nav.domContentLoadedEventEnd),
+        domCompleteMs: Math.round(nav.domComplete),
+        loadEventEndMs: Math.round(nav.loadEventEnd),
+        transferSize: nav.transferSize,
+      }
+    : null;
+
+  const paint = {};
+  for (const entry of performance.getEntriesByType("paint")) {
+    paint[entry.name] = Math.round(entry.startTime);
+  }
+
+  const longTasks = store.longTasks || [];
+  const longTaskTotalMs = Math.round(longTasks.reduce((sum, task) => sum + task.duration, 0));
+  const tbtProxyMs = Math.round(
+    longTasks.reduce((sum, task) => sum + Math.max(0, task.duration - 50), 0),
+  );
+
+  const interactionEvents = (store.events || []).filter((entry) => entry.startTime >= clickStart);
+  const maxDurationMs = interactionEvents.length
+    ? Math.round(Math.max(...interactionEvents.map((entry) => entry.duration)))
+    : null;
+
+  const jsResourceTimingBytes = performance
+    .getEntriesByType("resource")
+    .filter((entry) => entry.initiatorType === "script" || /\.js(\?|$)/.test(entry.name))
+    .reduce((sum, entry) => sum + (entry.encodedBodySize || 0), 0);
+
+  return {
+    marks,
+    navigationTiming,
+    paint,
+    longTasks: { count: longTasks.length, totalMs: longTaskTotalMs, tbtProxyMs },
+    interaction: {
+      count: interactionEvents.length,
+      maxDurationMs,
+      sample: interactionEvents.slice(0, 8).map((entry) => ({
+        name: entry.name,
+        durationMs: Math.round(entry.duration),
+      })),
+    },
+    jsResourceTimingBytes,
+  };
+}
+
+function collectMarks() {
+  return performance
+    .getEntriesByType("mark")
+    .filter((mark) => mark.name.startsWith("nteract:notebook-cloud:"))
+    .map((mark) => ({
+      name: mark.name.replace("nteract:notebook-cloud:", ""),
+      startTimeMs: Math.round(mark.startTime),
+    }));
+}
+
+function collectNavigationTiming() {
+  const nav = performance.getEntriesByType("navigation")[0];
+  if (!nav) {
+    return null;
+  }
+  return {
+    responseEndMs: Math.round(nav.responseEnd),
+    domContentLoadedMs: Math.round(nav.domContentLoadedEventEnd),
+    domCompleteMs: Math.round(nav.domComplete),
+    loadEventEndMs: Math.round(nav.loadEventEnd),
+    transferSize: nav.transferSize,
+  };
+}
+
+async function createLoopbackNotebook(context, baseUrl, origin) {
+  const response = await context.request.post(new URL("/api/n", baseUrl).href, {
+    headers: {
+      [DEV_TOKEN_HEADER]: DEV_TOKEN,
+      "X-User": DEV_USER,
+      "X-Scope": DEV_SCOPE,
+      "Content-Type": "application/json",
+      Origin: origin,
+    },
+    data: { title: "profile-local reconnect probe" },
+  });
+  if (response.status() !== 201) {
+    throw new Error(`create notebook returned ${response.status()}: ${await response.text()}`);
+  }
+  const body = await response.json();
+  if (!body.notebook_id || !body.viewer_url) {
+    throw new Error("create notebook response missing notebook_id or viewer_url");
+  }
+  return { notebookId: body.notebook_id, viewerUrl: body.viewer_url };
+}
+
+async function waitForWorkerReady(baseUrl) {
+  const healthUrl = new URL("/api/health", baseUrl).href;
+  const deadline = Date.now() + 30_000;
+  let lastError = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(healthUrl, { signal: AbortSignal.timeout(3_000) });
+      if (response.ok) {
+        return;
+      }
+      lastError = `status ${response.status}`;
+    } catch (error) {
+      lastError = errorText(error);
+    }
+    await sleep(500);
+  }
+  throw new Error(`worker at ${baseUrl} not ready within 30s (last: ${lastError})`);
+}
+
+function writeHumanTable(report) {
+  const lines = [];
+  lines.push("");
+  lines.push(`cloud viewer profile  base=${report.baseUrl}  settle=${report.settleMs}ms`);
+  lines.push("-".repeat(88));
+  const header = [
+    pad("route", 15),
+    pad("marks", 7),
+    pad("dclMs", 7),
+    pad("tbtMs", 7),
+    pad("inpMs", 7),
+    pad("jsKB", 8),
+    pad("ws", 4),
+    pad("renders", 8),
+  ].join(" ");
+  lines.push(header);
+  for (const [routePath, route] of Object.entries(report.routes)) {
+    lines.push(
+      [
+        pad(routePath, 15),
+        pad(String(route.marks.length), 7),
+        pad(numOrDash(route.navigationTiming?.domContentLoadedMs), 7),
+        pad(numOrDash(route.longTasks.tbtProxyMs), 7),
+        pad(numOrDash(route.interaction.inpProxyMs), 7),
+        pad(kb(bestJsBytes(route.jsTransferBytes)), 8),
+        pad(String(route.webSockets.length), 4),
+        pad(renderTotal(route.renderCounts), 8),
+      ].join(" "),
+    );
+  }
+  lines.push("-".repeat(88));
+  const nb = report.notebook;
+  if (nb) {
+    lines.push(`reconnect (${nb.mode}) marks=${nb.marks.length}`);
+    lines.push(
+      `  ws ${nb.reconnect.webSocketsBefore} -> ${nb.reconnect.webSocketsAfter}` +
+        `  newWs=${nb.reconnect.openedNewWebSocket}  reloaded=${nb.reconnect.reloaded}` +
+        `  stable=${nb.reconnect.stable}`,
+    );
+    if (nb.marks.length) {
+      lines.push(
+        `  marks: ${nb.marks.map((mark) => `${mark.name}@${mark.startTimeMs}`).join(", ")}`,
+      );
+    }
+  }
+  if (report.limitations.length) {
+    lines.push("limitations:");
+    for (const note of report.limitations) {
+      lines.push(`  - ${note}`);
+    }
+  }
+  lines.push("");
+  logStderr(lines.join("\n"));
+}
+
+function bestJsBytes(jsTransferBytes) {
+  return (
+    jsTransferBytes.networkBodyBytes ||
+    jsTransferBytes.networkContentLengthBytes ||
+    jsTransferBytes.resourceTimingEncodedBytes ||
+    0
+  );
+}
+
+function renderTotal(renderCounts) {
+  if (!renderCounts) {
+    return "-";
+  }
+  const total = Object.values(renderCounts).reduce((sum, value) => sum + Number(value || 0), 0);
+  return String(total);
+}
+
+function rebaseUrl(value, origin) {
+  const url = new URL(value, origin);
+  const base = new URL(origin);
+  url.protocol = base.protocol;
+  url.host = base.host;
+  return url;
+}
+
+function numOrDash(value) {
+  return value === null || value === undefined ? "-" : String(value);
+}
+
+function kb(bytes) {
+  if (!bytes) {
+    return "0";
+  }
+  return (bytes / 1024).toFixed(1);
+}
+
+function pad(value, width) {
+  const text = String(value);
+  return text.length >= width ? text : text + " ".repeat(width - text.length);
+}
+
+function errorText(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parsePositiveInteger(value, fallback) {
+  if (value === undefined || value === null || value === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`expected a positive integer, received ${JSON.stringify(value)}`);
+  }
+  return parsed;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function logStderr(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+}

--- a/apps/notebook-cloud/scripts/profile-local.mjs
+++ b/apps/notebook-cloud/scripts/profile-local.mjs
@@ -14,6 +14,16 @@ import { notebookCloudBaseUrl } from "./local-dev.mjs";
 // freshly created notebook room (loopback dev auth), or on /n when a room
 // cannot be created. One JSON report goes to stdout; a human table to stderr.
 //
+// A property that could not be measured is reported as unavailable, never as a
+// clean zero: a detached long-task observer yields tbtProxyMs null, an
+// interaction that never landed yields inpProxyMs null, and the reconnect check
+// asserts its own stability. A failed reconnect assertion (a new WebSocket or a
+// document reload) fails the process with a non-zero exit.
+//
+// Litter: each run creates one reconnect probe notebook and the worker exposes
+// no notebook-delete endpoint, so probes accumulate. Their titles carry an
+// ISO-8601 timestamp prefix so an operator can find and sweep them by age.
+//
 // Auth is loopback dev-token only. The worker trusts these localStorage keys and
 // the matching x-notebook-cloud-dev-token header on loopback hosts when started
 // with NOTEBOOK_CLOUD_TRUST_LOOPBACK_HEADERS:true (scripts/dev.mjs sets it). The
@@ -59,6 +69,7 @@ async function main() {
     scopeKey: DEV_SCOPE_STORAGE_KEY,
     scope: DEV_SCOPE,
   });
+  await context.addInitScript(visibilityOverrideInitScript);
 
   const limitations = [];
   let created = null;
@@ -115,8 +126,9 @@ async function main() {
       );
     }
 
+    const reconnect = notebook.reconnect;
     const report = {
-      ok: true,
+      ok: reconnect.stable,
       baseUrl,
       settleMs: SETTLE_MS,
       generatedAt: new Date().toISOString(),
@@ -127,6 +139,21 @@ async function main() {
     };
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     writeHumanTable(report);
+
+    // The reconnect check is an assertion, not a metric: a stable session must
+    // not dial a new WebSocket or reload the document across a focus/visibility
+    // cycle. Fail the process loudly so a regression cannot pass silently.
+    if (!reconnect.stable) {
+      const failed = Object.entries(reconnect.assertions)
+        .filter(([, assertion]) => !assertion.pass)
+        .map(([name, assertion]) => `${name} (${assertion.detail})`)
+        .join(", ");
+      logStderr(
+        `reconnect stability check FAILED for ${notebook.mode}: ${failed}. ` +
+          "A stable session must not open a new WebSocket or reload the document.",
+      );
+      process.exitCode = 1;
+    }
   } finally {
     await browser.close().catch(() => {});
   }
@@ -147,6 +174,7 @@ function profileInitScript(seed) {
   const store = (window.__nteractProfile = window.__nteractProfile || {
     longTasks: [],
     events: [],
+    longTaskObserverAttached: false,
   });
   try {
     new PerformanceObserver((list) => {
@@ -154,8 +182,12 @@ function profileInitScript(seed) {
         store.longTasks.push({ startTime: entry.startTime, duration: entry.duration });
       }
     }).observe({ type: "longtask", buffered: true });
+    // Only mark attached once observe() returns; a swallowed setup error must not
+    // masquerade as a zero-long-task run, which reads as a perfect TBT proxy.
+    store.longTaskObserverAttached = true;
   } catch {
-    // longtask timing is Chromium-only; absence degrades to an empty TBT proxy.
+    // longtask timing is Chromium-only; when the observer cannot attach the TBT
+    // proxy is reported as unavailable, never a misleading 0.
   }
   try {
     new PerformanceObserver((list) => {
@@ -171,6 +203,58 @@ function profileInitScript(seed) {
   } catch {
     // event timing is Chromium-only; absence degrades to a null INP proxy.
   }
+}
+
+// Runs before the viewer bundle so browser-signals.ts reads a controllable
+// visibility state. documentVisible$ gates on `document.visibilityState ===
+// "visible"`; that property is read-only, so dispatching `visibilitychange`
+// without changing it never flips the gate. These prototype getters read a
+// window-scoped override and fall back to the real value when the harness has
+// not set one, letting driveVisibilityCycle exercise both the hidden and visible
+// edges of the real gate code.
+function visibilityOverrideInitScript() {
+  const proto = Document.prototype;
+  const realVisibility = Object.getOwnPropertyDescriptor(proto, "visibilityState");
+  const realHidden = Object.getOwnPropertyDescriptor(proto, "hidden");
+  if (!realVisibility?.get || !realHidden?.get) {
+    return;
+  }
+  const override = () => {
+    const value = window.__nteractVisibilityOverride;
+    return value === "visible" || value === "hidden" ? value : null;
+  };
+  Object.defineProperty(proto, "visibilityState", {
+    configurable: true,
+    get() {
+      return override() ?? realVisibility.get.call(this);
+    },
+  });
+  Object.defineProperty(proto, "hidden", {
+    configurable: true,
+    get() {
+      const value = override();
+      return value === null ? realHidden.get.call(this) : value === "hidden";
+    },
+  });
+}
+
+// Drives one hidden -> visible cycle through the override the gate reads, firing
+// the same blur/focus and visibilitychange events a real tab-switch does. The
+// override flip is what makes browser-signals' documentVisible$ actually observe
+// false then true.
+async function driveVisibilityCycle(page) {
+  await page.evaluate(() => {
+    window.__nteractVisibilityOverride = "hidden";
+    window.dispatchEvent(new Event("blur"));
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  await page.waitForTimeout(500);
+  await page.evaluate(() => {
+    window.__nteractVisibilityOverride = "visible";
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  await page.waitForTimeout(2_000);
 }
 
 async function profileRoute(
@@ -194,7 +278,10 @@ async function profileRoute(
   const interaction = await runInteractionProbe(page, interactionCandidates);
   await page.waitForTimeout(1_000);
 
-  const metrics = await page.evaluate(collectPageMetrics, interaction.clickStart);
+  const metrics = await page.evaluate(collectPageMetrics, {
+    clickStart: interaction.clickStart,
+    clicked: interaction.clicked,
+  });
   const renderCounts = await page.evaluate(() => window.__nteractRenderCounts ?? null);
   await network.settle();
   await page.close();
@@ -209,7 +296,10 @@ async function profileRoute(
     longTasks: metrics.longTasks,
     interaction: {
       target: interaction.target,
+      clicked: metrics.interaction.clicked,
+      inpAvailable: metrics.interaction.available,
       inpProxyMs: metrics.interaction.maxDurationMs,
+      inpUnavailableReason: metrics.interaction.unavailableReason,
       eventCount: metrics.interaction.count,
       sampleEvents: metrics.interaction.sample,
     },
@@ -251,16 +341,7 @@ async function profileNotebookReconnect(context, { origin, created }) {
   // browser-signals visibility subject listen for these; a stable session must
   // not dial a new WebSocket or reload the document in response.
   for (let cycle = 0; cycle < 2; cycle += 1) {
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event("blur"));
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
-    await page.waitForTimeout(500);
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event("focus"));
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
-    await page.waitForTimeout(2_000);
+    await driveVisibilityCycle(page);
   }
 
   const wsAfter = network.webSockets().length;
@@ -271,8 +352,6 @@ async function profileNotebookReconnect(context, { origin, created }) {
   const renderCounts = await page.evaluate(() => window.__nteractRenderCounts ?? null);
   await page.close();
 
-  const reloaded = !nonceSurvived;
-  const openedNewWebSocket = wsAfter > wsBefore;
   return {
     mode: "notebook-room",
     notebookId: created.notebookId,
@@ -281,13 +360,11 @@ async function profileNotebookReconnect(context, { origin, created }) {
     marks,
     navigationTiming,
     webSockets: network.webSockets(),
-    reconnect: {
+    reconnect: summarizeReconnect({
       webSocketsBefore: wsBefore,
       webSocketsAfter: wsAfter,
-      openedNewWebSocket,
-      reloaded,
-      stable: !openedNewWebSocket && !reloaded,
-    },
+      reloaded: !nonceSurvived,
+    }),
     renderCounts,
   };
 }
@@ -309,16 +386,7 @@ async function profileListReconnect(context, { baseUrl }) {
     return value;
   });
   for (let cycle = 0; cycle < 2; cycle += 1) {
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event("blur"));
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
-    await page.waitForTimeout(500);
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event("focus"));
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
-    await page.waitForTimeout(2_000);
+    await driveVisibilityCycle(page);
   }
   const wsAfter = network.webSockets().length;
   const nonceSurvived = await page.evaluate(
@@ -327,22 +395,43 @@ async function profileListReconnect(context, { baseUrl }) {
   );
   await page.close();
 
-  const reloaded = !nonceSurvived;
-  const openedNewWebSocket = wsAfter > wsBefore;
   return {
     mode: "notebook-list",
     wallClockMs: null,
     marks: [],
     navigationTiming: null,
     webSockets: network.webSockets(),
-    reconnect: {
+    reconnect: summarizeReconnect({
       webSocketsBefore: wsBefore,
       webSocketsAfter: wsAfter,
-      openedNewWebSocket,
-      reloaded,
-      stable: !openedNewWebSocket && !reloaded,
-    },
+      reloaded: !nonceSurvived,
+    }),
     renderCounts: null,
+  };
+}
+
+// Turns the raw reconnect observations into named pass/fail assertions plus an
+// overall stable flag. The stability contract is the invariant the process exit
+// code enforces: no new WebSocket, no document reload across a focus cycle.
+function summarizeReconnect({ webSocketsBefore, webSocketsAfter, reloaded }) {
+  const openedNewWebSocket = webSocketsAfter > webSocketsBefore;
+  const assertions = {
+    noNewWebSocket: {
+      pass: !openedNewWebSocket,
+      detail: `webSockets ${webSocketsBefore} -> ${webSocketsAfter}`,
+    },
+    documentNotReloaded: {
+      pass: !reloaded,
+      detail: reloaded ? "reload nonce did not survive" : "reload nonce survived",
+    },
+  };
+  return {
+    webSocketsBefore,
+    webSocketsAfter,
+    openedNewWebSocket,
+    reloaded,
+    stable: assertions.noNewWebSocket.pass && assertions.documentNotReloaded.pass,
+    assertions,
   };
 }
 
@@ -358,10 +447,19 @@ async function runInteractionProbe(page, candidates) {
       continue;
     }
     const clickStart = await page.evaluate(() => performance.now());
-    await locator.click({ timeout: 5_000 }).catch(() => {});
-    return { target: candidate.label, selector: candidate.selector, clickStart };
+    // A swallowed click failure must not read as a successful interaction, so
+    // record the outcome instead of dropping the error. Only a click that
+    // actually resolved lets the INP proxy report a value.
+    let clicked = false;
+    try {
+      await locator.click({ timeout: 5_000 });
+      clicked = true;
+    } catch (error) {
+      logStderr(`interaction probe: click on ${candidate.selector} failed (${errorText(error)})`);
+    }
+    return { target: candidate.label, selector: candidate.selector, clickStart, clicked };
   }
-  return { target: null, selector: null, clickStart: 0 };
+  return { target: null, selector: null, clickStart: null, clicked: false };
 }
 
 function attachNetworkCollectors(page) {
@@ -410,9 +508,14 @@ function attachNetworkCollectors(page) {
 }
 
 // Evaluated in the page. `clickStart` scopes the event-timing entries to the one
-// scripted interaction so the INP proxy is that interaction's worst event.
-function collectPageMetrics(clickStart) {
-  const store = window.__nteractProfile || { longTasks: [], events: [] };
+// scripted interaction so the INP proxy is that interaction's worst event, and
+// `clicked` gates whether an INP value is reportable at all.
+function collectPageMetrics({ clickStart, clicked }) {
+  const store = window.__nteractProfile || {
+    longTasks: [],
+    events: [],
+    longTaskObserverAttached: false,
+  };
 
   const marks = performance
     .getEntriesByType("mark")
@@ -438,16 +541,36 @@ function collectPageMetrics(clickStart) {
     paint[entry.name] = Math.round(entry.startTime);
   }
 
+  // Without a live observer the long-task array is empty for the wrong reason,
+  // so the TBT proxy is unavailable rather than a clean 0.
+  const longTaskObserverAttached = Boolean(store.longTaskObserverAttached);
   const longTasks = store.longTasks || [];
-  const longTaskTotalMs = Math.round(longTasks.reduce((sum, task) => sum + task.duration, 0));
-  const tbtProxyMs = Math.round(
-    longTasks.reduce((sum, task) => sum + Math.max(0, task.duration - 50), 0),
-  );
+  const longTaskTotalMs = longTaskObserverAttached
+    ? Math.round(longTasks.reduce((sum, task) => sum + task.duration, 0))
+    : null;
+  const tbtProxyMs = longTaskObserverAttached
+    ? Math.round(longTasks.reduce((sum, task) => sum + Math.max(0, task.duration - 50), 0))
+    : null;
 
-  const interactionEvents = (store.events || []).filter((entry) => entry.startTime >= clickStart);
-  const maxDurationMs = interactionEvents.length
+  // Report an INP proxy only when the scripted click verifiably landed and the
+  // event-timing API attributed entries to it (a non-zero interactionId). A
+  // clickStart of 0/null must not admit unrelated events, and no click means no
+  // value: unavailable, never a fabricated fallback.
+  const clickLanded = clicked === true && typeof clickStart === "number" && clickStart > 0;
+  const interactionEvents = clickLanded
+    ? (store.events || []).filter(
+        (entry) => entry.startTime >= clickStart && entry.interactionId !== 0,
+      )
+    : [];
+  const inpAvailable = clickLanded && interactionEvents.length > 0;
+  const maxDurationMs = inpAvailable
     ? Math.round(Math.max(...interactionEvents.map((entry) => entry.duration)))
     : null;
+  const inpUnavailableReason = inpAvailable
+    ? null
+    : clicked === true
+      ? "click landed but produced no correlated event-timing entries"
+      : "no interaction target was clicked";
 
   const jsResourceTimingBytes = performance
     .getEntriesByType("resource")
@@ -458,10 +581,19 @@ function collectPageMetrics(clickStart) {
     marks,
     navigationTiming,
     paint,
-    longTasks: { count: longTasks.length, totalMs: longTaskTotalMs, tbtProxyMs },
+    longTasks: {
+      observerAttached: longTaskObserverAttached,
+      count: longTasks.length,
+      totalMs: longTaskTotalMs,
+      tbtProxyMs,
+      unavailableReason: longTaskObserverAttached ? null : "longtask observer failed to attach",
+    },
     interaction: {
+      clicked: clicked === true,
+      available: inpAvailable,
       count: interactionEvents.length,
       maxDurationMs,
+      unavailableReason: inpUnavailableReason,
       sample: interactionEvents.slice(0, 8).map((entry) => ({
         name: entry.name,
         durationMs: Math.round(entry.duration),
@@ -504,7 +636,9 @@ async function createLoopbackNotebook(context, baseUrl, origin) {
       "Content-Type": "application/json",
       Origin: origin,
     },
-    data: { title: "profile-local reconnect probe" },
+    // The worker exposes no notebook-delete endpoint, so this probe outlives the
+    // run. The ISO-8601 prefix lets an operator find and sweep old probes by age.
+    data: { title: `${new Date().toISOString()} profile-local reconnect probe` },
   });
   if (response.status() !== 201) {
     throw new Error(`create notebook returned ${response.status()}: ${await response.text()}`);
@@ -557,8 +691,8 @@ function writeHumanTable(report) {
         pad(routePath, 15),
         pad(String(route.marks.length), 7),
         pad(numOrDash(route.navigationTiming?.domContentLoadedMs), 7),
-        pad(numOrDash(route.longTasks.tbtProxyMs), 7),
-        pad(numOrDash(route.interaction.inpProxyMs), 7),
+        pad(tbtCell(route.longTasks), 7),
+        pad(inpCell(route.interaction), 7),
         pad(kb(bestJsBytes(route.jsTransferBytes)), 8),
         pad(String(route.webSockets.length), 4),
         pad(renderTotal(route.renderCounts), 8),
@@ -572,7 +706,7 @@ function writeHumanTable(report) {
     lines.push(
       `  ws ${nb.reconnect.webSocketsBefore} -> ${nb.reconnect.webSocketsAfter}` +
         `  newWs=${nb.reconnect.openedNewWebSocket}  reloaded=${nb.reconnect.reloaded}` +
-        `  stable=${nb.reconnect.stable}`,
+        `  stable=${nb.reconnect.stable}  [${nb.reconnect.stable ? "PASS" : "FAIL"}]`,
     );
     if (nb.marks.length) {
       lines.push(
@@ -617,6 +751,17 @@ function rebaseUrl(value, origin) {
 
 function numOrDash(value) {
   return value === null || value === undefined ? "-" : String(value);
+}
+
+// TBT and INP cells distinguish "measured as 0" from "could not measure": an
+// unattached long-task observer or an interaction that never landed prints
+// "unavail" so a reader never mistakes an absent property for a clean zero.
+function tbtCell(longTasks) {
+  return longTasks.observerAttached ? numOrDash(longTasks.tbtProxyMs) : "unavail";
+}
+
+function inpCell(interaction) {
+  return interaction.inpAvailable ? numOrDash(interaction.inpProxyMs) : "unavail";
 }
 
 function kb(bytes) {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Profiler, Suspense, useState, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { BookOpen, House, Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -195,10 +195,37 @@ function ViewerStartupLoading({ title }: { title: string }) {
   );
 }
 
+/**
+ * Dev/profiling instrumentation, not a product surface. When the viewer URL
+ * carries `?profile=1`, wrap the root in a React `<Profiler>` that tallies
+ * commit counts on `window.__nteractRenderCounts` keyed by Profiler id, for the
+ * local profiling harness (`scripts/profile-local.mjs`) to read after settle.
+ * Invariant: absent the flag no Profiler mounts and the tree is returned
+ * unchanged, so production renders stay byte-for-byte identical and pay nothing.
+ */
+function withRenderProfiler(node: ReactNode): ReactNode {
+  if (new URLSearchParams(window.location.search).get("profile") !== "1") {
+    return node;
+  }
+  const counters = ((
+    window as unknown as { __nteractRenderCounts?: Record<string, number> }
+  ).__nteractRenderCounts ??= {});
+  return (
+    <Profiler
+      id="cloud-viewer-app"
+      onRender={(id) => {
+        counters[id] = (counters[id] ?? 0) + 1;
+      }}
+    >
+      {node}
+    </Profiler>
+  );
+}
+
 createRoot(requireElement("#root")).render(
   <ErrorBoundary
     fallback={(error) => <ViewerStartupError message={`Cloud viewer crashed: ${error.message}`} />}
   >
-    <App />
+    {withRenderProfiler(<App />)}
   </ErrorBoundary>,
 );

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -200,8 +200,9 @@ function ViewerStartupLoading({ title }: { title: string }) {
  * carries `?profile=1`, wrap the root in a React `<Profiler>` that tallies
  * commit counts on `window.__nteractRenderCounts` keyed by Profiler id, for the
  * local profiling harness (`scripts/profile-local.mjs`) to read after settle.
- * Invariant: absent the flag no Profiler mounts and the tree is returned
- * unchanged, so production renders stay byte-for-byte identical and pay nothing.
+ * Invariant: without the flag no Profiler mounts and nothing attaches to
+ * window; the tree is returned unchanged. The helper itself and its one
+ * URLSearchParams parse still ship in the normal bundle.
  */
 function withRenderProfiler(node: ReactNode): ReactNode {
   if (new URLSearchParams(window.location.search).get("profile") !== "1") {

--- a/apps/notebook-cloud/vite.config.ts
+++ b/apps/notebook-cloud/vite.config.ts
@@ -9,12 +9,20 @@ import { isolatedRendererPlugin } from "../notebook/vite-plugin-isolated-rendere
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appDir, "../..");
 
+// Profiling build only: swap the root renderer for react-dom/profiling so the
+// `?profile=1` <Profiler> hook's onRender actually fires. React makes Profiler
+// timing inert in the default production react-dom build, so the render-count
+// harness needs this variant. Gated on an env flag; unset, the shipped bundle
+// resolves react-dom/client and is byte-identical.
+const profileReactBuild = process.env.NOTEBOOK_CLOUD_PROFILE_REACT === "1";
+
 export default defineConfig({
   plugins: [react(), tailwindcss(), isolatedRendererPlugin()],
   resolve: {
     alias: {
       "@/": path.join(repoRoot, "src") + "/",
       "~/": path.join(repoRoot, "apps/notebook/src") + "/",
+      ...(profileReactBuild ? { "react-dom/client": "react-dom/profiling" } : {}),
     },
   },
   build: {

--- a/docs/measurements/store-refactor-bundle-and-timers.md
+++ b/docs/measurements/store-refactor-bundle-and-timers.md
@@ -88,10 +88,37 @@ rail registry poll had any tests before. The pairing poll and the standalone
 page poll shipped with zero coverage; both now sit behind `createPoll` inside
 stores with 29- and 20-test suites.
 
+## Measured locally (wrangler + Playwright)
+
+`pnpm --dir apps/notebook-cloud profile:local` (scripts/profile-local.mjs)
+drives local wrangler with Playwright: cold-route timing, long-task and
+event-timing proxies, WebSocket census, render commits via the `?profile=1`
+`<Profiler>` hook (needs `NOTEBOOK_CLOUD_PROFILE_REACT=1 build:viewer` - the
+default react-dom keeps `<Profiler>` inert), and a reconnect-stability check.
+
+Results on this machine (profiling build, 10s settle):
+
+- **Reconnect stability, the property the auth store must hold:** on a live
+  notebook room, two focus/visibility refresh cycles produced
+  `openedNewWebSocket=false, reloaded=false` - one socket before, one after.
+  The reference-held `appSession$` does its job in a real browser, not just
+  in virtual time.
+- Render commits after settle: `/n` 7, `/workstations` 7, notebook room 16.
+- Notebook-route marks: `viewer-start@~490ms`, `live-room-ready@~525`,
+  `live-initial-cells@~615`, `live-ready@~635` (fresh empty notebook, so the
+  live path fires rather than instant paint).
+- TBT proxy 0 (no >50ms long tasks during load+settle); INP proxy sits at the
+  Event Timing API's 16ms floor for the scripted interactions.
+
+Harness limits: wrangler dev serves uncompressed (byte figures there are raw,
+not gzip - use the bundle table above for payload comparisons); headless
+cannot truly background a tab, so the reconnect check drives synthetic
+focus/visibility events; instant-paint marks need a notebook with a persisted
+snapshot.
+
 ## Not measured here
 
-Runtime render counts (React Profiler), INP/TBT, and reconnect behavior under
-auth renewal need a live browser session against a hosted or wrangler-served
-build - the store suites cover the semantics in virtual time, but interactive
-timing needs the browser. Candidate harness: the hosted smoke scripts plus a
-profiler pass, or a nightly-gremlins run.
+Renewal-path behavior against a real OIDC issuer (token rotation ->
+`authState$` identity -> live-room key stability) still needs either a hosted
+session or a local dev issuer; the loopback-trust auth mode local wrangler
+uses does not exercise the OIDC refresh driver end to end.

--- a/docs/measurements/store-refactor-bundle-and-timers.md
+++ b/docs/measurements/store-refactor-bundle-and-timers.md
@@ -1,0 +1,97 @@
+# Store Refactor: Bundle and Timer Measurements
+
+**Status:** Measurement, 2026-07-06.
+
+Before/after evidence for the cloud viewer store refactor (#3906, #3909,
+#3910): what the RxJS store layer and the `/workstations` route split actually
+changed in shipped bytes and runtime timer load. BEFORE is `4b4ed8420` (the
+commit before #3906); AFTER is main at `0e05a4e86`. Both sides were built,
+not estimated.
+
+## Method
+
+```bash
+# AFTER: in place on main
+pnpm --dir apps/notebook-cloud build:viewer
+
+# BEFORE: disposable worktree
+git worktree add /tmp/nteract-before 4b4ed8420
+cd /tmp/nteract-before && pnpm install --frozen-lockfile
+CARGO_TARGET_DIR=$HOME/.cache/runt-agent-target \
+  cargo xtask artifacts ensure runtime,sift,renderer
+pnpm --dir apps/notebook-cloud build:viewer
+```
+
+Chunk sizes come from vite's rollup report. Route payloads are the static
+closure of each route's chunk graph, traced by grepping `from "./x.js"` /
+`import("./x.js")` specifiers out of the built files and walking the graph -
+this matches what a browser fetches on a cold visit but was not captured via a
+live network trace.
+
+## Bundle results
+
+| Metric | Before | After |
+|---|---|---|
+| Entry chunk `notebook-cloud-viewer.js` (raw) | 334.71 kB | 302.79 kB (-9.5%) |
+| Entry chunk (gzip) | 84.99 kB | 77.37 kB (-9.0%) |
+| Workstations code location | in the entry's static closure, every route (269.45 kB raw / 70.09 kB gzip incl. bundled icons) | two lazy chunks, `/workstations` only (55.90 kB raw / 14.35 kB gzip) |
+| Cold `/n` payload (JS+CSS, gzip) | 222.81 kB | 220.86 kB (-1.95 kB) |
+| Cold `/workstations` payload (gzip) | 222.81 kB | 235.97 kB (+13.16 kB) |
+| Chunks in `/n` load path | 10 | 12 |
+| notebook-route lazy chunk (gzip) | 255.67 kB | 251.94 kB (noise-level) |
+
+## Reading the numbers honestly
+
+The headline win is **scope isolation, not raw bytes**. The workstations
+surface (store + management page UI) no longer ships to notebook and dashboard
+visitors, and the code that moved is now 14.35 kB gzip instead of riding
+inside a 70 kB chunk on every route.
+
+The byte-level win on `/n` is small (-1.95 kB gzip) because vite's rechunking
+simultaneously hoisted a lucide-icons vendor chunk (`icons-*.js`, 273.28 kB
+raw / 70.35 kB gzip) into the entry's static closure - before, that weight
+lived inside the workstations chunk that every route loaded anyway, so the
+swap nets out. Cold `/workstations` is +13.16 kB gzip versus the old
+monolith: it now pays entry + icons + its two route chunks + several small
+split chunks.
+
+**Identified follow-up:** the always-loaded icons chunk is the single biggest
+lever left. The entry-graph views use a handful of icons; if the 70 kB gzip
+chunk is mostly workstations/notebook iconography that per-icon tree-shaking
+or chunk hints could keep out of the entry closure, `/n` cold load drops by
+tens of kB gzip. Needs its own investigation (why rollup groups these icons
+into one shared chunk) before any config change.
+
+## Timer and listener census
+
+Method: `git grep` at `4b4ed8420` vs the current checkout, non-test viewer
+code; runtime sets counted by reading the old hook bodies and the new
+`activate()` drivers.
+
+| Metric | Before | After |
+|---|---|---|
+| Wall-clock timer call sites (viewer, non-test) | 23 | 16 (+3 RxJS `timer()` in stores) |
+| Auth timer/listener installs per page | 7 (2 intervals + 5 DOM listeners), rebuilt on every view mount, duplicated in source across 4 views | 2 timers + 3 driver subscriptions in one `activate()`; 3 DOM listeners are app-lifetime shared singletons (`browser-signals.ts`) |
+| Chained-`setTimeout` poll loops | 3 (two of them independent hand-rolled copies of the same registry poll) | 0 |
+| `createPoll` call sites | 0 | 3 (one collapses the duplicate registry polls, one migrates the pairing poll, one is the new access-request poll) |
+| Dedicated store tests | 0 | 69 across 4 suites (virtual-time driver contracts) |
+
+Two honest notes. First, the views are separate routes, so only one mounted at
+a time: the per-page runtime cost before was 7 installs, not 7x4 - the x4 was
+source duplication (four hand-maintained copies of the same wiring), which is
+a maintenance win more than a runtime one. Second, the transport-layer timers
+(`live-sync.ts`, `runtimed-wasm-client.ts`, `sync-heal.ts` - 16 sites) are
+deliberately untouched; this refactor only claimed the view/hook layer.
+
+The coverage delta is the sharpest number: of the three poll loops, only the
+rail registry poll had any tests before. The pairing poll and the standalone
+page poll shipped with zero coverage; both now sit behind `createPoll` inside
+stores with 29- and 20-test suites.
+
+## Not measured here
+
+Runtime render counts (React Profiler), INP/TBT, and reconnect behavior under
+auth renewal need a live browser session against a hosted or wrangler-served
+build - the store suites cover the semantics in virtual time, but interactive
+timing needs the browser. Candidate harness: the hosted smoke scripts plus a
+profiler pass, or a nightly-gremlins run.


### PR DESCRIPTION
Docs-only closeout for the store refactor arc (#3906, #3909, #3910, #3911): the before/after measurements memo and a review-rubric extension.

## Measurements memo

`docs/measurements/store-refactor-bundle-and-timers.md` - both sides built at their real commits (worktree at `4b4ed8420` vs main), no estimates. The honest story:

- Scope isolation is real: the workstations surface left every route's payload, and what moved shrank from a 70 kB gzip always-loaded chunk to 14 kB gzip route-local.
- The raw byte win on `/n` is small (-2 kB gzip) because vite's rechunking hoisted a 70 kB gzip lucide-icons chunk into the entry closure, and cold `/workstations` is +13 kB gzip vs the old monolith. The icons chunk is named as the next optimization lever, investigation before config.
- Timer census: 7 per-mount auth timer/listener installs, hand-duplicated in source across 4 views, collapse to one per-page driver set over 3 shared app-lifetime listeners; 3 hand-rolled poll loops become 3 `createPoll` sites; store test coverage goes 0 to 69, over surface where two of three poll loops previously had zero tests.
- Browser-side profiling (INP, render counts, reconnect behavior) is explicitly listed as not-measured-here with the candidate harness.

## Rubric extension

The review rubric's comment lens named history narration but not its mirror: speculative future-consumer claims. A month-old module header claiming the MCP surface consumes the TS store streams (it is Rust by design) survived every doctrine pass this week because no rule named speculation and cross-subsystem claims cannot be falsified from inside the module. The rubric now flags both, and carried-forward prose in a touched header is explicitly in scope.
