### PR TITLE
docs(agents): align stale-write guard terminology on activation epoch

### DIFF
--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -193,7 +193,7 @@ Use this subsection when editing RxJS or shared-store code such as
   ticks and keeps Desktop and Cloud behavior converged.
 - For async materialization or blob/output resolution, preserve ordering with
   `concatMap` or an explicit queue. After every `await`, check that the live
-  handle/session/auth/endpoint or activation generation still matches before
+  handle/session/auth/endpoint or activation epoch still matches before
   writing stores.
 - Reset paths must invalidate stale async writes, not just clear visible state.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ not a second source of truth. Keep RxJS sources private, expose readonly
 observables or named domain hooks, and test timers/cancellation with virtual
 time. Any async path that writes into a store after `await` must prove the
 current handle/session/auth/endpoint still matches or carry an activation
-generation that invalidates stale completions.
+epoch that invalidates stale completions.
 
 ## MCP servers
 


### PR DESCRIPTION
Follow-up to #3908 per its review thread: the guidance said "activation generation" in two places where the codebase (`activationEpoch`) and Decision 8 say epoch. Two-word fix so the vocabulary greps.