### PR TITLE
fix(notebook-cloud): dedup concurrent startPairing (workstation double-submit)

### DIFF
--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -593,6 +593,117 @@ describe("CloudWorkstationsStore pairing", () => {
     dispose();
   });
 
+  it("drops a concurrent startPairing so a double-click mints one code", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    let mintCalls = 0;
+    let resolveMint: (value: { id: string; code: string; expiresAt: string }) => void = () => {};
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        mintPairing: () => {
+          mintCalls += 1;
+          return new Promise((resolve) => {
+            resolveMint = resolve;
+          });
+        },
+      }),
+    );
+    await drainMicrotasks();
+
+    // Two rapid clicks before the first mint resolves: the second is dropped.
+    const first = store.startPairing();
+    const second = store.startPairing();
+    assert.equal(mintCalls, 1);
+
+    resolveMint({ id: "pair-1", code: "ABCD-EFGH", expiresAt: new Date(600_000).toISOString() });
+    await Promise.all([first, second]);
+    await drainMicrotasks();
+    assert.equal(mintCalls, 1);
+    assert.equal(store.snapshot.pairing?.code, "ABCD-EFGH");
+
+    // The guard clears on settle: a later click mints again.
+    const third = store.startPairing();
+    assert.equal(mintCalls, 2);
+    resolveMint({ id: "pair-2", code: "WXYZ-1234", expiresAt: new Date(600_000).toISOString() });
+    await third;
+    await drainMicrotasks();
+    assert.equal(store.snapshot.pairing?.code, "WXYZ-1234");
+
+    dispose();
+  });
+
+  it("clears the pairing guard on a mint rejection so the next click mints", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    let mintCalls = 0;
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        mintPairing: async () => {
+          mintCalls += 1;
+          if (mintCalls === 1) {
+            throw new Error("mint rejected");
+          }
+          return { id: "pair-2", code: "WXYZ-1234", expiresAt: new Date(600_000).toISOString() };
+        },
+      }),
+    );
+    await drainMicrotasks();
+
+    await store.startPairing();
+    assert.equal(store.snapshot.pairing?.status, "expired");
+
+    // The catch path must clear the guard, so a retry mints again.
+    await store.startPairing();
+    assert.equal(mintCalls, 2);
+    assert.equal(store.snapshot.pairing?.code, "WXYZ-1234");
+
+    dispose();
+  });
+
+  it("does not let a mint in flight across dispose/re-activate block a fresh mint", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const mintCalls: Array<{ resolve: (value: MintedCloudWorkstationPairing) => void }> = [];
+    const deps = baseDeps({
+      mintPairing: () =>
+        new Promise<MintedCloudWorkstationPairing>((resolve) => {
+          mintCalls.push({ resolve });
+        }),
+    });
+    const dispose = store.activate(inputs$, deps);
+    await drainMicrotasks();
+
+    // A mint is in flight (its latch holds the first activation's epoch)...
+    void store.startPairing();
+    await drainMicrotasks();
+    assert.equal(mintCalls.length, 1);
+    dispose();
+
+    // ...the route re-activates while that mint is still pending. The stale latch
+    // must not block the new mount's first pairing.
+    const reDispose = store.activate(inputs$, deps);
+    await drainMicrotasks();
+    void store.startPairing();
+    await drainMicrotasks();
+    assert.equal(mintCalls.length, 2);
+
+    // The old mint completing must not clear the new mint's latch: a concurrent
+    // click under the new mount is still dropped.
+    mintCalls[0].resolve({
+      id: "old",
+      code: "OLD-CODE",
+      expiresAt: new Date(600_000).toISOString(),
+    });
+    await drainMicrotasks();
+    void store.startPairing();
+    await drainMicrotasks();
+    assert.equal(mintCalls.length, 2);
+
+    reDispose();
+  });
+
   it("shows a mint failure as an expired pairing that never polls", async () => {
     const scheduler = newScheduler();
     const store = new CloudWorkstationsStore();

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -372,6 +372,19 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
    * paths' `RegistryTick`/`PairingStatusTick` auth tag.
    */
   private activationEpoch = 0;
+  /**
+   * Activation epoch of the in-flight pairing mint, or null when none is pending.
+   * Unlike `attach`/`setDefault`, which set a mutation state synchronously (so the
+   * UI disables their control during the request), `startPairing` writes no state
+   * until the mint resolves, so nothing stops a second click from minting a
+   * second, orphaned pairing code. Latching the epoch gives the action
+   * `exhaustMap` semantics for concurrent calls under one mount, while staying
+   * lifecycle-owned: dispose / re-activate / the signed-out gate all bump the
+   * epoch (like the `captureMutationIssue` guard), so a mint left in flight across
+   * that boundary neither blocks a fresh mint nor lets its late completion clear a
+   * newer mint's latch.
+   */
+  private pairingMintEpoch: number | null = null;
   /** Ordered refetch action stream; each carries a settle callback. */
   private readonly refetchRequests$ = new Subject<() => void>();
 
@@ -574,6 +587,11 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     if (!inputs || !deps || !inputs.workstationsEndpoint) {
       return;
     }
+    if (this.pairingMintEpoch === this.activationEpoch) {
+      return;
+    }
+    const mintEpoch = this.activationEpoch;
+    this.pairingMintEpoch = mintEpoch;
     const endpoint = inputs.workstationsEndpoint;
     const issue = this.captureMutationIssue(inputs.auth, endpoint);
     try {
@@ -613,6 +631,12 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
           error: errorMessage(error),
         },
       }));
+    } finally {
+      // Clear only if this call still owns the latch. A mint whose epoch was
+      // superseded by a dispose/re-activate must not clear a newer mint's latch.
+      if (this.pairingMintEpoch === mintEpoch) {
+        this.pairingMintEpoch = null;
+      }
     }
   }
 


### PR DESCRIPTION
A rapid double-click on the workstations "Add workstation" button minted two pairing codes: it fired two `POST /api/workstations/pairing-codes`, both returning 201, leaving the second code orphaned server-side until it expired.

## Root cause

`CloudWorkstationsStore.startPairing()` had no in-flight guard. Its sibling mutations `attach` and `setDefault` set a mutation state synchronously (`setMutation`) before their request, so the UI disables the triggering control while the request is outstanding. `startPairing` writes no state until the mint resolves, so nothing stopped a second concurrent call from minting again. The existing `captureMutationIssue`/`mutationStillCurrent` guard on the action handles a stale result (auth or endpoint changed during the await), not a concurrent duplicate.

## Fix

Latch the in-flight mint's activation epoch so the action gets `exhaustMap` semantics: while a mint is outstanding, a concurrent call under the same mount is dropped. The latch is lifecycle-owned, the same way the existing `captureMutationIssue` guard is. `dispose` / re-activate / the signed-out gate all bump `activationEpoch`, so a mint left in flight across one of those boundaries neither blocks a fresh mint on the new mount nor lets its late completion clear the newer mint's latch (the `finally` clears only if this call still owns the epoch). A plain boolean would wedge the button until a stale, possibly hung POST settled.

## Coverage

Store tests: two concurrent calls mint once and the latch clears on settle; a mint rejection clears the latch so a retry mints; a mint in flight across dispose/re-activate does not block the new mount's first mint, and the old completion does not clear the new latch.

Found by browser QA of the store refactor.
