### PR TITLE
perf(notebook-cloud): defer non-auth stores off the /n cold-load path

### DIFF
--- a/apps/notebook-cloud/viewer/__tests__/cloud-stores-context.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/cloud-stores-context.test.tsx
@@ -3,7 +3,8 @@ import { createElement, type ReactNode } from "react";
 import { describe, expect, it } from "vite-plus/test";
 
 import { cloudAccessRequestStore, CloudAccessRequestStore } from "../cloud-access-request-store";
-import { cloudAuthStore } from "../cloud-auth-store";
+import { CloudAuthStoreProvider, useCloudAuthStore } from "../cloud-auth-context";
+import { CloudAuthStore, cloudAuthStore } from "../cloud-auth-store";
 import { cloudCatalogStore } from "../cloud-catalog-store";
 import { CloudStoresProvider, type CloudStores } from "../cloud-stores-context";
 import { cloudWorkstationsStore } from "../cloud-workstations-store";
@@ -20,7 +21,6 @@ describe("CloudStoresProvider", () => {
 
     const fixtureAccessRequest = new CloudAccessRequestStore({ readSelectedMode: () => "edit" });
     const fixtureStores: CloudStores = {
-      auth: cloudAuthStore,
       accessRequest: fixtureAccessRequest,
       catalog: cloudCatalogStore,
       workstations: cloudWorkstationsStore,
@@ -40,5 +40,34 @@ describe("CloudStoresProvider", () => {
 
     expect(result.current).toBe("view");
     expect(result.current).toBe(cloudAccessRequestStore.selectedModeSnapshot);
+  });
+});
+
+describe("CloudAuthStoreProvider", () => {
+  it("routes auth consumers to the provider's store instance", () => {
+    const fixtureAuth = new CloudAuthStore({
+      readAuthState: () => ({
+        mode: "dev",
+        token: "fixture-token",
+        user: "Fixture User",
+        oidcClaims: null,
+        requestedScope: "viewer",
+        problem: null,
+      }),
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(CloudAuthStoreProvider, { store: fixtureAuth, children });
+
+    const { result } = renderHook(() => useCloudAuthStore(), { wrapper });
+
+    expect(result.current).toBe(fixtureAuth);
+    expect(result.current.authSnapshot.user).toBe("Fixture User");
+    expect(result.current).not.toBe(cloudAuthStore);
+  });
+
+  it("falls back to the singleton auth store with no provider", () => {
+    const { result } = renderHook(() => useCloudAuthStore());
+
+    expect(result.current).toBe(cloudAuthStore);
   });
 });

--- a/apps/notebook-cloud/viewer/cloud-auth-context.ts
+++ b/apps/notebook-cloud/viewer/cloud-auth-context.ts
@@ -1,0 +1,46 @@
+/**
+ * Consumption seam for the cloud viewer auth source store.
+ *
+ * Auth stays a module singleton - that is the boot and instant-paint reality,
+ * not something this seam changes. `cloud-auth-store.ts` MUST live at module
+ * scope because `instant-paint.ts` reads `authSnapshot` synchronously before
+ * React mounts, and the auth driver activates once at viewer boot, outside any
+ * React subtree. The three non-auth source stores live in the lazy
+ * `cloud-stores-context.ts` seam.
+ *
+ * This context overrides CONSUMPTION, never activation. The context defaults to
+ * the singleton, so a viewer with no provider resolves every auth consumer to
+ * the same singleton the boot driver activated - no provider is mounted on any
+ * production path. A test, an Elements fixture, or a future embedded viewer can
+ * mount `CloudAuthStoreProvider` with its own store instance and every auth
+ * consumer downstream reads it instead. The override's owner activates its own
+ * instance (calls `activate`); the provider swaps which store is read, not which
+ * store is driven.
+ */
+
+import { createContext, createElement, useContext, type ReactElement, type ReactNode } from "react";
+import { cloudAuthStore, type CloudAuthStore } from "./cloud-auth-store";
+
+/** The cloud viewer auth source store a subtree consumes. */
+const CloudAuthStoreContext = createContext<CloudAuthStore>(cloudAuthStore);
+
+export interface CloudAuthStoreProviderProps {
+  store: CloudAuthStore;
+  children: ReactNode;
+}
+
+/**
+ * Override the auth store a subtree consumes. Production mounts none of these;
+ * the owner that supplies `store` is responsible for activating that instance.
+ */
+export function CloudAuthStoreProvider({
+  store,
+  children,
+}: CloudAuthStoreProviderProps): ReactElement {
+  return createElement(CloudAuthStoreContext.Provider, { value: store }, children);
+}
+
+/** The auth store the current subtree consumes; the singleton by default. */
+export function useCloudAuthStore(): CloudAuthStore {
+  return useContext(CloudAuthStoreContext);
+}

--- a/apps/notebook-cloud/viewer/cloud-stores-context.ts
+++ b/apps/notebook-cloud/viewer/cloud-stores-context.ts
@@ -1,20 +1,19 @@
 /**
- * Consumption seam for the four cloud viewer source stores (auth,
- * access-request, catalog, workstations).
+ * Lazy consumption seam for the three non-auth cloud viewer source stores
+ * (access-request, catalog, workstations).
  *
- * The stores stay module singletons - that is the boot and instant-paint
- * reality, not something this seam changes. `cloud-auth-store.ts` MUST live at
- * module scope because `instant-paint.ts` reads `authSnapshot` synchronously
- * before React mounts, and every store's drivers activate once at viewer boot,
- * outside any React subtree. Decision 8 (`docs/adr/frontend-sync-bridge.md`)
- * records why.
+ * These stores stay module singletons; their route-level controllers activate
+ * the instances they consume, not this seam. Auth has its own always-loaded
+ * context because `instant-paint.ts` reads `authSnapshot` synchronously before
+ * React mounts and the auth driver activates once at viewer boot. Decision 8
+ * (`docs/adr/frontend-sync-bridge.md`) records why.
  *
- * What this adds is an override of CONSUMPTION, never of activation. The context
- * defaults to the singleton bundle, so a viewer with no provider resolves every
- * domain hook to the same singletons the drivers booted - no provider is mounted
- * on any production path and behavior stays byte-identical. A test, an Elements
- * fixture, or a future embedded viewer can mount `CloudStoresProvider` with its
- * own store instances and every domain hook downstream reads them instead. The
+ * This context overrides CONSUMPTION, never activation. The context defaults to
+ * the singleton bundle, so a viewer with no provider resolves every non-auth
+ * domain hook to the same singletons the route controllers activate - no
+ * provider is mounted on any production path. A test, an Elements fixture, or a
+ * future embedded viewer can mount `CloudStoresProvider` with its own store
+ * instances and every non-auth domain hook downstream reads them instead. The
  * override's owner activates its own instances (calls `activate`/`seedFromSsr`);
  * the provider swaps which stores are read, not which stores are driven.
  */
@@ -24,13 +23,11 @@ import {
   cloudAccessRequestStore,
   type CloudAccessRequestStore,
 } from "./cloud-access-request-store";
-import { cloudAuthStore, type CloudAuthStore } from "./cloud-auth-store";
 import { cloudCatalogStore, type CloudCatalogStore } from "./cloud-catalog-store";
 import { cloudWorkstationsStore, type CloudWorkstationsStore } from "./cloud-workstations-store";
 
-/** The four cloud viewer source stores a subtree consumes. */
+/** The three non-auth cloud viewer source stores a subtree consumes. */
 export interface CloudStores {
-  auth: CloudAuthStore;
   accessRequest: CloudAccessRequestStore;
   catalog: CloudCatalogStore;
   workstations: CloudWorkstationsStore;
@@ -38,10 +35,9 @@ export interface CloudStores {
 
 /**
  * The module singletons, bundled. This is the context default, so a subtree with
- * no provider consumes exactly the instances the boot drivers activate.
+ * no provider consumes exactly the instances the route controllers activate.
  */
 const singletonCloudStores: CloudStores = {
-  auth: cloudAuthStore,
   accessRequest: cloudAccessRequestStore,
   catalog: cloudCatalogStore,
   workstations: cloudWorkstationsStore,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -38,7 +38,7 @@ import {
   type CloudPrototypeAuthState,
   type CloudSyncAuth,
 } from "./collaborator-auth";
-import { useCloudStores } from "./cloud-stores-context";
+import { useCloudAuthStore } from "./cloud-auth-context";
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudLivePresenceStore } from "./live-presence";
 import {
@@ -229,12 +229,13 @@ export function useCloudViewerSession({
   widgetStore,
 }: UseCloudViewerSessionOptions): CloudViewerSession {
   // Auth snapshot reads below (connection diagnostics, the instant-paint
-  // principal gate, the sync-auth fallback) resolve through this context bundle
-  // so a CloudStoresProvider override drives the same store this hook reads. The
-  // context default is the singleton, a stable reference, so the `auth` entries
-  // added to the effect deps below cannot retrigger a connect in production;
-  // each read still takes the latest snapshot at read time.
-  const { auth } = useCloudStores();
+  // principal gate, the sync-auth fallback) resolve through the auth context so
+  // a CloudAuthStoreProvider override routes this hook to the same store its
+  // owner activates. The context default is the singleton, a stable reference,
+  // so the `auth` entries added to the effect deps below cannot retrigger a
+  // connect in production; each read still takes the latest snapshot at read
+  // time.
+  const auth = useCloudAuthStore();
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
     message: loadingPolicy.initialStatusMessage,

--- a/apps/notebook-cloud/viewer/home-view.tsx
+++ b/apps/notebook-cloud/viewer/home-view.tsx
@@ -14,13 +14,13 @@ import { cloudNotebookSignInLabel, resolveCloudSignInMethod } from "./cloud-auth
 import { clearCloudPrototypeDevAuth, prepareCloudOidcViewerLogin } from "./collaborator-auth";
 import { beginOidcLogin } from "./oidc-auth";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
-import { useCloudStores } from "./cloud-stores-context";
+import { useCloudAuthStore } from "./cloud-auth-context";
 import { useCloudAppSession, useCloudAuthRenewal, useCloudAuthState } from "./use-cloud-auth-store";
 import type { CloudViewerAuthConfig } from "./cloud-viewer-types";
 
 export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   const appSessionStatus = useCloudAppSession();
   const authState = useCloudAuthState();
   const authRenewal = useCloudAuthRenewal();

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -38,7 +38,7 @@ import {
   useCloudAuthState,
   useHostedCatalogAuth,
 } from "./use-cloud-auth-store";
-import { useCloudStores } from "./cloud-stores-context";
+import { useCloudAuthStore } from "./cloud-auth-context";
 import { loadCloudNotebookListBootstrap } from "./cloud-viewer-config";
 import type { CloudAppSession } from "./app-session";
 import type {
@@ -66,7 +66,7 @@ import { preloadNotebookRoute } from "./notebook-route-preload";
 
 export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   const [bootstrap, setBootstrap] = useState<CloudNotebookListBootstrap | null>(() =>
     loadCloudNotebookListBootstrap(),
   );

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -167,6 +167,7 @@ import type {
   CloudViewerAuthConfig,
   ViewerRuntime,
 } from "./cloud-viewer-types";
+import { useCloudAuthStore } from "./cloud-auth-context";
 import { useCloudStores } from "./cloud-stores-context";
 import {
   useBrowserApiAuthState,
@@ -242,10 +243,11 @@ export function NotebookViewer({
   authConfig: CloudViewerAuthConfig;
 }) {
   const { config } = runtime;
-  // Store actions and snapshot reads below resolve through this context bundle
-  // (the singletons by default) so a CloudStoresProvider override drives the
-  // same instances this component reads and mutates.
-  const { auth, accessRequest, catalog } = useCloudStores();
+  // Store actions and snapshot reads below resolve through their consumption
+  // contexts (the singletons by default) so provider overrides route this
+  // component to the same instances it reads and mutates.
+  const auth = useCloudAuthStore();
+  const { accessRequest, catalog } = useCloudStores();
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
   const [notebookTitleSaving, setNotebookTitleSaving] = useState(false);
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);

--- a/apps/notebook-cloud/viewer/use-cloud-auth-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-auth-store.ts
@@ -9,12 +9,12 @@
  * `auth.activate`), so each hook binds a store-owned projection through the
  * shared `useObservableProjection`. The projections are stable per store
  * instance, so the binding cache stays hot across renders. The store instance
- * comes from `useCloudStores()`, which is the singleton by default and an
- * override under `CloudStoresProvider`.
+ * comes from `useCloudAuthStore()`, which is the singleton by default and an
+ * override under `CloudAuthStoreProvider`.
  */
 
 import { useObservableProjection } from "@/components/notebook/state/observable-binding";
-import { useCloudStores } from "./cloud-stores-context";
+import { useCloudAuthStore } from "./cloud-auth-context";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import type { HostedCatalogAuthProjection } from "./hosted-catalog-auth";
 import type { CloudAuthRenewalState } from "./notice-types";
@@ -22,36 +22,36 @@ import type { CloudAppSessionViewState } from "./use-cloud-auth";
 
 /** Deduped prototype auth state (mode/token/user/scope/oidc subject). */
 export function useCloudAuthState(): CloudPrototypeAuthState {
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   return useObservableProjection(auth.authState$);
 }
 
 /** Full app-session view (status/session/error), reference-stable session. */
 export function useCloudAppSession(): CloudAppSessionViewState {
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   return useObservableProjection(auth.appSessionView$);
 }
 
 /** OIDC renewal notice. */
 export function useCloudAuthRenewal(): CloudAuthRenewalState {
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   return useObservableProjection(auth.renewal$);
 }
 
 /** Stable auth object for host-owned browser API and blob fetches. */
 export function useBrowserApiAuthState(): CloudPrototypeAuthState {
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   return useObservableProjection(auth.browserApiAuthState$);
 }
 
 /** Stable connection key for the live-room reconnect dependency. */
 export function useCloudSyncAuthConnectionKey(): string {
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   return useObservableProjection(auth.syncAuthConnectionKey$);
 }
 
 /** Hosted catalog auth projection for the current auth/app-session state. */
 export function useHostedCatalogAuth(): HostedCatalogAuthProjection {
-  const { auth } = useCloudStores();
+  const auth = useCloudAuthStore();
   return useObservableProjection(auth.hostedAuth$);
 }

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -269,23 +269,30 @@ The module singletons are the boot and instant-paint reality: the drivers
 activate them once at viewer boot, and `instant-paint.ts` reads `authSnapshot`
 before React mounts. Neither can go through a React provider, so the singletons
 stay. What the hook layer adds is a consumption override, not an activation
-override: `cloud-stores-context.ts` creates a context whose default value is the
-singleton bundle, and every domain hook reads its store from `useCloudStores()`.
-No provider is mounted on any production path, so production resolves to the
+override: `cloud-auth-context.ts` creates the always-loaded auth context whose
+default value is `cloudAuthStore`, while `cloud-stores-context.ts` creates the
+lazy context whose default value is the three non-auth store singleton bundle.
+Auth domain hooks and boot-critical snapshot readers use `useCloudAuthStore()`;
+access-request, catalog, and workstations hooks use `useCloudStores()`. No
+provider is mounted on any production path, so production resolves to the
 singletons and behavior is byte-identical. A test, an Elements fixture, or a
-future embedded viewer mounts `CloudStoresProvider` with its own instances and
+future embedded viewer mounts the matching provider with its own instances and
 the subtree's hooks read those instead; that override's owner activates its own
 instances, because the provider swaps which stores are consumed, not which
 stores are driven. Context is a consumption override with a singleton default,
-never a requirement: the default keeps `useCloudStores()` provider-free, and the
+never a requirement: the default keeps the hooks provider-free, and the
 singleton keeps owning boot and instant paint.
 
 Boot-path discipline follows from the same split: only the auth store may be
 module-evaluated on the entry chunk (its synchronous seed is what instant paint
-reads). Every other store rides its route's chunk - the workstations surface
-loads with the lazy `/workstations` route, not with the notebook or dashboard
-entry. A new store landing in the entry chunk needs an instant-paint-grade
-reason recorded here.
+reads). The three non-auth stores stay behind `cloud-stores-context.ts`, which
+is imported only by lazy route chunks, keeping those store modules out of the
+`/n` cold-load static closure (a measured 8.6 kB gzip off the shared icons chunk,
+69.4 -> 60.8 kB).
+Every other store rides its route's chunk - the workstations surface loads with
+the lazy `/workstations` route, not with the notebook or dashboard entry. A new
+store landing in the entry chunk needs an instant-paint-grade reason recorded
+here.
 
 ### The convention layer stays a convention layer
 


### PR DESCRIPTION
The `/n` cold load statically pulled all four cloud viewer source stores because `cloud-stores-context.ts` built its default bundle from all four store modules, while every always-loaded consumer of that context reads only `auth`. The three non-auth stores (access-request, catalog, workstations) are consumed only in lazy route chunks, so their code rode the cold-load static closure for nothing.

## Change

Split the consumption seam. Auth gets its own always-loaded context, `cloud-auth-context.ts` (`useCloudAuthStore`); the three non-auth stores stay in `cloud-stores-context.ts` (`useCloudStores`), which is now imported only by the lazy notebook and workstations route chunks. Auth must stay static: `instant-paint.ts` reads its snapshot synchronously before React mounts and the auth driver activates at viewer boot.

This is a consumption-wiring change, never an activation change. Production mounts no provider, so it resolves to the same module singletons and behavior is byte-identical. The provider-override seam (tests, Elements, a future embedded viewer) is preserved as two providers, `CloudAuthStoreProvider` and `CloudStoresProvider`.

## Measured

The shared always-loaded chunk drops **69.4 -> 60.8 kB gzip (8.6 kB)** off the `/n` cold load; the entry chunk is unchanged. The non-auth store modules move to their lazy route chunks (workstations to its own chunk, catalog and access-request into the notebook route). An earlier estimate of ~13 kB was optimistic: the shared runtime deps (RxJS, sync-engine, projections) stay because the always-loaded auth and dashboard code uses them too. Only the store-specific code leaves.

`docs/adr/frontend-sync-bridge.md` Decision 8 records the split and the measured number.

## Gate

Typecheck, full notebook-cloud suite (1284 node:test + 46 viewer vitest, including the updated provider test), and lint - all green.
