### PR TITLE
docs: cloud viewer measurements currency + instant-paint validity memo

### DIFF
--- a/docs/measurements/store-refactor-bundle-and-timers.md
+++ b/docs/measurements/store-refactor-bundle-and-timers.md
@@ -66,12 +66,18 @@ per-icon tree-shaking or chunk hints would not move first-load bytes. An earlier
 draft of this memo called this "the always-loaded icons chunk, the single
 biggest lever left"; that was reading the chunk's name, not its contents.
 
-**Identified follow-up:** the 70 kB gzip always-loaded chunk is real and worth
-attacking, but the lever is what pulls RxJS, the `runtimed` store/projection
-code, and the cloud dashboard stores into the entry's static closure
-(`apps/notebook-cloud/viewer/index.tsx`, `notebook-dashboard.ts`), not icon
-import style. Deferring route-specific store/projection code out of the
-first-load closure is the real `/n` cold-load win.
+**Follow-up, first cut landed (#3918):** the 70 kB gzip always-loaded chunk is
+real, and the lever is what pulls RxJS, the `runtimed` store/projection code, and
+the cloud dashboard stores into the entry's static closure
+(`apps/notebook-cloud/viewer/index.tsx`, `notebook-dashboard.ts`), not icon import
+style. PR #3918 took the first cut: it split the store-consumption seam so the
+three non-auth source stores (access-request, catalog, workstations) load with
+their lazy routes instead of the `/n` cold path. Measured 8.6 kB gzip off the
+shared always-loaded chunk (69.4 -> 60.8 kB); the entry chunk is unchanged. An
+earlier ~13 kB estimate was optimistic - the shared runtime deps stay because the
+always-loaded auth and dashboard code uses them too, so only the store-specific
+code leaves. Deferring more route-specific store/projection code out of the
+first-load closure is the remaining lever.
 
 ## Timer and listener census
 
@@ -127,9 +133,13 @@ cannot truly background a tab, so the reconnect check drives synthetic
 focus/visibility events; instant-paint marks need a notebook with a persisted
 snapshot.
 
-## Not measured here
+## Renewal path
 
 Renewal-path behavior against a real OIDC issuer (token rotation ->
-`authState$` identity -> live-room key stability) still needs either a hosted
-session or a local dev issuer; the loopback-trust auth mode local wrangler
-uses does not exercise the OIDC refresh driver end to end.
+`authState$` identity -> live-room key stability) is now exercised end to end by
+the dev OIDC issuer (`@nteract/local-oidc`, #3914), which the local wrangler
+mounts; the loopback-trust auth mode alone does not drive the OIDC refresh
+driver. The `profile-local.mjs` renewal probe measures it, and holds green only
+when a real app-session was established, a live room socket existed before
+rotation, the token actually rotated, and the post-rotation reconnect stayed
+stable - a vacuous 0-to-0-socket pass no longer counts.

--- a/docs/memos/instant-paint-validity-ssr.md
+++ b/docs/memos/instant-paint-validity-ssr.md
@@ -1,0 +1,70 @@
+# Instant-paint validity and the SSR opening from first-party sessions
+
+Status: memo. Captures a production concern in the cloud viewer's optimistic
+early render and the server-bootstrap opening the app-session cookie now creates.
+
+## The concern: early paint keys on session presence, not validity
+
+`cloudInstantPaintPrincipalMatcher` (`apps/notebook-cloud/viewer/instant-paint.ts`)
+renders persisted notebook content before the room handshake, deriving a principal
+matcher from locally stored auth material. For OIDC its gate is:
+
+```
+oidc_expired && hasAppSession === true
+```
+
+That is a check on the app-session cookie's presence, not on the refresh token
+still being valid. The cookie sits in the browser until something actively tries
+to refresh it and fails. So a session whose refresh token was revoked or expired
+server-side still reads `hasAppSession === true`, and the viewer paints the user's
+last-known content in the window before the app-session refresh fires, fails, and
+gates them.
+
+The matcher's documented backstops - the post-handshake principal guard, live
+materialization replacing the paint, an authoritative empty room displacing it -
+all defend against a *wrong-principal* (cross-user) paint. None of them addresses
+a *present-but-dead* session. The painted content is the user's own sub-matched
+local data, so this is not a cross-user leak. The sharp edge is a user whose
+access was revoked, or whose refresh is dead, seeing their last-known content for
+a beat before the handshake catches up. That is a "gate on validity, not
+presence" problem, the same family as the reconnect stale-write guards: presence
+of a token or cookie is not proof the session is live.
+
+## Why it exists: the viewer renders client-side
+
+The heuristic is a workaround for client-only rendering. Browser auth is
+localStorage-based, so on first navigation the Worker cannot server-render
+authenticated HTML - it ships a shell and the client optimistically reconstructs
+what it can from local material. Instant paint is that optimism. Its validity gap
+is inherent to assuming early on the client instead of confirming on the server.
+
+## The opening: first-party sessions make server bootstrap reachable
+
+The OIDC work added a first-party app-session cookie. That is precisely the layer
+that makes server bootstrap of app-owned routes viable: the Worker can read the
+app-session on the first request, confirm it against the session store, and hand
+back correct content (or a clean gate) for app-shell routes like `/n`. The room
+WebSocket credentials stay explicit/ticketed and output frames stay on the
+isolated origin, per the existing host-shell boundaries - only the app-owned
+shell HTML moves server-side.
+
+Server-rendering (or server-bootstrapping) the app shell would dissolve the
+present-vs-valid gap for those routes in one move: the server gates on a validated
+session, so there is no client window that paints ahead of validity. Instant paint
+would remain the mechanism for the live notebook room (which is inherently a
+client handshake), but the dashboard and other app-owned surfaces would not need
+to guess.
+
+## Open questions
+
+- Scope: which routes are app-owned enough to server-bootstrap (`/n`, sharing,
+  home) versus inherently client-handshake (the live room)?
+- Interim: is a client-side validity gate on the early paint (probe app-session
+  freshness before trusting `hasAppSession`) worth doing before any SSR work, or
+  does it add a request on the hot path for a case the handshake already backstops?
+- Cost: server bootstrap needs the Worker to render or hydrate the shell with
+  session-validated data; how much of the current client bootstrap
+  (`loadCloudNotebookListBootstrap`) already models this and could move server-side?
+
+Not a decision. A pointer at where the real production correctness lever is, and
+why the app-session cookie changed what is reachable.


### PR DESCRIPTION
Two docs updates from the store-refactor QA and perf work.

## Measurements memo currency

`docs/measurements/store-refactor-bundle-and-timers.md`:

- The store/runtime-code follow-up is acted on. PR #3918 split the store-consumption seam so the three non-auth source stores load with their lazy routes instead of the `/n` cold path - a measured 8.6 kB gzip off the shared always-loaded chunk (69.4 -> 60.8 kB). Corrected the earlier ~13 kB estimate: the shared runtime deps stay because the always-loaded auth and dashboard code uses them too, so only the store-specific code leaves.
- The renewal path is measured now, not a gap. The dev OIDC issuer (#3914) exercises the refresh driver end to end through local wrangler; the `profile-local.mjs` renewal probe holds green only on a real app-session, a live pre-rotation room socket, an actual token rotation, and a stable post-rotation reconnect - a vacuous 0-to-0-socket pass no longer counts.

## New memo: instant-paint validity and the SSR opening

`docs/memos/instant-paint-validity-ssr.md` captures a production concern surfaced while working the auth path:

- Instant-paint's early render keys on the app-session cookie's presence, not on refresh-token validity, so a present-but-dead session can paint cached content in the window before the refresh-fail gate. The matcher's documented backstops cover a wrong-principal paint, not a present-but-dead one.
- The app-session cookie the OIDC work added is the first-party session layer that makes server bootstrap of app-owned routes like `/n` reachable, which would dissolve the present-vs-valid gap for those routes rather than patch it.
