### PR TITLE
fix(cloud): deterministic per-identity avatar colors on the /n dashboard

### DIFF
--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -45,6 +45,10 @@ describe("cloud notebook dashboard projection", () => {
       facts: [],
       identityLabel: null,
       notebook: newOwner,
+      // Deterministic per-identity color from the owner principal; owner-scope
+      // rows compute it even though the avatar renders only for shared rows.
+      ownerColor: "#7c3aed",
+      ownerContrast: "#ffffff",
       ownerInitials: "AL",
       // Owner-scope rows read "You" (the requester owns them); initials stay
       // derived from the real identity so the avatar keeps meaning.

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -482,7 +482,17 @@ function CloudNotebookDashboardRowView({
       <span className="nb-col nb-col-owner">
         {notebook.scope === "owner" ? null : (
           <>
-            <span className="nb-avatar nb-avatar-sm">{row.ownerInitials}</span>
+            <span
+              className="nb-avatar nb-avatar-sm"
+              style={
+                {
+                  "--nb-avatar-bg": row.ownerColor,
+                  "--nb-avatar-fg": row.ownerContrast,
+                } as CSSProperties
+              }
+            >
+              {row.ownerInitials}
+            </span>
             <span className="nb-col-owner-name">{row.ownerLabel}</span>
           </>
         )}

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -873,8 +873,8 @@ body {
   flex: 0 0 auto;
   place-items: center;
   border-radius: 50%;
-  background: var(--uv);
-  color: #fff;
+  background: var(--nb-avatar-bg, var(--uv));
+  color: var(--nb-avatar-fg, #fff);
   font-size: 12px;
   font-weight: 700;
 }
@@ -1176,8 +1176,8 @@ body {
   flex: 0 0 auto;
   place-items: center;
   border-radius: 50%;
-  background: color-mix(in srgb, var(--foreground) 72%, var(--background));
-  color: var(--background);
+  background: var(--nb-avatar-bg, color-mix(in srgb, var(--foreground) 72%, var(--background)));
+  color: var(--nb-avatar-fg, var(--background));
   font-weight: 700;
 }
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -1,5 +1,7 @@
 import { cloudNotebookUrlWithMode, type CloudNotebookUrlMode } from "./cloud-notebook-mode";
 import {
+  colorForActorIdentity,
+  contrastColorForActorIdentity,
   isNotebookComputeSessionSummary,
   projectNotebookComputeSessionFact,
   type NotebookComputeSessionSummary,
@@ -115,6 +117,8 @@ export interface CloudNotebookDashboardRow {
   facts: readonly CloudNotebookDashboardRowFact[];
   identityLabel: string | null;
   notebook: CloudNotebookListItem;
+  ownerColor: string;
+  ownerContrast: string;
   ownerInitials: string;
   ownerLabel: string;
   runtimeStatus: CloudNotebookDashboardRuntimeStatus;
@@ -728,6 +732,8 @@ function dashboardRow(notebook: CloudNotebookListItem | null): CloudNotebookDash
       ? null
       : cloudNotebookShortId(notebook.notebook_id),
     notebook,
+    ownerColor: colorForActorIdentity(notebook.owner_principal),
+    ownerContrast: contrastColorForActorIdentity(notebook.owner_principal),
     ownerInitials: cloudNotebookOwnerInitials(ownerDisplaySource),
     ownerLabel,
     runtimeStatus: cloudNotebookDashboardRuntimeStatus(notebook),

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+} from "react";
 import {
   AlertCircle,
   ArrowUpRight,
@@ -10,6 +17,7 @@ import {
   Search,
   Sparkles,
 } from "lucide-react";
+import { colorForActorIdentity, contrastColorForActorIdentity } from "runtimed";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -344,6 +352,12 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   const currentUserInitials = currentUserDisplay
     ? cloudNotebookInitialsFromLabel(currentUserDisplay)
     : cloudNotebookListCurrentUserInitials(authState);
+  // Deterministic per-identity avatar color via the same palette/contrast
+  // helpers as presence and cursors, but keyed on a best-effort self identity
+  // (auth claims, not the room actor label), so it replaces the fixed brand fill
+  // now; an exact cross-surface match waits on the user store's canonical
+  // self principal.
+  const currentUserColorKey = cloudNotebookListCurrentUserColorKey(authState);
 
   return (
     <main className="cloud-notebook-list-page nb-app">
@@ -393,7 +407,16 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
                   <LogOut aria-hidden="true" />
                   <span className="nb-btn-label">Sign out</span>
                 </Button>
-                <span className="nb-avatar-me" title={currentUserDisplay ?? headerDetail}>
+                <span
+                  className="nb-avatar-me"
+                  style={
+                    {
+                      "--nb-avatar-bg": colorForActorIdentity(currentUserColorKey),
+                      "--nb-avatar-fg": contrastColorForActorIdentity(currentUserColorKey),
+                    } as CSSProperties
+                  }
+                  title={currentUserDisplay ?? headerDetail}
+                >
                   {currentUserInitials}
                 </span>
               </div>
@@ -635,6 +658,15 @@ function cloudNotebookListCurrentUserInitials(authState: CloudPrototypeAuthState
     (authState.mode === "dev" ? authState.user?.trim() : "") ||
     "You";
   return cloudNotebookInitialsFromLabel(label);
+}
+
+function cloudNotebookListCurrentUserColorKey(authState: CloudPrototypeAuthState): string {
+  return (
+    authState.oidcClaims?.sub?.trim() ||
+    (authState.mode === "dev" ? authState.user?.trim() : "") ||
+    authState.oidcClaims?.email?.trim() ||
+    "you"
+  );
 }
 
 function cloudNotebookInitialsFromLabel(label: string): string {


### PR DESCRIPTION
The `/n` dashboard header self-avatar hardcoded `var(--uv)` (the brand magenta) and the owner-row avatar hardcoded a neutral gray, so every viewer's own avatar was always purple and every shared-notebook owner rendered the same gray. The deterministic `colorForActorIdentity` hash already used for cursors, presence, and comment authors was never applied on this surface.

## Change

- Owner-row avatar colors from `owner_principal`, projected as `ownerColor` / `ownerContrast` on `CloudNotebookDashboardRow` (`notebook-dashboard.ts`).
- Header self-avatar colors from a best-effort self identity key (OIDC `sub`, else dev user, else email) via `cloudNotebookListCurrentUserColorKey` (`notebook-list-view.tsx`).
- Both set `--nb-avatar-bg` / `--nb-avatar-fg` inline, mirroring the existing `--nb-peer-bg` presence pattern; `index.css` keeps the prior fills as `var(--nb-avatar-bg, <old>)` fallbacks, so any avatar that does not set the inline vars is unchanged. Readable foreground comes from `contrastColorForActorIdentity`.

Exact cross-surface color match for self (the header avatar keys on auth claims, not the room actor label) and IdP-provided color are follow-ons once the cloud user store carries the canonical self principal (`docs/adr/cloud-user-store.md`).
