### PR TITLE
feat(cloud): CloudUserStore - unified principal->display resolution

### DIFF
--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -68,6 +68,7 @@ export interface AuthenticatedConnectionMetadata {
     | "workstation-credential-header";
   principalNamespace: string;
   displayName?: string;
+  avatarUrl?: string;
   email?: string;
   emailVerified?: boolean;
   workstationCredentialId?: string;
@@ -156,6 +157,7 @@ interface JwtPayload {
   iss?: string;
   name?: string;
   nbf?: number;
+  picture?: string;
   preferred_username?: string;
   sub?: string;
   token_use?: string;
@@ -312,6 +314,7 @@ export async function authenticateOidcRequest(
       transport: credential.transport,
       principalNamespace: config.principalNamespace,
       ...(profile.displayName ? { displayName: profile.displayName } : {}),
+      ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),
       ...(profile.email ? { email: profile.email } : {}),
       ...(profile.email ? { emailVerified: payload.email_verified === true } : {}),
     },
@@ -323,9 +326,11 @@ export async function authenticateOidcRequest(
 
 function profileFromOidcPayload(payload: JwtPayload): {
   displayName?: string;
+  avatarUrl?: string;
   email?: string;
 } {
   const email = payload.email?.trim() || undefined;
+  const avatarUrl = payload.picture?.trim() || undefined;
   const displayName =
     payload.name?.trim() ||
     [payload.given_name, payload.family_name]
@@ -337,6 +342,7 @@ function profileFromOidcPayload(payload: JwtPayload): {
 
   return {
     ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
     ...(email ? { email } : {}),
   };
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3560,14 +3560,12 @@ async function routeNotebookAuthorProfiles(
   );
   return json({
     notebook_id: notebookId,
-    profiles: profileLookups
-      .map((lookup) =>
-        authorProfileResponse(
-          lookup.requestedPrincipal,
-          lookup.profilePrincipals.map((principal) => profilesByPrincipal.get(principal) ?? null),
-        ),
-      )
-      .filter((profile) => profile !== null),
+    profiles: profileLookups.map((lookup) =>
+      authorProfileResponse(
+        lookup.requestedPrincipal,
+        lookup.profilePrincipals.map((principal) => profilesByPrincipal.get(principal) ?? null),
+      ),
+    ),
   });
 }
 
@@ -3599,16 +3597,22 @@ function requestedAuthorProfilePrincipals(params: URLSearchParams): string[] | R
 function authorProfileResponse(
   principal: string,
   rows: readonly (PrincipalProfileRow | null)[],
-): Record<string, unknown> | null {
-  const row = rows.find((candidate) => candidate?.display_name?.trim());
-  const label = row?.display_name?.trim() ?? null;
-  if (!row || !label) {
-    return null;
-  }
+): Record<string, unknown> {
+  const nameRow = rows.find((candidate) => candidate?.display_name?.trim());
+  const label = nameRow?.display_name?.trim() ?? null;
+  const avatarRow = nameRow?.avatar_url?.trim()
+    ? nameRow
+    : rows.find((candidate) => candidate?.avatar_url?.trim());
+  // Every allowed principal returns an entry; `resolved` marks whether the host
+  // has a display name. Unresolved entries (label null) let the user store tell
+  // "no profile yet" from "never looked up", and the comments client's
+  // non-empty-label validator ignores them. The caller's gate omits non-allowed
+  // principals entirely, so this is never a principal-existence oracle.
   return {
     principal,
     label,
-    image_url: row.avatar_url,
+    image_url: avatarRow?.avatar_url?.trim() ?? null,
+    resolved: label !== null,
   };
 }
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1224,10 +1224,16 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
   ]);
   // Same resolution chain the viewer shell uses: live identity metadata, then
   // the app session's captured display name, then the profile store.
+  const currentUserProfile = principalDisplays.get(principal);
   const currentUserDisplay =
     (!isAnonymousViewer(identity) ? identity.metadata.displayName?.trim() : undefined) ||
     appSession?.displayName?.trim() ||
-    principalDisplays.get(principal);
+    currentUserProfile?.displayName ||
+    undefined;
+  const currentUserAvatar =
+    (!isAnonymousViewer(identity) ? identity.metadata.avatarUrl?.trim() : undefined) ||
+    currentUserProfile?.avatarUrl ||
+    undefined;
   return json({
     ok: true,
     notebooks: notebookListResponseRows(
@@ -1239,6 +1245,7 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
       principalDisplays,
     ),
     ...(currentUserDisplay ? { current_user_display: currentUserDisplay } : {}),
+    ...(currentUserAvatar ? { current_user_avatar: currentUserAvatar } : {}),
   });
 }
 
@@ -1249,18 +1256,17 @@ async function listNotebookPrincipalDisplays(
   env: Env,
   notebooks: readonly ListedNotebookRow[],
   requesterPrincipal: string,
-): Promise<Map<string, string>> {
-  const displays = new Map<string, string>();
+): Promise<Map<string, { displayName: string | null; avatarUrl: string | null }>> {
+  const displays = new Map<string, { displayName: string | null; avatarUrl: string | null }>();
   try {
     const principals = Array.from(
       new Set([...notebooks.map((notebook) => notebook.owner_principal), requesterPrincipal]),
     );
     const profiles = await getPrincipalProfiles(env, principals);
     for (const profile of profiles) {
-      const display = profile.display_name?.trim();
-      if (display) {
-        displays.set(profile.principal, display);
-      }
+      const displayName = profile.display_name?.trim() || null;
+      const avatarUrl = profile.avatar_url?.trim() || null;
+      displays.set(profile.principal, { displayName, avatarUrl });
     }
   } catch (error) {
     cloudLog("warn", "notebook.list.profile_hydration_failed", {
@@ -1436,7 +1442,10 @@ function notebookListResponseRows(
   env?: Env,
   computeSessions: ReadonlyMap<string, NotebookComputeSessionSummary> = new Map(),
   roomPresence: ReadonlyMap<string, NotebookRoomSummaryOccupant[]> = new Map(),
-  principalDisplays: ReadonlyMap<string, string> = new Map(),
+  principalDisplays: ReadonlyMap<
+    string,
+    { displayName: string | null; avatarUrl: string | null }
+  > = new Map(),
 ): Array<Record<string, unknown>> {
   return notebooks.map((notebook) => {
     const notebookPathId = encodeURIComponent(notebook.id);
@@ -1449,6 +1458,8 @@ function notebookListResponseRows(
         : null;
     const cover = notebookCoverResponse(notebook);
     const peers = (roomPresence.get(notebook.id) ?? []).slice(0, MAX_NOTEBOOK_LIST_PEERS_PER_ROW);
+    const ownerProfile = principalDisplays.get(notebook.owner_principal);
+    const ownerResolved = principalDisplays.has(notebook.owner_principal);
     return {
       notebook_id: notebook.id,
       title: notebook.title,
@@ -1457,9 +1468,9 @@ function notebookListResponseRows(
       created_at: notebook.created_at,
       updated_at: notebook.updated_at,
       latest_revision_id: notebook.latest_revision_id,
-      ...(principalDisplays.has(notebook.owner_principal)
-        ? { owner_display: principalDisplays.get(notebook.owner_principal) }
-        : {}),
+      ...(ownerProfile?.displayName ? { owner_display: ownerProfile.displayName } : {}),
+      ...(ownerProfile?.avatarUrl ? { owner_avatar: ownerProfile.avatarUrl } : {}),
+      owner_resolved: ownerResolved,
       ...(composition ? { composition } : {}),
       ...(preview?.length ? { preview } : {}),
       ...(cover ? { cover } : {}),
@@ -5037,6 +5048,7 @@ async function syncAuthenticatedProfile(
       provider: identity.metadata.provider,
       email: identity.metadata.email ?? null,
       displayName: identity.metadata.displayName ?? null,
+      avatarUrl: identity.metadata.avatarUrl ?? null,
     };
 
     // Canonical account ACLs are keyed by verified email. OIDC carries an
@@ -5092,6 +5104,7 @@ async function syncStoredAppSessionProfile(env: Env, session: CloudAppSession): 
       email: profile.email_normalized,
       emailVerified: true,
       displayName: session.displayName ?? profile.display_name,
+      avatarUrl: profile.avatar_url,
     });
     logInviteResolutionCompleted({
       principal: session.principal,

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -699,6 +699,7 @@ export async function resolveNotebookInvitesForLogin(
     email: login.email,
     emailVerified: login.emailVerified,
     displayName: login.displayName,
+    avatarUrl: login.avatarUrl,
     timestamp: now,
   });
 

--- a/apps/notebook-cloud/src/sharing.ts
+++ b/apps/notebook-cloud/src/sharing.ts
@@ -23,6 +23,7 @@ export interface AuthenticatedLoginProfile {
   email: string | null;
   emailVerified: boolean;
   displayName: string | null;
+  avatarUrl?: string | null;
 }
 
 export interface PrincipalProfile {

--- a/apps/notebook-cloud/test/cloud-user-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-user-store.test.ts
@@ -1,0 +1,739 @@
+/**
+ * Cloud user store driver contract tests.
+ *
+ * Backfill promises settle on the real microtask queue, drained with
+ * `drainMicrotasks`, while network operations and future clocks are injected.
+ * The store has no timer today, so the virtual scheduler is present to preserve
+ * the house pattern and keep the driver contract virtual-time total.
+ *
+ * The load-bearing cases: presence and self seed through the same precedence
+ * merge, cached and in-flight principals are deduped, author-profile backfills
+ * chunk and cache unresolved relationship-gate omissions, same-rank writes never
+ * null out existing content, stale completions drop on dispose/re-activate or
+ * endpoint changes, and sign-out clears cached identity plus in-flight writes.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { BehaviorSubject, VirtualAction, VirtualTimeScheduler } from "rxjs";
+import { COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE } from "../viewer/comment-author-profiles";
+import {
+  CloudUserStore,
+  type CloudResolvedProfile,
+  type CloudUserStoreDeps,
+  type CloudUserStoreInputs,
+} from "../viewer/cloud-user-store";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import type { CloudViewerPresenceState } from "../viewer/presence";
+
+/** Advance the virtual clock by `ms`, stopping at the target frame. */
+function advanceBy(scheduler: VirtualTimeScheduler, ms: number): void {
+  const target = scheduler.frame + ms;
+  scheduler.maxFrames = target;
+  scheduler.schedule(() => {}, ms);
+  scheduler.flush();
+}
+
+/** Let queued microtasks (promise `.then` chains) run to completion. */
+async function drainMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+function newScheduler(): VirtualTimeScheduler {
+  return new VirtualTimeScheduler(VirtualAction, Infinity);
+}
+
+const STABLE_AUTH: CloudPrototypeAuthState = {
+  mode: "dev",
+  token: "dev-token",
+  user: "Owner User",
+  oidcClaims: null,
+  requestedScope: "owner",
+  problem: null,
+};
+
+const OIDC_AUTH: CloudPrototypeAuthState = {
+  mode: "oidc",
+  token: "oidc-token",
+  user: "Owner User",
+  oidcClaims: {
+    sub: "owner-sub",
+    email: "owner@example.com",
+    name: "Owner Claims",
+    picture: "https://cdn.example.com/owner.png",
+  },
+  requestedScope: "owner",
+  problem: null,
+};
+
+const SIGNED_OUT_AUTH: CloudPrototypeAuthState = {
+  mode: "anonymous",
+  token: null,
+  user: null,
+  oidcClaims: null,
+  requestedScope: null,
+  problem: null,
+};
+
+function actor(index: number): string {
+  return `user:anaconda:actor-${index}`;
+}
+
+function baseInputs(overrides: Partial<CloudUserStoreInputs> = {}): CloudUserStoreInputs {
+  return {
+    auth: STABLE_AUTH,
+    authorProfilesEndpoint: "/api/n/nb-1/author-profiles",
+    ...overrides,
+  };
+}
+
+function baseDeps(overrides: Partial<CloudUserStoreDeps> = {}): CloudUserStoreDeps {
+  return {
+    scheduler: newScheduler(),
+    now: () => 0,
+    fetchProfiles: async () => jsonResponse({ profiles: [] }),
+    ...overrides,
+  };
+}
+
+function presenceState(
+  overrides: Partial<CloudViewerPresenceState> = {},
+): CloudViewerPresenceState {
+  return {
+    connection: "connected",
+    ownPeerId: null,
+    actorLabel: null,
+    ownPeerLabel: null,
+    peers: [],
+    roomPeerCount: 1,
+    runtimePeerCount: 0,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** A `fetchProfiles` whose promises the test resolves on demand. */
+function deferredFetch() {
+  const calls: Array<{
+    url: string;
+    signal?: AbortSignal;
+    resolve: (value: Response) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  const fetchProfiles = (url: string, signal?: AbortSignal) =>
+    new Promise<Response>((resolve, reject) => {
+      calls.push({ url, signal, resolve, reject });
+    });
+  return { fetchProfiles, calls };
+}
+
+function profile(store: CloudUserStore, principal: string): CloudResolvedProfile | undefined {
+  return store.snapshot.profiles.get(principal);
+}
+
+function activateStore(
+  options: {
+    deps?: Partial<CloudUserStoreDeps>;
+    inputs?: Partial<CloudUserStoreInputs>;
+  } = {},
+): {
+  dispose: () => void;
+  inputs$: BehaviorSubject<CloudUserStoreInputs>;
+  store: CloudUserStore;
+} {
+  const store = new CloudUserStore();
+  const inputs$ = new BehaviorSubject<CloudUserStoreInputs>(baseInputs(options.inputs));
+  const dispose = store.activate(inputs$, baseDeps(options.deps));
+  return { dispose, inputs$, store };
+}
+
+describe("CloudUserStore seeding", () => {
+  it("seeds presence peers and self, including the self avatar from auth claims", () => {
+    const store = new CloudUserStore();
+
+    store.seedFromPresence(
+      presenceState({
+        actorLabel: "user:oidc:owner-sub",
+        ownPeerLabel: "Owner Room",
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Peer One",
+            connectionScope: null,
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      OIDC_AUTH,
+    );
+
+    assert.deepEqual(profile(store, actor(1)), {
+      principal: actor(1),
+      displayName: "Peer One",
+      avatarUrl: null,
+      source: "presence",
+    });
+    assert.deepEqual(profile(store, "user:oidc:owner-sub"), {
+      principal: "user:oidc:owner-sub",
+      displayName: "Owner Room",
+      avatarUrl: "https://cdn.example.com/owner.png",
+      source: "self",
+    });
+  });
+
+  it("keeps a fetched profile when a presence snapshot later carries the same principal", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    store.requestResolve([actor(1)]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [
+          {
+            principal: actor(1),
+            label: "Fetched Peer",
+            image_url: "https://cdn.example.com/p.png",
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    await drainMicrotasks();
+
+    store.seedFromPresence(
+      presenceState({
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Presence Peer",
+            connectionScope: null,
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      STABLE_AUTH,
+    );
+
+    assert.deepEqual(profile(store, actor(1)), {
+      principal: actor(1),
+      displayName: "Fetched Peer",
+      avatarUrl: "https://cdn.example.com/p.png",
+      source: "profile",
+    });
+    dispose();
+  });
+
+  it("dedupes repeated snapshots without state churn", () => {
+    const store = new CloudUserStore();
+    let emissions = 0;
+    const sub = store.profiles$.subscribe(() => {
+      emissions += 1;
+    });
+    const state = presenceState({
+      peers: [
+        {
+          id: "peer-1",
+          participantKey: actor(1),
+          label: "Peer One",
+          connectionScope: null,
+          kind: "peer",
+          status: "active",
+        },
+      ],
+    });
+
+    store.seedFromPresence(state, STABLE_AUTH);
+    store.seedFromPresence(state, STABLE_AUTH);
+
+    assert.equal(emissions, 2);
+    sub.unsubscribe();
+  });
+});
+
+describe("CloudUserStore backfill", () => {
+  it("dedupes cached and in-flight principals", async () => {
+    const scheduler = newScheduler();
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({
+      deps: { fetchProfiles: fetch.fetchProfiles, scheduler },
+    });
+
+    store.requestResolve([actor(1), actor(1)]);
+    store.requestResolve([actor(1)]);
+    advanceBy(scheduler, 1_000);
+
+    assert.equal(fetch.calls.length, 1);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: null, image_url: null, resolved: false }],
+      }),
+    );
+    await drainMicrotasks();
+    assert.equal(profile(store, actor(1))?.source, "unresolved");
+
+    store.requestResolve([actor(1)]);
+    assert.equal(fetch.calls.length, 1);
+    dispose();
+  });
+
+  it("chunks sequentially by the shared author-profile batch constant", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    const labels = Array.from({ length: COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE + 1 }, (_, i) =>
+      actor(i),
+    );
+
+    store.requestResolve(labels);
+    assert.equal(fetch.calls.length, 1);
+    assert.equal(
+      new URL(`http://unit.test${fetch.calls[0]?.url}`).searchParams.getAll("actor_label").length,
+      COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE,
+    );
+
+    fetch.calls[0]?.resolve(jsonResponse({ profiles: [] }));
+    await drainMicrotasks();
+    assert.equal(fetch.calls.length, 2);
+    assert.equal(
+      new URL(`http://unit.test${fetch.calls[1]?.url}`).searchParams.getAll("actor_label").length,
+      1,
+    );
+
+    fetch.calls[1]?.resolve(jsonResponse({ profiles: [] }));
+    await drainMicrotasks();
+    assert.equal(store.snapshot.profiles.size, COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE + 1);
+    dispose();
+  });
+
+  it("caches resolved false and absent principals as unresolved and does not refetch them", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+
+    store.requestResolve([actor(1), actor(2)]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: null, image_url: null, resolved: false }],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(profile(store, actor(1))?.source, "unresolved");
+    assert.equal(profile(store, actor(2))?.source, "unresolved");
+
+    store.requestResolve([actor(1), actor(2)]);
+    assert.equal(fetch.calls.length, 1);
+    dispose();
+  });
+
+  it("upgrades a presence entry when a resolved profile arrives", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    store.seedFromPresence(
+      presenceState({
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Presence Peer",
+            connectionScope: null,
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      STABLE_AUTH,
+    );
+
+    store.requestResolve([actor(2)]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [
+          {
+            principal: actor(2),
+            label: "Profile Peer",
+            image_url: "https://cdn.example.com/p.png",
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(profile(store, actor(1))?.source, "presence");
+    assert.deepEqual(profile(store, actor(2)), {
+      principal: actor(2),
+      displayName: "Profile Peer",
+      avatarUrl: "https://cdn.example.com/p.png",
+      source: "profile",
+    });
+    dispose();
+  });
+});
+
+describe("CloudUserStore never demote", () => {
+  it("leaves cached profiles intact on rejected and non-ok batches", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    store.seedFromPresence(
+      presenceState({
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Peer One",
+            connectionScope: null,
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      STABLE_AUTH,
+    );
+
+    store.requestResolve([actor(2)]);
+    fetch.calls[0]?.reject(new Error("network down"));
+    await drainMicrotasks();
+
+    store.requestResolve([actor(2)]);
+    fetch.calls[1]?.resolve(jsonResponse({ profiles: [] }, 503));
+    await drainMicrotasks();
+
+    assert.deepEqual(profile(store, actor(1)), {
+      principal: actor(1),
+      displayName: "Peer One",
+      avatarUrl: null,
+      source: "presence",
+    });
+    assert.equal(profile(store, actor(2)), undefined);
+    dispose();
+  });
+
+  it("does not clear unrelated cached profiles when a batch response is empty", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    store.seedFromPresence(
+      presenceState({
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Peer One",
+            connectionScope: null,
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      STABLE_AUTH,
+    );
+
+    store.requestResolve([actor(2)]);
+    fetch.calls[0]?.resolve(jsonResponse({ profiles: [] }));
+    await drainMicrotasks();
+
+    assert.equal(profile(store, actor(1))?.displayName, "Peer One");
+    assert.equal(profile(store, actor(2))?.source, "unresolved");
+    dispose();
+  });
+
+  it("does not null out an existing avatar at the same profile rank", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+
+    store.requestResolve([actor(1)]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [
+          {
+            principal: actor(1),
+            label: "Profile Peer",
+            image_url: "https://cdn.example.com/p.png",
+            resolved: true,
+          },
+          { principal: actor(1), label: "Profile Peer", image_url: null, resolved: true },
+        ],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(profile(store, actor(1))?.avatarUrl, "https://cdn.example.com/p.png");
+    dispose();
+  });
+});
+
+describe("CloudUserStore stale-completion guards", () => {
+  it("drops a fetch that resolves after dispose", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+
+    store.requestResolve([actor(1)]);
+    dispose();
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: "Too Late", image_url: null, resolved: true }],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(store.snapshot.profiles.size, 0);
+  });
+
+  it("drops an old fetch that resolves after re-activation", async () => {
+    const fetch = deferredFetch();
+    const { dispose, inputs$, store } = activateStore({
+      deps: { fetchProfiles: fetch.fetchProfiles },
+    });
+    store.requestResolve([actor(1)]);
+    dispose();
+
+    const disposeAgain = store.activate(inputs$, baseDeps({ fetchProfiles: fetch.fetchProfiles }));
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: "Old Peer", image_url: null, resolved: true }],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(profile(store, actor(1)), undefined);
+    store.requestResolve([actor(1)]);
+    assert.equal(fetch.calls.length, 2);
+    fetch.calls[1]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: "Current Peer", image_url: null, resolved: true }],
+      }),
+    );
+    await drainMicrotasks();
+    assert.equal(profile(store, actor(1))?.displayName, "Current Peer");
+    disposeAgain();
+  });
+
+  it("drops a fetch whose endpoint changed before completion", async () => {
+    const fetch = deferredFetch();
+    const { dispose, inputs$, store } = activateStore({
+      deps: { fetchProfiles: fetch.fetchProfiles },
+    });
+
+    store.requestResolve([actor(1)]);
+    inputs$.next(baseInputs({ authorProfilesEndpoint: "/api/n/nb-2/author-profiles" }));
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [
+          { principal: actor(1), label: "Wrong Notebook", image_url: null, resolved: true },
+        ],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(profile(store, actor(1)), undefined);
+    store.requestResolve([actor(1)]);
+    assert.equal(fetch.calls.length, 2);
+    assert.match(fetch.calls[1]?.url ?? "", /^\/api\/n\/nb-2\/author-profiles/);
+    dispose();
+  });
+});
+
+describe("CloudUserStore signed-out gate", () => {
+  it("resets the map, bumps the epoch, and drops in-flight completions", async () => {
+    const fetch = deferredFetch();
+    const { dispose, inputs$, store } = activateStore({
+      deps: { fetchProfiles: fetch.fetchProfiles },
+    });
+    store.seedFromPresence(
+      presenceState({
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Peer One",
+            connectionScope: null,
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      STABLE_AUTH,
+    );
+    store.requestResolve([actor(2)]);
+
+    inputs$.next(baseInputs({ auth: SIGNED_OUT_AUTH }));
+    assert.equal(store.snapshot.profiles.size, 0);
+
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(2), label: "Too Late", image_url: null, resolved: true }],
+      }),
+    );
+    await drainMicrotasks();
+
+    assert.equal(store.snapshot.profiles.size, 0);
+    dispose();
+  });
+});
+
+describe("CloudUserStore resolve", () => {
+  it("uses a cached profile as the ActorDisplay peer directory", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    store.requestResolve([actor(1)]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [
+          {
+            principal: actor(1),
+            label: "Profile Peer",
+            image_url: "https://cdn.example.com/p.png",
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    await drainMicrotasks();
+
+    const display = store.resolve(actor(1));
+    assert.equal(display.displayName, "Profile Peer");
+    assert.equal(display.imageUrl, "https://cdn.example.com/p.png");
+    dispose();
+  });
+
+  it("falls back through resolveActorDisplay without returning a raw Anaconda principal", () => {
+    const store = new CloudUserStore();
+    const actorLabel = "user:anaconda:550e8400-e29b-41d4-a716-446655440000";
+
+    const display = store.resolve(actorLabel);
+
+    assert.notEqual(display.displayName, actorLabel);
+    assert.notEqual(display.displayName, "550e8400-e29b-41d4-a716-446655440000");
+  });
+});
+
+describe("CloudUserStore cross-rank merges, renewal, and route swaps", () => {
+  it("keeps the self avatar when a resolved profile arrives without one", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+    const selfLabel = "user:anaconda:actor-self/browser:tab";
+
+    store.seedFromPresence(
+      presenceState({ actorLabel: selfLabel, ownPeerLabel: "Owner Claims" }),
+      OIDC_AUTH,
+    );
+    assert.equal(
+      profile(store, "user:anaconda:actor-self")?.avatarUrl,
+      OIDC_AUTH.oidcClaims?.picture,
+    );
+
+    // A profile row outranks the self seed, but its null avatar must not erase
+    // the avatar the auth claims already supplied.
+    store.requestResolve([selfLabel]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [
+          {
+            principal: "user:anaconda:actor-self",
+            label: "Owner Profile",
+            image_url: null,
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    await drainMicrotasks();
+
+    const merged = profile(store, "user:anaconda:actor-self");
+    assert.equal(merged?.source, "profile");
+    assert.equal(merged?.displayName, "Owner Profile");
+    assert.equal(merged?.avatarUrl, OIDC_AUTH.oidcClaims?.picture);
+    dispose();
+  });
+
+  it("keeps cached identities across an oidc_expired renewal window", async () => {
+    const fetch = deferredFetch();
+    const { dispose, inputs$, store } = activateStore({
+      inputs: { auth: OIDC_AUTH },
+      deps: { fetchProfiles: fetch.fetchProfiles },
+    });
+
+    store.requestResolve([actor(1)]);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: "Mara Osei", image_url: null, resolved: true }],
+      }),
+    );
+    await drainMicrotasks();
+    assert.equal(profile(store, actor(1))?.displayName, "Mara Osei");
+
+    // Token renewal is the same principal mid-refresh, not a sign-out.
+    inputs$.next(baseInputs({ auth: { ...OIDC_AUTH, mode: "oidc_expired" } }));
+
+    assert.equal(profile(store, actor(1))?.displayName, "Mara Osei");
+    dispose();
+  });
+
+  it("keeps a presence name the endpoint declined to upgrade and stops refetching it", async () => {
+    const fetch = deferredFetch();
+    const { dispose, store } = activateStore({ deps: { fetchProfiles: fetch.fetchProfiles } });
+
+    store.seedFromPresence(
+      presenceState({
+        peers: [
+          {
+            id: "peer-1",
+            participantKey: actor(1),
+            label: "Roster Name",
+            connectionScope: "editor",
+            kind: "peer",
+            status: "active",
+          },
+        ],
+      }),
+      STABLE_AUTH,
+    );
+
+    // Presence seeds stay backfill-eligible, so the first request fetches.
+    store.requestResolve([actor(1)]);
+    assert.equal(fetch.calls.length, 1);
+    fetch.calls[0]?.resolve(
+      jsonResponse({
+        profiles: [{ principal: actor(1), label: null, image_url: null, resolved: false }],
+      }),
+    );
+    await drainMicrotasks();
+
+    // The unresolved answer neither demotes the roster name nor re-arms a fetch.
+    assert.equal(profile(store, actor(1))?.displayName, "Roster Name");
+    assert.equal(profile(store, actor(1))?.source, "presence");
+    store.requestResolve([actor(1)]);
+    assert.equal(fetch.calls.length, 1);
+    dispose();
+  });
+
+  it("re-checks unresolved principals against a new notebook endpoint", async () => {
+    const fetch = deferredFetch();
+    const { dispose, inputs$, store } = activateStore({
+      deps: { fetchProfiles: fetch.fetchProfiles },
+    });
+
+    store.requestResolve([actor(1)]);
+    fetch.calls[0]?.resolve(jsonResponse({ profiles: [] }));
+    await drainMicrotasks();
+    assert.equal(profile(store, actor(1))?.source, "unresolved");
+
+    // Unresolved is a per-relationship fact; the next notebook may resolve it.
+    inputs$.next(baseInputs({ authorProfilesEndpoint: "/api/n/nb-2/author-profiles" }));
+
+    assert.equal(profile(store, actor(1)), undefined);
+    store.requestResolve([actor(1)]);
+    assert.equal(fetch.calls.length, 2);
+    assert.match(fetch.calls[1]?.url ?? "", /nb-2/);
+    dispose();
+  });
+});

--- a/apps/notebook-cloud/test/comment-author-profiles.test.ts
+++ b/apps/notebook-cloud/test/comment-author-profiles.test.ts
@@ -3,10 +3,8 @@ import { describe, it } from "node:test";
 import type { CommentsProjection } from "@/components/notebook";
 import {
   commentAuthorActorLabels,
-  commentAuthorProfilePeers,
   commentAuthorProfileUrls,
   commentAuthorProfilesUrl,
-  mergeCommentAuthorPeers,
 } from "../viewer/comment-author-profiles.ts";
 
 describe("cloud comment author profiles", () => {
@@ -61,49 +59,6 @@ describe("cloud comment author profiles", () => {
     assert.deepEqual(
       urls.map((url) => new URL(url, "http://localhost").searchParams.getAll("actor_label").length),
       [100, 100, 5],
-    );
-  });
-
-  it("projects profile rows into author peers and keeps profile labels over generic presence", () => {
-    const profilePeers = commentAuthorProfilePeers({
-      profiles: [
-        {
-          principal: "user:anaconda:greg",
-          label: "Greg Jennings",
-          image_url: "https://profiles.example/greg.png",
-        },
-        {
-          principal: "user:anaconda:bad",
-          label: "",
-        },
-      ],
-    });
-
-    assert.deepEqual(profilePeers, [
-      {
-        participantKey: "user:anaconda:greg",
-        label: "Greg Jennings",
-        imageUrl: "https://profiles.example/greg.png",
-      },
-    ]);
-    assert.deepEqual(
-      mergeCommentAuthorPeers(profilePeers, [
-        {
-          participantKey: "user:anaconda:greg",
-          label: "Anaconda user",
-        },
-      ]),
-      profilePeers,
-    );
-  });
-
-  it("lets specific live presence refresh a stored profile label", () => {
-    assert.deepEqual(
-      mergeCommentAuthorPeers(
-        [{ participantKey: "user:anaconda:greg", label: "Greg Jennings" }],
-        [{ participantKey: "user:anaconda:greg", label: "Greg J." }],
-      ),
-      [{ participantKey: "user:anaconda:greg", label: "Greg J." }],
     );
   });
 });

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -738,7 +738,10 @@ describe("OIDC identity", () => {
     const { env, token } = await oidcTokenFixture({
       subject: "user/123",
       email: "alice@example.com",
-      extraPayload: { email_verified: true },
+      extraPayload: {
+        email_verified: true,
+        picture: "https://profiles.example/alice.png",
+      },
       name: "Alice Demo",
     });
 
@@ -761,6 +764,7 @@ describe("OIDC identity", () => {
         transport: "oidc-bearer",
         principalNamespace: "user:anaconda",
         displayName: "Alice Demo",
+        avatarUrl: "https://profiles.example/alice.png",
         email: "alice@example.com",
         emailVerified: true,
       },
@@ -791,6 +795,7 @@ describe("OIDC identity", () => {
     assert.equal(identity.operator, "browser:tab%2Fsession");
     assert.equal(identity.actorLabel, "user:anaconda:alice-subject/browser:tab%2Fsession");
     assert.equal(identity.metadata.displayName, "Alice Example");
+    assert.equal(identity.metadata.avatarUrl, undefined);
     assert.equal(identity.metadata.email, "alice@example.com");
     assert.equal(identity.metadata.emailVerified, true);
   });

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -759,6 +759,30 @@ describe("cloud notebook dashboard projection", () => {
     assert.notEqual(fallback.continueRow?.ownerLabel, "Mara Osei");
   });
 
+  it("threads unified-profile owner avatars and resolved state through dashboard rows", () => {
+    const shared = notebook({
+      id: "shared-avatar-notebook",
+      title: "Shared Avatar Notebook",
+      scope: "viewer",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const withAvatar = {
+      ...shared,
+      owner_avatar: "https://profiles.example/mara.png",
+      owner_display: "Mara Osei",
+      owner_resolved: true,
+    };
+
+    assert.equal(isCloudNotebookListItem(withAvatar), true);
+    assert.equal(isCloudNotebookListItem({ ...shared, owner_avatar: 42 }), false);
+    assert.equal(isCloudNotebookListItem({ ...shared, owner_resolved: "yes" }), false);
+
+    const model = projectCloudNotebookDashboard([withAvatar]);
+    assert.equal(model.continueRow?.ownerAvatar, "https://profiles.example/mara.png");
+    assert.equal(model.continueRow?.notebook.owner_resolved, true);
+  });
+
   it("never renders an opaque owner principal as a name", () => {
     const shared = notebook({
       id: "opaque-owner",

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -759,6 +759,22 @@ describe("cloud notebook dashboard projection", () => {
     assert.notEqual(fallback.continueRow?.ownerLabel, "Mara Osei");
   });
 
+  it("never renders an opaque owner principal as a name", () => {
+    const shared = notebook({
+      id: "opaque-owner",
+      title: "Shared Notebook",
+      scope: "viewer",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const opaque = { ...shared, owner_principal: "user:oidc:b0204af7084b1c2d3e4f5a6b" };
+
+    const model = projectCloudNotebookDashboard([opaque]);
+    // The owner column shows a generic label, never the raw identifier.
+    assert.equal(model.continueRow?.ownerLabel, "Notebook owner");
+    assert.equal(model.continueRow?.ownerInitials, "NO");
+  });
+
   it("threads room peers through list-item validation and active filtering", () => {
     const withPeers = notebook({
       id: "presence-notebook",

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -107,6 +107,19 @@ describe("hosted sharing storage", () => {
     assert.equal(env.DB.maxPrincipalProfileLookupBindCount, 50);
   });
 
+  it("threads login avatars through transport and canonical profile upserts", async () => {
+    const env = fakeEnv();
+    const avatarUrl = "https://profiles.example/alice.png";
+    const login = oidcLogin({ avatarUrl });
+    const accountPrincipal = await canonicalAccountPrincipalForProfile(login);
+    assert.ok(accountPrincipal);
+
+    await resolveNotebookInvitesForLogin(env, login, "2026-05-24T12:00:00.000Z");
+
+    assert.equal(env.DB.profiles.get(login.principal)?.avatar_url, avatarUrl);
+    assert.equal(env.DB.profiles.get(accountPrincipal)?.avatar_url, avatarUrl);
+  });
+
   it("backfills provider subject when a profile was first seen without one", async () => {
     const env = fakeEnv();
     await resolveNotebookInvitesForLogin(env, oidcLogin(), "2026-05-24T12:00:00.000Z");

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -219,7 +219,7 @@ describe("cloud viewer sharing client", () => {
     );
     assert.deepEqual(
       rows.map((row) => row.title),
-      ["user:dev:fixture", "user:anaconda:alice%40example.com"],
+      ["fixture", "alice@example.com"],
     );
   });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -4513,6 +4513,7 @@ describe("Worker artifact routes", () => {
         principal: gregTransport,
         label: "Greg Jennings",
         image_url: "https://profiles.example/greg.png",
+        resolved: true,
       },
     ]);
   });
@@ -4552,7 +4553,17 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 200);
     const body = (await response.json()) as { profiles: Array<Record<string, unknown>> };
-    assert.deepEqual(body.profiles, []);
+    // Allowed but unprofiled: the entry carries no name and no email - label is
+    // null, never the email fallback - so a public viewer still cannot learn the
+    // author's email.
+    assert.deepEqual(body.profiles, [
+      {
+        principal: "user:dev:alice",
+        label: null,
+        image_url: null,
+        resolved: false,
+      },
+    ]);
   });
 
   it("does not expose ACL principal profiles unless they authored visible comments", async () => {
@@ -4613,6 +4624,7 @@ describe("Worker artifact routes", () => {
         principal: "user:dev:alice",
         label: "Alice Example",
         image_url: null,
+        resolved: true,
       },
     ]);
   });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1980,6 +1980,72 @@ describe("Worker artifact routes", () => {
     assert.equal(body.notebooks[1]?.endpoints.catalog, "/api/n/editor-shared");
   });
 
+  it("hydrates owner and current-user avatars from principal profiles in notebook lists", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "profiled-shared");
+    seedNotebook(env, "unresolved-shared");
+    env.DB.notebooks.get("profiled-shared")!.owner_principal = "user:dev:bob";
+    env.DB.notebooks.get("unresolved-shared")!.owner_principal = "user:dev:carol";
+    seedAcl(env, { notebookId: "profiled-shared", subject: "user:dev:alice", scope: "editor" });
+    seedAcl(env, { notebookId: "unresolved-shared", subject: "user:dev:alice", scope: "viewer" });
+    env.DB.profiles.set(
+      "user:dev:alice",
+      principalProfileRow({
+        principal: "user:dev:alice",
+        provider_subject: "alice",
+        display_name: "Alice Example",
+        avatar_url: "https://profiles.example/alice.png",
+      }),
+    );
+    env.DB.profiles.set(
+      "user:dev:bob",
+      principalProfileRow({
+        principal: "user:dev:bob",
+        provider_subject: "bob",
+        email_normalized: "bob@example.com",
+        display_name: "Bob Example",
+        avatar_url: "https://profiles.example/bob.png",
+      }),
+    );
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      current_user_avatar?: string;
+      current_user_display?: string;
+      notebooks: Array<{
+        notebook_id: string;
+        owner_avatar?: string;
+        owner_display?: string;
+        owner_resolved?: boolean;
+      }>;
+    };
+    assert.equal(body.current_user_display, "alice");
+    assert.equal(body.current_user_avatar, "https://profiles.example/alice.png");
+    const profiled = body.notebooks.find((notebook) => notebook.notebook_id === "profiled-shared");
+    const unresolved = body.notebooks.find(
+      (notebook) => notebook.notebook_id === "unresolved-shared",
+    );
+    assert.equal(profiled?.owner_display, "Bob Example");
+    assert.equal(profiled?.owner_avatar, "https://profiles.example/bob.png");
+    assert.equal(profiled?.owner_resolved, true);
+    assert.equal(Object.hasOwn(profiled ?? {}, "owner_avatar"), true);
+    assert.equal(unresolved?.owner_resolved, false);
+    assert.equal(Object.hasOwn(unresolved ?? {}, "owner_display"), false);
+    assert.equal(Object.hasOwn(unresolved ?? {}, "owner_avatar"), false);
+  });
+
   it("omits malformed notebook composition and preview cells from list rows without dropping language", async () => {
     const env = fakeEnv();
     seedNotebook(env, "malformed-summary");
@@ -5353,11 +5419,14 @@ describe("Worker artifact routes", () => {
     );
   });
 
-  it("stores OIDC profile labels even when there are no pending invites", async () => {
+  it("stores OIDC profile labels and avatars even when there are no pending invites", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({
       subject: "fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
       email: "kkelley@anaconda.com",
-      extraPayload: { email_verified: true },
+      extraPayload: {
+        email_verified: true,
+        picture: "https://profiles.example/kkelley.png",
+      },
       name: "Kyle Kelley",
     });
     const env = fakeEnv({
@@ -5396,6 +5465,53 @@ describe("Worker artifact routes", () => {
     assert.equal(profile?.email_normalized, "kkelley@anaconda.com");
     assert.equal(profile?.email_verified, 1);
     assert.equal(profile?.display_name, "Kyle Kelley");
+    assert.equal(profile?.avatar_url, "https://profiles.example/kkelley.png");
+  });
+
+  it("stores null avatar URLs when OIDC picture claims are absent", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "no-picture-user",
+      email: "no-picture@example.com",
+      extraPayload: { email_verified: true },
+      name: "No Picture",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => new Response("room ok"),
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "oidc-no-picture-demo");
+    seedAcl(env, {
+      notebookId: "oidc-no-picture-demo",
+      subject: "user:anaconda:no-picture-user",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://cloud.test/n/oidc-no-picture-demo/sync?operator=browser:tab&scope=viewer",
+        {
+          headers: {
+            Origin: "https://cloud.test",
+            "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+              token,
+            )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+            Upgrade: "websocket",
+          },
+        },
+      ),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const profile = env.DB.profiles.get("user:anaconda:no-picture-user");
+    assert.equal(profile?.provider, "oidc");
+    assert.equal(profile?.avatar_url, null);
   });
 
   it("resolves pending email invites for OIDC editor WebSocket requests", async () => {
@@ -7140,6 +7256,22 @@ function seedNotebook(env: FakeEnv, notebookId: string): void {
     preview_cells: null,
     language: null,
   });
+}
+
+function principalProfileRow(overrides: Partial<PrincipalProfileRow> = {}): PrincipalProfileRow {
+  return {
+    principal: "user:dev:alice",
+    provider: "dev",
+    provider_subject: "alice",
+    email_normalized: "alice@example.com",
+    email_verified: 1,
+    display_name: "Alice Example",
+    avatar_url: null,
+    first_seen_at: "2026-05-28T00:00:00.000Z",
+    last_seen_at: "2026-05-28T00:00:00.000Z",
+    raw_claims_json: null,
+    ...overrides,
+  };
 }
 
 function seedAcl(

--- a/apps/notebook-cloud/viewer/__tests__/cloud-stores-context.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/cloud-stores-context.test.tsx
@@ -7,6 +7,7 @@ import { CloudAuthStoreProvider, useCloudAuthStore } from "../cloud-auth-context
 import { CloudAuthStore, cloudAuthStore } from "../cloud-auth-store";
 import { cloudCatalogStore } from "../cloud-catalog-store";
 import { CloudStoresProvider, type CloudStores } from "../cloud-stores-context";
+import { cloudUserStore } from "../cloud-user-store";
 import { cloudWorkstationsStore } from "../cloud-workstations-store";
 import { useCloudSelectedMode } from "../use-cloud-access-request-controller";
 
@@ -23,6 +24,7 @@ describe("CloudStoresProvider", () => {
     const fixtureStores: CloudStores = {
       accessRequest: fixtureAccessRequest,
       catalog: cloudCatalogStore,
+      user: cloudUserStore,
       workstations: cloudWorkstationsStore,
     };
     const wrapper = ({ children }: { children: ReactNode }) =>

--- a/apps/notebook-cloud/viewer/__tests__/sharing-client.test.ts
+++ b/apps/notebook-cloud/viewer/__tests__/sharing-client.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  buildCloudShareAccessRows,
+  clearCloudShareAccessRowsCachesForTests,
+  type CloudNotebookAccessRequest,
+  type CloudNotebookAclRow,
+} from "../sharing-client";
+
+const TIMESTAMP = "2026-07-06T12:00:00.000Z";
+const OPAQUE_SUBJECT = "01987654-3210-7def-8123-456789abcdef";
+
+function aclRow(subject: string): CloudNotebookAclRow {
+  return {
+    notebook_id: "nb-1",
+    subject_kind: "principal",
+    subject,
+    scope: "editor",
+    created_at: TIMESTAMP,
+    updated_at: TIMESTAMP,
+    created_by_actor_label: "user:dev:owner",
+  };
+}
+
+function accessRequest(requesterPrincipal: string): CloudNotebookAccessRequest {
+  return {
+    id: "request-1",
+    notebook_id: "nb-1",
+    requester_principal: requesterPrincipal,
+    scope: "editor",
+    status: "pending",
+    requested_by_actor_label: requesterPrincipal,
+    resolved_by_actor_label: null,
+    created_at: TIMESTAMP,
+    updated_at: TIMESTAMP,
+    resolved_at: null,
+  };
+}
+
+afterEach(() => {
+  clearCloudShareAccessRowsCachesForTests();
+});
+
+describe("buildCloudShareAccessRows", () => {
+  it("keeps opaque principal subjects out of sharing labels and titles", () => {
+    const rows = buildCloudShareAccessRows({
+      acl: [aclRow(OPAQUE_SUBJECT)],
+      invites: [],
+      accessRequests: [accessRequest(`user:anaconda:${OPAQUE_SUBJECT}`)],
+    });
+
+    const acl = rows.find((row) => row.kind === "acl");
+    const request = rows.find((row) => row.kind === "access_request");
+
+    expect(acl?.label).toBe("Collaborator");
+    expect(acl?.detail).toBe("Collaborator");
+    expect(acl?.title).toBe("Collaborator");
+    expect(request?.label).toBe("Collaborator");
+    expect(request?.title).toBe("Collaborator");
+  });
+
+  it("keeps readable dev handles and emails as sharing fallbacks", () => {
+    const rows = buildCloudShareAccessRows({
+      acl: [aclRow("user:dev:kyle")],
+      invites: [],
+      accessRequests: [accessRequest("user:anaconda:kyle%40example.com")],
+    });
+
+    const acl = rows.find((row) => row.kind === "acl");
+    const request = rows.find((row) => row.kind === "access_request");
+
+    expect(acl?.label).toBe("kyle");
+    expect(acl?.detail).toBe("Dev identity");
+    expect(acl?.title).toBe("kyle");
+    expect(request?.label).toBe("k...e@example.com");
+    expect(request?.title).toBe("kyle@example.com");
+  });
+});

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-user-store.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-user-store.test.tsx
@@ -1,15 +1,18 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { describe, expect, it } from "vite-plus/test";
+import { BehaviorSubject } from "rxjs";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import { cloudAccessRequestStore } from "../cloud-access-request-store";
+import { CloudAuthStore } from "../cloud-auth-store";
+import { CloudAuthStoreProvider } from "../cloud-auth-context";
 import { cloudCatalogStore } from "../cloud-catalog-store";
 import { CloudStoresProvider, type CloudStores } from "../cloud-stores-context";
 import { CloudUserStore } from "../cloud-user-store";
 import { cloudWorkstationsStore } from "../cloud-workstations-store";
 import type { CloudPrototypeAuthState } from "../collaborator-auth";
 import type { CloudViewerPresenceState } from "../presence";
-import { useResolvedActor } from "../use-cloud-user-store";
+import { useCloudUserStoreController, useResolvedActor } from "../use-cloud-user-store";
 
 const STABLE_AUTH: CloudPrototypeAuthState = {
   mode: "dev",
@@ -39,17 +42,47 @@ function presenceState(
   };
 }
 
-function wrapperFor(user: CloudUserStore): ({ children }: { children: ReactNode }) => ReactNode {
+function wrapperFor(
+  user: CloudUserStore,
+  authStore?: CloudAuthStore,
+): ({ children }: { children: ReactNode }) => ReactNode {
   const stores: CloudStores = {
     accessRequest: cloudAccessRequestStore,
     catalog: cloudCatalogStore,
     user,
     workstations: cloudWorkstationsStore,
   };
-  return ({ children }) => createElement(CloudStoresProvider, { stores, children });
+  return ({ children }) => {
+    const tree = createElement(CloudStoresProvider, { stores, children });
+    return authStore
+      ? createElement(CloudAuthStoreProvider, { store: authStore, children: tree })
+      : tree;
+  };
 }
 
 describe("useResolvedActor", () => {
+  it("activates the consumed user store with auth and endpoint inputs", async () => {
+    const user = new CloudUserStore();
+    const authStore = new CloudAuthStore({ readAuthState: () => STABLE_AUTH });
+    const inputs: unknown[] = [];
+    const activate = vi.spyOn(user, "activate").mockImplementation((inputs$) => {
+      const subscription = inputs$.subscribe((value) => inputs.push(value));
+      return () => subscription.unsubscribe();
+    });
+
+    renderHook(() => useCloudUserStoreController("/author-profiles"), {
+      wrapper: wrapperFor(user, authStore),
+    });
+
+    await waitFor(() => expect(activate).toHaveBeenCalledTimes(1));
+    expect(inputs).toEqual([
+      {
+        auth: STABLE_AUTH,
+        authorProfilesEndpoint: "/author-profiles",
+      },
+    ]);
+  });
+
   it("subscribes only to the rendered principal", () => {
     const user = new CloudUserStore();
     let renders = 0;
@@ -100,5 +133,63 @@ describe("useResolvedActor", () => {
 
     expect(renders).toBe(2);
     expect(result.current.displayName).toBe("Rendered Peer");
+  });
+
+  it("requests profile backfill and reflects a store upgrade", async () => {
+    const user = new CloudUserStore();
+    const fetchProfiles = vi.fn(async () =>
+      Response.json({
+        profiles: [
+          {
+            principal: actor(1),
+            label: "Profile Peer",
+            image_url: "/avatars/profile-peer.png",
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    const inputs$ = new BehaviorSubject({
+      auth: STABLE_AUTH,
+      authorProfilesEndpoint: "/author-profiles",
+    });
+    const dispose = user.activate(inputs$, { fetchProfiles });
+    const { result } = renderHook(() => useResolvedActor(actor(1)), {
+      wrapper: wrapperFor(user),
+    });
+
+    try {
+      act(() => {
+        user.seedFromPresence(
+          presenceState({
+            peers: [
+              {
+                id: "peer-1",
+                participantKey: actor(1),
+                label: "Presence Peer",
+                connectionScope: null,
+                kind: "peer",
+                status: "active",
+              },
+            ],
+          }),
+          STABLE_AUTH,
+        );
+      });
+      expect(result.current.displayName).toBe("Presence Peer");
+
+      act(() => {
+        user.requestResolve([actor(1)]);
+      });
+
+      await waitFor(() => expect(result.current.displayName).toBe("Profile Peer"));
+      expect(result.current.imageUrl).toBe("/avatars/profile-peer.png");
+      expect(fetchProfiles).toHaveBeenCalledWith(
+        "/author-profiles?actor_label=user%3Aanaconda%3Aactor-1",
+        expect.any(AbortSignal),
+      );
+    } finally {
+      dispose();
+    }
   });
 });

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-user-store.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-user-store.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { cloudAccessRequestStore } from "../cloud-access-request-store";
+import { cloudCatalogStore } from "../cloud-catalog-store";
+import { CloudStoresProvider, type CloudStores } from "../cloud-stores-context";
+import { CloudUserStore } from "../cloud-user-store";
+import { cloudWorkstationsStore } from "../cloud-workstations-store";
+import type { CloudPrototypeAuthState } from "../collaborator-auth";
+import type { CloudViewerPresenceState } from "../presence";
+import { useResolvedActor } from "../use-cloud-user-store";
+
+const STABLE_AUTH: CloudPrototypeAuthState = {
+  mode: "dev",
+  token: "dev-token",
+  user: "Owner User",
+  oidcClaims: null,
+  requestedScope: "owner",
+  problem: null,
+};
+
+function actor(index: number): string {
+  return `user:anaconda:actor-${index}`;
+}
+
+function presenceState(
+  overrides: Partial<CloudViewerPresenceState> = {},
+): CloudViewerPresenceState {
+  return {
+    connection: "connected",
+    ownPeerId: null,
+    actorLabel: null,
+    ownPeerLabel: null,
+    peers: [],
+    roomPeerCount: 1,
+    runtimePeerCount: 0,
+    ...overrides,
+  };
+}
+
+function wrapperFor(user: CloudUserStore): ({ children }: { children: ReactNode }) => ReactNode {
+  const stores: CloudStores = {
+    accessRequest: cloudAccessRequestStore,
+    catalog: cloudCatalogStore,
+    user,
+    workstations: cloudWorkstationsStore,
+  };
+  return ({ children }) => createElement(CloudStoresProvider, { stores, children });
+}
+
+describe("useResolvedActor", () => {
+  it("subscribes only to the rendered principal", () => {
+    const user = new CloudUserStore();
+    let renders = 0;
+    const { result } = renderHook(
+      () => {
+        renders += 1;
+        return useResolvedActor(actor(1));
+      },
+      { wrapper: wrapperFor(user) },
+    );
+
+    act(() => {
+      user.seedFromPresence(
+        presenceState({
+          peers: [
+            {
+              id: "peer-2",
+              participantKey: actor(2),
+              label: "Other Peer",
+              connectionScope: null,
+              kind: "peer",
+              status: "active",
+            },
+          ],
+        }),
+        STABLE_AUTH,
+      );
+    });
+    expect(renders).toBe(1);
+
+    act(() => {
+      user.seedFromPresence(
+        presenceState({
+          peers: [
+            {
+              id: "peer-1",
+              participantKey: actor(1),
+              label: "Rendered Peer",
+              connectionScope: null,
+              kind: "peer",
+              status: "active",
+            },
+          ],
+        }),
+        STABLE_AUTH,
+      );
+    });
+
+    expect(renders).toBe(2);
+    expect(result.current.displayName).toBe("Rendered Peer");
+  });
+});

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -485,13 +485,19 @@ function CloudNotebookDashboardRowView({
             <span
               className="nb-avatar nb-avatar-sm"
               style={
-                {
-                  "--nb-avatar-bg": row.ownerColor,
-                  "--nb-avatar-fg": row.ownerContrast,
-                } as CSSProperties
+                row.ownerAvatar
+                  ? undefined
+                  : ({
+                      "--nb-avatar-bg": row.ownerColor,
+                      "--nb-avatar-fg": row.ownerContrast,
+                    } as CSSProperties)
               }
             >
-              {row.ownerInitials}
+              {row.ownerAvatar ? (
+                <img className="nb-avatar-img" src={row.ownerAvatar} alt={row.ownerLabel} />
+              ) : (
+                row.ownerInitials
+              )}
             </span>
             <span className="nb-col-owner-name">{row.ownerLabel}</span>
           </>

--- a/apps/notebook-cloud/viewer/cloud-presence-status.tsx
+++ b/apps/notebook-cloud/viewer/cloud-presence-status.tsx
@@ -6,7 +6,9 @@ import {
   AvatarFallback,
   AvatarGroup,
   AvatarGroupCount,
+  AvatarImage,
 } from "@/components/ui/avatar";
+import type { ActorDisplay } from "runtimed";
 import {
   cloudPresenceInitials,
   cloudViewerPresenceDisplay,
@@ -16,9 +18,11 @@ import {
 
 export function CloudPresenceStatus({
   connectionError,
+  resolveActor,
   store,
 }: {
   connectionError: string | null;
+  resolveActor?: (actorLabel: string) => ActorDisplay;
   store: CloudViewerPresenceStore;
 }) {
   const presence = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
@@ -42,7 +46,12 @@ export function CloudPresenceStatus({
     >
       <AvatarGroup className="cloud-presence-avatar-group" aria-hidden="true">
         {presenceDisplay.peers.map((peer) => (
-          <CloudPresenceAvatar key={peer.id} peer={peer} connected={connected} />
+          <CloudPresenceAvatar
+            key={peer.id}
+            peer={peer}
+            connected={connected}
+            resolveActor={resolveActor}
+          />
         ))}
         {presenceDisplay.hiddenCount > 0 ? (
           <AvatarGroupCount className="cloud-presence-avatar-count" data-size="sm">
@@ -76,11 +85,15 @@ function sanitizeCloudConnectionError(error: string): string {
 function CloudPresenceAvatar({
   connected,
   peer,
+  resolveActor,
 }: {
   connected: boolean;
   peer: CloudViewerPresencePeer;
+  resolveActor?: (actorLabel: string) => ActorDisplay;
 }) {
   const status = connected ? peer.status : "offline";
+  const actorLabel = peer.actorLabel ?? peer.participantKey;
+  const imageUrl = resolveActor?.(actorLabel).imageUrl ?? null;
   return (
     <Avatar
       size="sm"
@@ -89,6 +102,7 @@ function CloudPresenceAvatar({
       data-status={status}
       title={peer.label}
     >
+      {imageUrl ? <AvatarImage className="nb-avatar-img" src={imageUrl} alt="" /> : null}
       <AvatarFallback>
         {peer.kind === "anonymous" ? (
           <>

--- a/apps/notebook-cloud/viewer/cloud-principal-display.ts
+++ b/apps/notebook-cloud/viewer/cloud-principal-display.ts
@@ -1,0 +1,15 @@
+/**
+ * Principal-display helpers shared by cloud viewer surfaces that must not show
+ * opaque subject identifiers before the user directory resolves a real name.
+ */
+
+// A principal subject that is only an identifier - a UUID, ULID, or long hex
+// room/subject id - has no human reading, so it must never be rendered as a
+// name. Resolving these to real display names is the cloud user store's job.
+export function cloudPrincipalSubjectIsOpaque(subject: string): boolean {
+  return (
+    /^[0-9a-f]{12,}$/iu.test(subject) ||
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(subject) ||
+    /^[0-9A-HJKMNP-TV-Z]{26}$/iu.test(subject)
+  );
+}

--- a/apps/notebook-cloud/viewer/cloud-stores-context.ts
+++ b/apps/notebook-cloud/viewer/cloud-stores-context.ts
@@ -1,6 +1,6 @@
 /**
- * Lazy consumption seam for the three non-auth cloud viewer source stores
- * (access-request, catalog, workstations).
+ * Lazy consumption seam for the four non-auth cloud viewer source stores
+ * (access-request, catalog, user directory, workstations).
  *
  * These stores stay module singletons; their route-level controllers activate
  * the instances they consume, not this seam. Auth has its own always-loaded
@@ -24,12 +24,14 @@ import {
   type CloudAccessRequestStore,
 } from "./cloud-access-request-store";
 import { cloudCatalogStore, type CloudCatalogStore } from "./cloud-catalog-store";
+import { cloudUserStore, type CloudUserStore } from "./cloud-user-store";
 import { cloudWorkstationsStore, type CloudWorkstationsStore } from "./cloud-workstations-store";
 
-/** The three non-auth cloud viewer source stores a subtree consumes. */
+/** The non-auth cloud viewer source stores a subtree consumes. */
 export interface CloudStores {
   accessRequest: CloudAccessRequestStore;
   catalog: CloudCatalogStore;
+  user: CloudUserStore;
   workstations: CloudWorkstationsStore;
 }
 
@@ -40,6 +42,7 @@ export interface CloudStores {
 const singletonCloudStores: CloudStores = {
   accessRequest: cloudAccessRequestStore,
   catalog: cloudCatalogStore,
+  user: cloudUserStore,
   workstations: cloudWorkstationsStore,
 };
 

--- a/apps/notebook-cloud/viewer/cloud-user-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-user-store.ts
@@ -1,0 +1,561 @@
+/**
+ * Cloud viewer user store: the single owner of the principal-keyed display
+ * directory used to resolve notebook actor labels to names and avatars. The
+ * cache is keyed by principal rather than notebook so switching notebooks can
+ * retain known identities while each backfill still uses the current
+ * notebook-scoped, relationship-gated author-profiles endpoint.
+ *
+ * The store is a module-level source store because presence, comments,
+ * dashboard, and shell surfaces must converge on one identity cache instead of
+ * rebuilding peer directories per component. React reads the narrow domain hook;
+ * the store owns precedence, never-demote merging, presence/self seeding, and
+ * async stale-write guards.
+ *
+ * The drivers live behind `activate(inputs$, deps)` and `connectPresence(...)`.
+ * Network operations and any future timers are injectable, so the whole store is
+ * virtual-time-total and node-testable without a browser.
+ */
+
+import { Subscription, type Observable, type SchedulerLike } from "rxjs";
+import {
+  ObservableStore,
+  notebookActorProjectionFromLabel,
+  resolveActorDisplay,
+  type ActorDisplay,
+} from "runtimed";
+import type { ActorDisplayPeer } from "runtimed";
+import {
+  COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE,
+  commentAuthorProfilesUrl,
+} from "./comment-author-profiles";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import type { CloudViewerPresenceState, CloudViewerPresenceStore } from "./presence";
+
+export interface CloudResolvedProfile {
+  principal: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  source: "self" | "presence" | "profile" | "unresolved";
+}
+
+export interface CloudUserDirectoryState {
+  profiles: ReadonlyMap<string, CloudResolvedProfile>;
+}
+
+export interface CloudUserStoreInputs {
+  /** Browser auth identity; signed-out transitions invalidate cached identity. */
+  auth: CloudPrototypeAuthState;
+  /** Notebook-scoped author-profiles endpoint; null on routes with no notebook. */
+  authorProfilesEndpoint: string | null;
+}
+
+export interface CloudUserStoreDeps {
+  scheduler?: SchedulerLike;
+  now?: () => number;
+  fetchProfiles?: (url: string, signal?: AbortSignal) => Promise<Response>;
+}
+
+interface ResolvedCloudUserStoreDeps {
+  fetchProfiles: NonNullable<CloudUserStoreDeps["fetchProfiles"]>;
+}
+
+interface BackfillIssue {
+  epoch: number;
+  endpoint: string;
+}
+
+interface ParsedProfileEntry {
+  principal: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  resolved: boolean;
+}
+
+const EMPTY_STATE: CloudUserDirectoryState = {
+  profiles: new Map(),
+};
+
+const SOURCE_RANK: Record<CloudResolvedProfile["source"], number> = {
+  profile: 3,
+  self: 2,
+  presence: 1,
+  unresolved: 0,
+};
+
+function defaultFetchProfiles(url: string, signal?: AbortSignal): Promise<Response> {
+  if (typeof fetch !== "function") {
+    return Promise.reject(new Error("fetch is unavailable"));
+  }
+  return fetch(url, { signal });
+}
+
+function profileEquals(a: CloudResolvedProfile, b: CloudResolvedProfile): boolean {
+  return (
+    a === b ||
+    (a.principal === b.principal &&
+      a.displayName === b.displayName &&
+      a.avatarUrl === b.avatarUrl &&
+      a.source === b.source)
+  );
+}
+
+function principalFromActorLabel(actorLabel: string | null | undefined): string | null {
+  const trimmed = actorLabel?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return notebookActorProjectionFromLabel(trimmed, {
+      source: "cloud",
+      isPublic: trimmed.startsWith("anonymous:"),
+    }).principal.id;
+  } catch {
+    return null;
+  }
+}
+
+function authDisplayName(auth: CloudPrototypeAuthState): string | null {
+  const claimName = auth.oidcClaims?.name?.trim();
+  if (claimName) {
+    return claimName;
+  }
+  const claimEmail = auth.oidcClaims?.email?.trim();
+  if (claimEmail) {
+    return claimEmail;
+  }
+  const user = auth.user?.trim();
+  return user || null;
+}
+
+function authAvatarUrl(auth: CloudPrototypeAuthState): string | null {
+  return auth.oidcClaims?.picture?.trim() || null;
+}
+
+function signedOut(auth: CloudPrototypeAuthState): boolean {
+  // `oidc_expired` is mid-renewal: the principal is unchanged and instant paint
+  // keeps rendering, so cached identities stay. Only a genuine identity loss
+  // (anonymous, invalid) clears the directory.
+  return auth.mode === "anonymous" || auth.mode === "invalid";
+}
+
+function usablePrincipal(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function usableLabel(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || genericPresenceLabel(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function genericPresenceLabel(label: string): boolean {
+  switch (label) {
+    case "Anonymous":
+    case "Peer":
+    case "Public viewer":
+    case "Unknown viewer":
+    case "User":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function profileFromEntry(entry: ParsedProfileEntry): CloudResolvedProfile {
+  return {
+    principal: entry.principal,
+    displayName: entry.resolved ? entry.displayName : null,
+    avatarUrl: entry.resolved ? entry.avatarUrl : null,
+    source: entry.resolved ? "profile" : "unresolved",
+  };
+}
+
+function parseProfileEntry(value: unknown): ParsedProfileEntry | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const entry = value as {
+    principal?: unknown;
+    label?: unknown;
+    image_url?: unknown;
+    resolved?: unknown;
+  };
+  if (typeof entry.principal !== "string" || entry.principal.trim().length === 0) {
+    return null;
+  }
+  if (typeof entry.resolved !== "boolean") {
+    return null;
+  }
+  if (entry.label !== null && typeof entry.label !== "string") {
+    return null;
+  }
+  if (
+    entry.image_url !== undefined &&
+    entry.image_url !== null &&
+    typeof entry.image_url !== "string"
+  ) {
+    return null;
+  }
+  return {
+    principal: entry.principal.trim(),
+    displayName: entry.label?.trim() || null,
+    avatarUrl: typeof entry.image_url === "string" ? entry.image_url.trim() || null : null,
+    resolved: entry.resolved,
+  };
+}
+
+function parseProfilesResponse(value: unknown): ParsedProfileEntry[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  const profiles = (value as { profiles?: unknown }).profiles;
+  if (!Array.isArray(profiles)) {
+    return [];
+  }
+  return profiles.map(parseProfileEntry).filter((entry): entry is ParsedProfileEntry => !!entry);
+}
+
+export class CloudUserStore extends ObservableStore<CloudUserDirectoryState> {
+  /** Principal-keyed profile directory. */
+  readonly profiles$: Observable<ReadonlyMap<string, CloudResolvedProfile>>;
+
+  private latestInputs: CloudUserStoreInputs | null = null;
+  private resolvedDeps: ResolvedCloudUserStoreDeps | null = null;
+  /**
+   * Monotonic activation counter, bumped on every `activate`, its disposer, and
+   * the signed-out gate. Backfill requests capture the epoch at issue time so a
+   * completion that lands after teardown or identity loss cannot write profiles
+   * into the current mount.
+   */
+  private activationEpoch = 0;
+  private lastSignedOut: boolean | null = null;
+  private lastEndpoint: string | null = null;
+  private readonly inFlight = new Map<string, symbol>();
+  /**
+   * Principals the current endpoint answered "unresolved" for (or omitted).
+   * Blocks refetch loops for presence-named principals that keep their seeded
+   * entry, without demoting it. Endpoint-scoped: a different notebook is a
+   * different relationship and may resolve what this one could not.
+   */
+  private readonly backfillMisses = new Set<string>();
+
+  constructor() {
+    super(EMPTY_STATE);
+    this.profiles$ = this.select((state) => state.profiles);
+  }
+
+  profileFor$(principal: string): Observable<CloudResolvedProfile | undefined> {
+    return this.select((state) => state.profiles.get(principal), Object.is);
+  }
+
+  /**
+   * Start the user-store input driver and return a disposer. State is not reset
+   * on activation because the cache is principal-keyed and intentionally
+   * survives notebook route swaps; sign-out is the identity boundary that clears
+   * it.
+   */
+  activate(inputs$: Observable<CloudUserStoreInputs>, deps: CloudUserStoreDeps = {}): () => void {
+    const epoch = (this.activationEpoch += 1);
+    const resolved = this.resolveDeps(deps);
+    this.resolvedDeps = resolved;
+    const subscription = new Subscription();
+
+    subscription.add(
+      inputs$.subscribe((inputs) => {
+        this.latestInputs = inputs;
+        if (inputs.authorProfilesEndpoint !== this.lastEndpoint) {
+          // Unresolved is a per-relationship fact: a new notebook may resolve
+          // what the previous one could not, so misses reset while named
+          // profile/presence/self entries survive the route swap.
+          this.lastEndpoint = inputs.authorProfilesEndpoint;
+          this.backfillMisses.clear();
+          this.dropUnresolvedEntries();
+        }
+        const isSignedOut = signedOut(inputs.auth);
+        if (isSignedOut && this.lastSignedOut !== true) {
+          // A signed-out transition invalidates every cached identity and every
+          // async completion issued under the signed-in epoch.
+          this.activationEpoch += 1;
+          this.inFlight.clear();
+          this.backfillMisses.clear();
+          this.resetState(EMPTY_STATE);
+        }
+        this.lastSignedOut = isSignedOut;
+      }),
+    );
+
+    return () => {
+      if (this.activationEpoch === epoch) {
+        this.activationEpoch += 1;
+      }
+      subscription.unsubscribe();
+      this.resolvedDeps = null;
+      this.latestInputs = null;
+      this.lastSignedOut = null;
+      this.lastEndpoint = null;
+      this.inFlight.clear();
+      this.backfillMisses.clear();
+    };
+  }
+
+  requestResolve(actorLabels: readonly string[]): void {
+    const endpoint = this.latestInputs?.authorProfilesEndpoint ?? null;
+    const deps = this.resolvedDeps;
+    if (!endpoint || !deps) {
+      return;
+    }
+
+    const byPrincipal = new Map<string, string>();
+    for (const actorLabel of actorLabels) {
+      const principal = principalFromActorLabel(actorLabel);
+      if (!principal) {
+        continue;
+      }
+      const cached = this.snapshot.profiles.get(principal);
+      // `profile` and `unresolved` mean the host answered; `backfillMisses`
+      // covers presence/self-named principals the endpoint declined to upgrade.
+      // Remaining presence/self seeds stay eligible so backfill can lift a
+      // roster name to the durable profile name and avatar.
+      if (cached?.source === "profile" || cached?.source === "unresolved") {
+        continue;
+      }
+      if (this.backfillMisses.has(principal) || this.inFlight.has(principal)) {
+        continue;
+      }
+      if (!byPrincipal.has(principal)) {
+        byPrincipal.set(principal, actorLabel);
+      }
+    }
+    if (byPrincipal.size === 0) {
+      return;
+    }
+
+    const queued = Array.from(byPrincipal, ([principal, actorLabel]) => ({
+      principal,
+      actorLabel,
+      token: Symbol(principal),
+    }));
+    for (const request of queued) {
+      this.inFlight.set(request.principal, request.token);
+    }
+
+    void this.resolveQueuedProfiles(endpoint, queued, deps);
+  }
+
+  connectPresence(
+    presenceStore: CloudViewerPresenceStore,
+    getAuthSnapshot: () => CloudPrototypeAuthState,
+  ): () => void {
+    const seed = () => this.seedFromPresence(presenceStore.getSnapshot(), getAuthSnapshot());
+    const unsubscribe = presenceStore.subscribe(seed);
+    seed();
+    return () => {
+      unsubscribe();
+    };
+  }
+
+  seedFromPresence(state: CloudViewerPresenceState, auth: CloudPrototypeAuthState): void {
+    for (const peer of state.peers) {
+      const principal = usablePrincipal(peer.participantKey);
+      const displayName = usableLabel(peer.label);
+      if (!principal || !displayName) {
+        continue;
+      }
+      this.mergeProfile({
+        principal,
+        displayName,
+        avatarUrl: null,
+        source: "presence",
+      });
+    }
+
+    const ownPrincipal = principalFromActorLabel(state.actorLabel);
+    if (!ownPrincipal) {
+      return;
+    }
+    const ownDisplayName = usableLabel(state.ownPeerLabel) ?? authDisplayName(auth);
+    const ownAvatarUrl = authAvatarUrl(auth);
+    if (!ownDisplayName && !ownAvatarUrl) {
+      return;
+    }
+    this.mergeProfile({
+      principal: ownPrincipal,
+      displayName: ownDisplayName,
+      avatarUrl: ownAvatarUrl,
+      source: "self",
+    });
+  }
+
+  resolve(actorLabel: string, source: "cloud" | "local" = "cloud"): ActorDisplay {
+    const principal = principalFromActorLabel(actorLabel);
+    const profile = principal ? this.snapshot.profiles.get(principal) : undefined;
+    const peers: ActorDisplayPeer[] =
+      profile && profile.displayName
+        ? [
+            {
+              participantKey: profile.principal,
+              label: profile.displayName,
+              imageUrl: profile.avatarUrl,
+            },
+          ]
+        : [];
+    return resolveActorDisplay({ actorLabel, peers, source });
+  }
+
+  private async resolveQueuedProfiles(
+    endpoint: string,
+    queued: readonly {
+      principal: string;
+      actorLabel: string;
+      token: symbol;
+    }[],
+    deps: ResolvedCloudUserStoreDeps,
+  ): Promise<void> {
+    for (let index = 0; index < queued.length; index += COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE) {
+      const batch = queued.slice(index, index + COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE);
+      await this.resolveProfileBatch(endpoint, batch, deps);
+    }
+  }
+
+  private async resolveProfileBatch(
+    endpoint: string,
+    batch: readonly {
+      principal: string;
+      actorLabel: string;
+      token: symbol;
+    }[],
+    deps: ResolvedCloudUserStoreDeps,
+  ): Promise<void> {
+    const issue = this.captureBackfillIssue(endpoint);
+    const controller = new AbortController();
+    try {
+      const url = commentAuthorProfilesUrl(
+        endpoint,
+        batch.map((request) => request.actorLabel),
+      );
+      const response = await deps.fetchProfiles(url, controller.signal);
+      if (!this.backfillStillCurrent(issue)) {
+        return;
+      }
+      if (!response.ok) {
+        return;
+      }
+      const parsed = parseProfilesResponse(await response.json());
+      if (!this.backfillStillCurrent(issue)) {
+        return;
+      }
+      this.applyBackfillBatch(batch, parsed);
+    } catch {
+      return;
+    } finally {
+      controller.abort();
+      for (const request of batch) {
+        if (this.inFlight.get(request.principal) === request.token) {
+          this.inFlight.delete(request.principal);
+        }
+      }
+    }
+  }
+
+  private applyBackfillBatch(
+    batch: readonly {
+      principal: string;
+      actorLabel: string;
+      token: symbol;
+    }[],
+    entries: readonly ParsedProfileEntry[],
+  ): void {
+    const requestedPrincipals = new Set(batch.map((request) => request.principal));
+    const seenPrincipals = new Set<string>();
+    for (const entry of entries) {
+      if (!requestedPrincipals.has(entry.principal)) {
+        continue;
+      }
+      seenPrincipals.add(entry.principal);
+      if (!entry.resolved) {
+        this.backfillMisses.add(entry.principal);
+      }
+      this.mergeProfile(profileFromEntry(entry));
+    }
+
+    for (const principal of requestedPrincipals) {
+      if (seenPrincipals.has(principal)) {
+        continue;
+      }
+      // The relationship gate omits principals it will not resolve; cache that
+      // miss so repeated surfaces do not refetch the same denied principal.
+      this.backfillMisses.add(principal);
+      this.mergeProfile({
+        principal,
+        displayName: null,
+        avatarUrl: null,
+        source: "unresolved",
+      });
+    }
+  }
+
+  /** Route-swap cleanup: unresolved entries belong to the endpoint that said so. */
+  private dropUnresolvedEntries(): void {
+    const entries = Array.from(this.snapshot.profiles).filter(
+      ([, profile]) => profile.source !== "unresolved",
+    );
+    if (entries.length === this.snapshot.profiles.size) {
+      return;
+    }
+    this.setState({ profiles: new Map(entries) });
+  }
+
+  private captureBackfillIssue(endpoint: string): BackfillIssue {
+    return { epoch: this.activationEpoch, endpoint };
+  }
+
+  private backfillStillCurrent(issue: BackfillIssue): boolean {
+    // A backfill response belongs only to the endpoint and epoch it was issued under.
+    return (
+      this.activationEpoch === issue.epoch &&
+      this.latestInputs?.authorProfilesEndpoint === issue.endpoint
+    );
+  }
+
+  /**
+   * Apply source precedence and the never-demote invariant from the ADR:
+   * absence of a fresh answer is not evidence the name is gone. A higher-rank
+   * source takes over the entry, but its null fields are backfilled from the
+   * existing entry so a profile row with no avatar cannot erase the avatar a
+   * self/presence seed already knew.
+   */
+  private mergeProfile(next: CloudResolvedProfile): void {
+    const existing = this.snapshot.profiles.get(next.principal);
+    if (existing) {
+      if (next.source === "unresolved" || SOURCE_RANK[next.source] < SOURCE_RANK[existing.source]) {
+        return;
+      }
+      next = {
+        ...next,
+        displayName: next.displayName ?? existing.displayName,
+        avatarUrl: next.avatarUrl ?? existing.avatarUrl,
+      };
+      if (profileEquals(existing, next)) {
+        return;
+      }
+    }
+    const profiles = new Map(this.snapshot.profiles);
+    profiles.set(next.principal, next);
+    this.setState({ profiles });
+  }
+
+  private resolveDeps(deps: CloudUserStoreDeps): ResolvedCloudUserStoreDeps {
+    return {
+      fetchProfiles: deps.fetchProfiles ?? defaultFetchProfiles,
+    };
+  }
+}
+
+/**
+ * The app-wide user directory store. Route controllers activate it; domain
+ * hooks consume it through `useCloudStores()`.
+ */
+export const cloudUserStore = new CloudUserStore();

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -26,6 +26,8 @@ export interface CloudNotebookListResponse {
   notebooks: CloudNotebookListItem[];
   /** Requester's unified-profile display name, when the store has one. */
   current_user_display?: string;
+  /** Requester's unified-profile avatar URL, when the store has one. */
+  current_user_avatar?: string;
 }
 
 export interface CloudNotebookListBootstrap {

--- a/apps/notebook-cloud/viewer/comment-author-profiles.ts
+++ b/apps/notebook-cloud/viewer/comment-author-profiles.ts
@@ -1,16 +1,11 @@
-import type { ActorDisplayPeer } from "runtimed";
+/**
+ * Comment-author batch helpers for the cloud user store.
+ *
+ * Comments still supply actor-label sets, and the store uses the notebook-scoped
+ * author-profiles endpoint to backfill display names and avatars in batches.
+ */
+
 import type { CommentsProjection } from "@/components/notebook";
-
-export interface CloudCommentAuthorProfile {
-  principal: string;
-  label: string;
-  image_url?: string | null;
-}
-
-export interface CloudCommentAuthorProfilesResponse {
-  notebook_id?: string;
-  profiles?: unknown;
-}
 
 export const COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE = 100;
 
@@ -57,77 +52,7 @@ export function commentAuthorProfileUrls(
   return urls;
 }
 
-export function commentAuthorProfilePeers(
-  response: CloudCommentAuthorProfilesResponse,
-): ActorDisplayPeer[] {
-  if (!Array.isArray(response.profiles)) return [];
-
-  const peers: ActorDisplayPeer[] = [];
-  for (const profile of response.profiles) {
-    if (!isCloudCommentAuthorProfile(profile)) continue;
-    peers.push({
-      participantKey: profile.principal,
-      label: profile.label,
-      imageUrl: profile.image_url ?? null,
-    });
-  }
-  return peers;
-}
-
-export function mergeCommentAuthorPeers(
-  profilePeers: readonly ActorDisplayPeer[],
-  presencePeers: readonly ActorDisplayPeer[],
-): ActorDisplayPeer[] {
-  const merged = new Map<string, ActorDisplayPeer>();
-  for (const peer of profilePeers) {
-    if (usableAuthorPeer(peer)) {
-      merged.set(peer.participantKey, peer);
-    }
-  }
-
-  for (const peer of presencePeers) {
-    if (!usableAuthorPeer(peer)) continue;
-    const existing = merged.get(peer.participantKey);
-    if (!existing || !isGenericAuthorLabel(peer.label)) {
-      merged.set(peer.participantKey, peer);
-    }
-  }
-
-  return Array.from(merged.values());
-}
-
 function addActorLabel(labels: Set<string>, value: string | null | undefined): void {
   const trimmed = value?.trim();
   if (trimmed) labels.add(trimmed);
-}
-
-function isCloudCommentAuthorProfile(value: unknown): value is CloudCommentAuthorProfile {
-  if (!value || typeof value !== "object") return false;
-  const profile = value as Partial<CloudCommentAuthorProfile>;
-  return (
-    typeof profile.principal === "string" &&
-    profile.principal.trim().length > 0 &&
-    typeof profile.label === "string" &&
-    profile.label.trim().length > 0 &&
-    (profile.image_url === undefined ||
-      profile.image_url === null ||
-      typeof profile.image_url === "string")
-  );
-}
-
-function usableAuthorPeer(peer: ActorDisplayPeer): boolean {
-  return peer.participantKey.trim().length > 0 && peer.label.trim().length > 0;
-}
-
-function isGenericAuthorLabel(label: string): boolean {
-  switch (label.trim()) {
-    case "Anaconda user":
-    case "OIDC user":
-    case "User":
-    case "Peer":
-    case "Unknown viewer":
-      return true;
-    default:
-      return false;
-  }
 }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1187,6 +1187,13 @@ body {
   font-size: 8px;
 }
 
+.nb-avatar-img {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+}
+
 .nb-scope-badge {
   padding: 1px 7px;
   color: var(--muted-foreground);

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -1,4 +1,5 @@
 import { cloudNotebookUrlWithMode, type CloudNotebookUrlMode } from "./cloud-notebook-mode";
+import { cloudPrincipalSubjectIsOpaque } from "./cloud-principal-display";
 import {
   colorForActorIdentity,
   contrastColorForActorIdentity,
@@ -856,19 +857,6 @@ function isNonNegativeFiniteNumber(value: unknown): value is number {
 // Shown when an owner principal has no resolvable human name, in place of the
 // raw identifier.
 const CLOUD_NOTEBOOK_OWNER_FALLBACK = "Notebook owner";
-
-// A principal subject that is only an identifier - a UUID, ULID, or long hex
-// room/subject id - has no human reading, so it must never be rendered as a
-// name. Resolving these to real display names is the cloud user store's job
-// (docs/adr/cloud-user-store.md); this is the never-raw floor for the /n owner
-// column until that lands.
-function cloudPrincipalSubjectIsOpaque(subject: string): boolean {
-  return (
-    /^[0-9a-f]{12,}$/iu.test(subject) ||
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(subject) ||
-    /^[0-9A-HJKMNP-TV-Z]{26}$/iu.test(subject)
-  );
-}
 
 function cloudNotebookOwnerLabel(principal: string): string {
   const trimmed = principal.trim();

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -847,17 +847,37 @@ function isNonNegativeFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
+// Shown when an owner principal has no resolvable human name, in place of the
+// raw identifier.
+const CLOUD_NOTEBOOK_OWNER_FALLBACK = "Notebook owner";
+
+// A principal subject that is only an identifier - a UUID, ULID, or long hex
+// room/subject id - has no human reading, so it must never be rendered as a
+// name. Resolving these to real display names is the cloud user store's job
+// (docs/adr/cloud-user-store.md); this is the never-raw floor for the /n owner
+// column until that lands.
+function cloudPrincipalSubjectIsOpaque(subject: string): boolean {
+  return (
+    /^[0-9a-f]{12,}$/iu.test(subject) ||
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(subject) ||
+    /^[0-9A-HJKMNP-TV-Z]{26}$/iu.test(subject)
+  );
+}
+
 function cloudNotebookOwnerLabel(principal: string): string {
   const trimmed = principal.trim();
   if (!trimmed) {
-    return "Unknown";
+    return CLOUD_NOTEBOOK_OWNER_FALLBACK;
   }
   const emailLocal = trimmed.match(/([^:@\s]+)@[^@\s]+$/u)?.[1];
   if (emailLocal) {
     return emailLocal;
   }
-  const parts = trimmed.split(":").filter(Boolean);
-  return parts.at(-1) ?? trimmed;
+  const subject = trimmed.split(":").filter(Boolean).at(-1) ?? trimmed;
+  if (cloudPrincipalSubjectIsOpaque(subject)) {
+    return CLOUD_NOTEBOOK_OWNER_FALLBACK;
+  }
+  return subject;
 }
 
 function cloudNotebookOwnerInitials(label: string): string {

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -16,6 +16,8 @@ export interface CloudNotebookListItem {
   updated_at: string;
   latest_revision_id: string | null;
   owner_display?: string;
+  owner_avatar?: string;
+  owner_resolved?: boolean;
   compute_session?: NotebookComputeSessionSummary | null;
   composition?: CloudNotebookComposition;
   cover?: CloudNotebookCover;
@@ -119,6 +121,7 @@ export interface CloudNotebookDashboardRow {
   notebook: CloudNotebookListItem;
   ownerColor: string;
   ownerContrast: string;
+  ownerAvatar?: string;
   ownerInitials: string;
   ownerLabel: string;
   runtimeStatus: CloudNotebookDashboardRuntimeStatus;
@@ -328,6 +331,8 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
     (candidate.preview === undefined || isCloudNotebookPreviewCells(candidate.preview)) &&
     (candidate.language === undefined || typeof candidate.language === "string") &&
     (candidate.owner_display === undefined || typeof candidate.owner_display === "string") &&
+    (candidate.owner_avatar === undefined || typeof candidate.owner_avatar === "string") &&
+    (candidate.owner_resolved === undefined || typeof candidate.owner_resolved === "boolean") &&
     (candidate.peers === undefined ||
       (Array.isArray(candidate.peers) && candidate.peers.every(isCloudNotebookPresencePeer))) &&
     typeof candidate.viewer_url === "string" &&
@@ -734,6 +739,7 @@ function dashboardRow(notebook: CloudNotebookListItem | null): CloudNotebookDash
     notebook,
     ownerColor: colorForActorIdentity(notebook.owner_principal),
     ownerContrast: contrastColorForActorIdentity(notebook.owner_principal),
+    ...(notebook.owner_avatar?.trim() ? { ownerAvatar: notebook.owner_avatar.trim() } : {}),
     ownerInitials: cloudNotebookOwnerInitials(ownerDisplaySource),
     ownerLabel,
     runtimeStatus: cloudNotebookDashboardRuntimeStatus(notebook),

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -159,6 +159,11 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         if (typeof body.current_user_display === "string" && body.current_user_display.trim()) {
           setCurrentUserDisplay(body.current_user_display.trim());
         }
+        setCurrentUserAvatar(
+          typeof body.current_user_avatar === "string" && body.current_user_avatar.trim()
+            ? body.current_user_avatar.trim()
+            : null,
+        );
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -347,6 +352,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
 
   const headerDetail = cloudNotebookListHeaderDetail(authState, hasAppSession, authConfig);
   const [currentUserDisplay, setCurrentUserDisplay] = useState<string | null>(null);
+  const [currentUserAvatar, setCurrentUserAvatar] = useState<string | null>(null);
   // Prefer the unified user store's display name (delivered with the list
   // response) over auth-claim parsing for the header identity.
   const currentUserInitials = currentUserDisplay
@@ -410,14 +416,24 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
                 <span
                   className="nb-avatar-me"
                   style={
-                    {
-                      "--nb-avatar-bg": colorForActorIdentity(currentUserColorKey),
-                      "--nb-avatar-fg": contrastColorForActorIdentity(currentUserColorKey),
-                    } as CSSProperties
+                    currentUserAvatar
+                      ? undefined
+                      : ({
+                          "--nb-avatar-bg": colorForActorIdentity(currentUserColorKey),
+                          "--nb-avatar-fg": contrastColorForActorIdentity(currentUserColorKey),
+                        } as CSSProperties)
                   }
                   title={currentUserDisplay ?? headerDetail}
                 >
-                  {currentUserInitials}
+                  {currentUserAvatar ? (
+                    <img
+                      className="nb-avatar-img"
+                      src={currentUserAvatar}
+                      alt={currentUserDisplay ?? headerDetail}
+                    />
+                  ) : (
+                    currentUserInitials
+                  )}
                 </span>
               </div>
             </>

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -68,10 +68,9 @@ import {
   colorForActorIdentity,
   contrastColorForActorIdentity,
   NotebookClient,
-  resolveActorDisplay,
   workstationAttachmentCanExecute,
   workstationAttachmentIsConnected,
-  type ActorDisplayPeer,
+  type ActorDisplay,
   type CellChangeset,
   type NotebookOutlineItem,
   type SyncEngineLogger,
@@ -116,13 +115,7 @@ import { beginOidcLogin } from "./oidc-auth";
 import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { cloudPresenceHasRuntimePeer, cloudPresenceRuntimePeerCount } from "./presence";
-import {
-  commentAuthorActorLabels,
-  commentAuthorProfilePeers,
-  commentAuthorProfileUrls,
-  mergeCommentAuthorPeers,
-  type CloudCommentAuthorProfilesResponse,
-} from "./comment-author-profiles";
+import { commentAuthorActorLabels } from "./comment-author-profiles";
 import type { ResolvedCell } from "./render-resolution";
 import {
   CloudNotebookNotices,
@@ -188,6 +181,7 @@ import {
   useCloudNotebookTitle,
   useCloudNotebookTitleError,
 } from "./use-cloud-catalog-store";
+import { useCloudUserProfiles, useCloudUserStoreController } from "./use-cloud-user-store";
 import { useCloudShellCapabilities } from "./use-cloud-shell-capabilities";
 import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { cloudSignInMethodForConfig, CloudNotebookSignInButton } from "./cloud-auth-controls";
@@ -210,6 +204,17 @@ const cloudNotebookClientLogger: SyncEngineLogger = {
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
 const CLOUD_EMPTY_ROOM_GRACE_MS = 900;
+
+function mapToCommentAuthor(display: ActorDisplay): CommentAuthor {
+  return {
+    displayName: display.displayName,
+    color: display.color,
+    imageUrl: display.imageUrl,
+    isAgent: display.isAgent,
+    onBehalfOf: display.onBehalfOf,
+    onBehalfOfColor: display.onBehalfOfColor,
+  };
+}
 
 function decodeHashAnchorId(hash: string): string {
   const raw = hash.startsWith("#") ? hash.slice(1) : hash;
@@ -247,7 +252,7 @@ export function NotebookViewer({
   // contexts (the singletons by default) so provider overrides route this
   // component to the same instances it reads and mutates.
   const auth = useCloudAuthStore();
-  const { accessRequest, catalog } = useCloudStores();
+  const { accessRequest, catalog, user } = useCloudStores();
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
   const [notebookTitleSaving, setNotebookTitleSaving] = useState(false);
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
@@ -346,6 +351,7 @@ export function NotebookViewer({
     loadCatalogAccess,
     initialCatalogAccess: config.initialCatalogAccess,
   });
+  useCloudUserStoreController(config.authorProfilesEndpoint ?? null);
   const catalogAccessFacts = useCloudCatalogAccessFacts();
   const catalogAccessScope = catalogAccessFacts.scope;
   const catalogAccessResolved = catalogAccessFacts.status === "ready";
@@ -446,6 +452,10 @@ export function NotebookViewer({
     resolveSyncAuth,
     widgetStore,
   });
+  useEffect(
+    () => user.connectPresence(presenceStore, () => auth.authSnapshot),
+    [auth, presenceStore, user],
+  );
   // Mirror the desktop app: expose the local author's comment color and a
   // legible foreground as CSS vars the shared affordance and composer styles
   // read. The cloud viewer previously set neither, so cloud create surfaces fell
@@ -505,81 +515,25 @@ export function NotebookViewer({
     presenceStore.getSnapshot,
     presenceStore.getSnapshot,
   );
-  const liveCommentAuthorPeers = useMemo(
-    () =>
-      presenceSnapshot.peers.map((peer) => ({
-        participantKey: peer.participantKey,
-        label: peer.label,
-      })),
-    [presenceSnapshot.peers],
-  );
   const commentAuthorLabels = useMemo(
     () => commentAuthorActorLabels(commentsProjection),
     [commentsProjection],
   );
   const commentAuthorLabelsKey = commentAuthorLabels.join("\u0000");
-  const [profileCommentAuthorPeers, setProfileCommentAuthorPeers] = useState<ActorDisplayPeer[]>(
-    [],
-  );
+  const profilesSnapshot = useCloudUserProfiles();
   useEffect(() => {
-    const endpoint = config.authorProfilesEndpoint;
-    if (!endpoint || commentAuthorLabelsKey === "") {
-      setProfileCommentAuthorPeers([]);
+    if (commentAuthorLabelsKey === "") {
       return;
     }
-    const actorLabels = commentAuthorLabelsKey.split("\u0000");
-
-    const controller = new AbortController();
-    void (async () => {
-      try {
-        const peers: ActorDisplayPeer[] = [];
-        for (const url of commentAuthorProfileUrls(endpoint, actorLabels)) {
-          const response = await fetchWithCloudPrototypeAuth(
-            url,
-            { headers: { Accept: "application/json" }, signal: controller.signal },
-            browserApiAuthState,
-          );
-          if (controller.signal.aborted) return;
-          if (!response.ok) {
-            setProfileCommentAuthorPeers([]);
-            return;
-          }
-          const body = (await response.json()) as CloudCommentAuthorProfilesResponse;
-          if (controller.signal.aborted) return;
-          peers.push(...commentAuthorProfilePeers(body));
-        }
-        setProfileCommentAuthorPeers(peers);
-      } catch {
-        if (!controller.signal.aborted) {
-          setProfileCommentAuthorPeers([]);
-        }
-      }
-    })();
-
-    return () => controller.abort();
-  }, [browserApiAuthState, commentAuthorLabelsKey, config.authorProfilesEndpoint]);
-  const commentAuthorPeers = useMemo(
-    () => mergeCommentAuthorPeers(profileCommentAuthorPeers, liveCommentAuthorPeers),
-    [liveCommentAuthorPeers, profileCommentAuthorPeers],
-  );
+    user.requestResolve(commentAuthorLabels);
+  }, [commentAuthorLabels, commentAuthorLabelsKey, config.authorProfilesEndpoint, user]);
   const resolveCloudCommentAuthor = useCallback(
-    (actorLabel: string): CommentAuthor => {
-      const display = resolveActorDisplay({
-        actorLabel,
-        peers: commentAuthorPeers,
-        source: "cloud",
-      });
-
-      return {
-        displayName: display.displayName,
-        color: display.color,
-        imageUrl: display.imageUrl,
-        isAgent: display.isAgent,
-        onBehalfOf: display.onBehalfOf,
-        onBehalfOfColor: display.onBehalfOfColor,
-      };
-    },
-    [commentAuthorPeers],
+    (actorLabel: string): CommentAuthor => mapToCommentAuthor(user.resolve(actorLabel)),
+    [profilesSnapshot, user],
+  );
+  const resolveCloudPresenceActor = useCallback(
+    (actorLabel: string): ActorDisplay => user.resolve(actorLabel),
+    [profilesSnapshot, user],
   );
   const runtimeState = useRuntimeState();
   // Deduplicated shared projection — re-renders only when attachment facts
@@ -1643,7 +1597,11 @@ export function NotebookViewer({
       }
       utilityControls={
         notebookHeaderChrome.showPresenceStatus ? (
-          <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
+          <CloudPresenceStatus
+            connectionError={connectionError}
+            store={presenceStore}
+            resolveActor={resolveCloudPresenceActor}
+          />
         ) : null
       }
       authControls={

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -31,6 +31,7 @@ export interface CloudViewerPresenceDisplay {
 export interface CloudViewerPresencePeer {
   id: string;
   participantKey: string;
+  actorLabel?: string | null;
   label: string;
   connectionScope: ConnectionScope | null;
   kind: "self" | "peer" | "anonymous" | "runtime" | "unknown";
@@ -196,6 +197,7 @@ function cloudPresencePeerFromMessage({
   return {
     id: peerId,
     participantKey: cloudPresenceParticipantKey({ participantKey, actorLabel, peerId }),
+    actorLabel: actorLabel?.trim() || null,
     label,
     connectionScope: normalizedConnectionScope,
     kind: isRuntimePeer ? "runtime" : isAnonymous ? "anonymous" : kind === "self" ? "self" : "peer",

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -1,4 +1,5 @@
 import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "runtimed";
+import { cloudPrincipalSubjectIsOpaque } from "./cloud-principal-display";
 
 export type CloudShareScope = "viewer" | "editor" | "runtime_peer" | "owner";
 export type CloudShareInviteScope = "viewer" | "editor";
@@ -122,6 +123,7 @@ const SHARE_ACCESS_PROJECTION_CACHE = new Map<string, CloudShareAccessProjection
 const SHARE_ACCESS_ROW_CACHE_LIMIT = 512;
 const SHARE_ACCESS_ROWS_CACHE_LIMIT = 128;
 const SHARE_ACCESS_PROJECTION_CACHE_LIMIT = 128;
+const CLOUD_SHARE_PRINCIPAL_FALLBACK = "Collaborator";
 const CLOUD_NOTEBOOK_ACL_ROW_FIELDS = {
   notebook_id: true,
   subject_kind: true,
@@ -443,7 +445,7 @@ function detailForAcl(row: CloudNotebookAclRow): string {
       return displayEmail(email);
     }
     if (display.principal !== row.subject) {
-      return display.principal;
+      return titleForPrincipalSubject(display.principal);
     }
   }
   return detailForPrincipalSubject(row.subject);
@@ -457,10 +459,11 @@ function titleForAcl(row: CloudNotebookAclRow): string {
   if (row.display?.kind === "principal") {
     const email = row.display.email?.trim();
     if (email) return email;
-    if (row.display.principal !== row.subject) return row.display.principal;
+    if (row.display.principal !== row.subject)
+      return titleForPrincipalSubject(row.display.principal);
   }
 
-  return row.subject;
+  return titleForPrincipalSubject(row.subject);
 }
 
 function labelForAccessRequest(request: CloudNotebookAccessRequest): string {
@@ -475,9 +478,9 @@ function titleForAccessRequest(request: CloudNotebookAccessRequest): string {
   const email = request.display?.email?.trim();
   if (email) return email;
   if (request.display?.principal && request.display.principal !== request.requester_principal) {
-    return request.display.principal;
+    return titleForPrincipalSubject(request.display.principal);
   }
-  return request.requester_principal;
+  return titleForPrincipalSubject(request.requester_principal);
 }
 
 function displayEmail(value: string): string {
@@ -494,8 +497,7 @@ function displayEmail(value: string): string {
 }
 
 function labelForPrincipalSubject(subject: string): string {
-  const decoded = decodePrincipalTail(subject);
-  return decoded || subject;
+  return principalSubjectDisplay(subject, CLOUD_SHARE_PRINCIPAL_FALLBACK);
 }
 
 function detailForPrincipalSubject(subject: string): string {
@@ -505,7 +507,19 @@ function detailForPrincipalSubject(subject: string): string {
   if (subject.startsWith("user:anaconda:")) {
     return "Anaconda identity";
   }
-  return subject;
+  return principalSubjectDisplay(subject, CLOUD_SHARE_PRINCIPAL_FALLBACK);
+}
+
+function titleForPrincipalSubject(subject: string): string {
+  return principalSubjectDisplay(subject, CLOUD_SHARE_PRINCIPAL_FALLBACK);
+}
+
+function principalSubjectDisplay(subject: string, fallback: string): string {
+  const decoded = decodePrincipalTail(subject);
+  if (!decoded || cloudPrincipalSubjectIsOpaque(decoded)) {
+    return fallback;
+  }
+  return decoded;
 }
 
 function decodePrincipalTail(subject: string): string | null {

--- a/apps/notebook-cloud/viewer/use-cloud-user-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-user-store.ts
@@ -1,16 +1,36 @@
 /**
  * React boundary for the cloud user store.
  *
- * Views import `useResolvedActor` here, never the store's raw observables or the
- * generic binding. The hook subscribes to the resolved profile for one principal
- * and then asks the store's synchronous resolver to build the shared
- * `ActorDisplay`.
+ * Views import `useResolvedActor`, `useCloudUserProfiles`, and the controller
+ * here, never the store's raw observables or the generic binding. The hook
+ * subscribes to the resolved profile for one principal and then asks the
+ * store's synchronous resolver to build the shared `ActorDisplay`.
  */
 
-import { useMemo } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { BehaviorSubject } from "rxjs";
 import { notebookActorProjectionFromLabel, type ActorDisplay } from "runtimed";
 import { useObservableProjection } from "@/components/notebook/state/observable-binding";
 import { useCloudStores } from "./cloud-stores-context";
+import type { CloudResolvedProfile, CloudUserStoreInputs } from "./cloud-user-store";
+import { cloudBrowserApiAuthStateForFetch, fetchWithCloudPrototypeAuth } from "./collaborator-auth";
+import { useCloudAuthState } from "./use-cloud-auth-store";
+
+/**
+ * A `BehaviorSubject` re-pushed on every render. Seeded synchronously so the
+ * store's driver reads the current inputs the moment `activate` subscribes.
+ */
+function useLiveInputs<T>(value: T): BehaviorSubject<T> {
+  const subjectRef = useRef<BehaviorSubject<T> | null>(null);
+  if (subjectRef.current === null) {
+    subjectRef.current = new BehaviorSubject(value);
+  }
+  const subject = subjectRef.current;
+  useLayoutEffect(() => {
+    subject.next(value);
+  });
+  return subject;
+}
 
 function principalFromActorLabel(actorLabel: string): string {
   const trimmed = actorLabel.trim();
@@ -34,4 +54,37 @@ export function useResolvedActor(actorLabel: string): ActorDisplay {
   const profile$ = useMemo(() => user.profileFor$(principal), [principal, user]);
   void useObservableProjection(profile$);
   return user.resolve(actorLabel);
+}
+
+/** Principal-keyed user directory snapshot for surfaces that resolve many actors. */
+export function useCloudUserProfiles(): ReadonlyMap<string, CloudResolvedProfile> {
+  const { user } = useCloudStores();
+  return useObservableProjection(user.profiles$);
+}
+
+/** Wire the cloud user store to auth identity and the notebook-scoped resolver endpoint. */
+export function useCloudUserStoreController(authorProfilesEndpoint: string | null): void {
+  const { user } = useCloudStores();
+  const auth = useCloudAuthState();
+  const inputs$ = useLiveInputs<CloudUserStoreInputs>({
+    auth,
+    authorProfilesEndpoint,
+  });
+
+  useEffect(
+    () =>
+      user.activate(inputs$, {
+        // The resolver endpoint is viewer-gated, so backfill must carry the
+        // same credentials as every other browser API call. Auth is read at
+        // call time from the live inputs so a token refresh mid-session does
+        // not strand backfill on stale credentials.
+        fetchProfiles: (url, signal) =>
+          fetchWithCloudPrototypeAuth(
+            url,
+            { headers: { Accept: "application/json" }, signal },
+            cloudBrowserApiAuthStateForFetch(inputs$.getValue().auth),
+          ),
+      }),
+    [inputs$, user],
+  );
 }

--- a/apps/notebook-cloud/viewer/use-cloud-user-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-user-store.ts
@@ -1,0 +1,37 @@
+/**
+ * React boundary for the cloud user store.
+ *
+ * Views import `useResolvedActor` here, never the store's raw observables or the
+ * generic binding. The hook subscribes to the resolved profile for one principal
+ * and then asks the store's synchronous resolver to build the shared
+ * `ActorDisplay`.
+ */
+
+import { useMemo } from "react";
+import { notebookActorProjectionFromLabel, type ActorDisplay } from "runtimed";
+import { useObservableProjection } from "@/components/notebook/state/observable-binding";
+import { useCloudStores } from "./cloud-stores-context";
+
+function principalFromActorLabel(actorLabel: string): string {
+  const trimmed = actorLabel.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    return notebookActorProjectionFromLabel(trimmed, {
+      source: "cloud",
+      isPublic: trimmed.startsWith("anonymous:"),
+    }).principal.id;
+  } catch {
+    return "";
+  }
+}
+
+/** Resolve one actor label through the cloud user directory. */
+export function useResolvedActor(actorLabel: string): ActorDisplay {
+  const { user } = useCloudStores();
+  const principal = principalFromActorLabel(actorLabel);
+  const profile$ = useMemo(() => user.profileFor$(principal), [principal, user]);
+  void useObservableProjection(profile$);
+  return user.resolve(actorLabel);
+}


### PR DESCRIPTION
Implements `docs/adr/cloud-user-store.md`: one cached, subscribable resolver so every cloud surface — dashboard owners, comment authors, presence peers, and the viewer's own identity — resolves a principal to the same display, instead of the ad hoc per-surface fetch-merge-fallback that lets the `/n` dashboard leak raw principals like `b0204af7084b`.

**All four stages are in as ordered commits.** The Decision 3 relationship-gated resolver is the one piece flagged for a human security review before merge.

## Stages

- [x] **Stage 0 — never-raw floor.** The `/n` owner column no longer renders a raw principal: an opaque subject (UUID, ULID, long hex) degrades to a generic "Notebook owner" label; real subjects pass through.
- [x] **Stage 1 — server.** One shared `principal → {displayName, avatarUrl, resolved}` projector reused across the list, `/acl`, `/access-requests`, and author-profiles; OIDC `picture` avatar capture at auth time; `avatar_url` + a `resolved` flag on the `/api/n` list; the notebook-scoped resolver with its relationship gate.
- [x] **Stage 2 — the store.** `cloud-user-store.ts` (private RxJS source + `useSyncExternalStore`, mirroring `cloud-auth-store.ts`), seeded from self + presence, batched backfill from the resolver, activation-epoch stale-write guard, never-raw fallback policy.
- [x] **Stage 3 — converge.** Comments, presence, self-identity, `/n` owners, and the sharing UI read the store; the duplicated fetch-merge-fallback code and the two competing fallback formatters are deleted. Diagnostics and instant-paint principal matching stay on raw principals.

Design, boundaries, and the auth gate are in `docs/adr/cloud-user-store.md`.
