### PR TITLE
fix(outputs): improve traceback legibility

### DIFF
--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -570,11 +570,13 @@ const jsonOutputFixture = {
 
 const modelCodeCell = getElementsNotebookPrimaryCodeCell();
 const [modelFeatureLine, modelFitLine, modelPredictLine] = modelCodeCell.source.split("\n");
+const tracebackLongEvalue =
+  "feature matrix contains null values after the package loader expanded the training window; check the imputed columns before retrying the model run.";
 const tracebackOutputFixture = {
   ename: "ValueError",
-  evalue: "feature matrix contains null values",
+  evalue: tracebackLongEvalue,
   language: modelCodeCell.language ?? "python",
-  text: `ValueError: feature matrix contains null values
+  text: `ValueError: ${tracebackLongEvalue}
   at cell ${modelCodeCell.id} line 3`,
   execution: {
     execution_id: modelCodeCell.executionId ?? "execution-model-run",
@@ -593,6 +595,41 @@ const tracebackOutputFixture = {
         { lineno: 1, source: modelFeatureLine ?? "" },
         { lineno: 2, source: modelFitLine ?? "" },
         { lineno: 3, source: modelPredictLine ?? "", highlight: true },
+      ],
+    },
+    {
+      filename:
+        "/Users/local/Library/Caches/runt/inline-envs/fixture/lib/python3.13/site-packages/sklearn/pipeline.py",
+      lineno: 781,
+      name: "predict",
+      library: true,
+      lines: [
+        { lineno: 779, source: "Xt = transform.transform(Xt)" },
+        {
+          lineno: 780,
+          source: "with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1)):",
+        },
+        {
+          lineno: 781,
+          source: "    return self.steps[-1][1].predict(Xt, **params)",
+          highlight: true,
+        },
+      ],
+    },
+    {
+      filename:
+        "/Users/local/Library/Caches/runt/inline-envs/fixture/lib/python3.13/site-packages/sklearn/ensemble/_forest.py",
+      lineno: 1084,
+      name: "predict",
+      library: true,
+      lines: [
+        { lineno: 1082, source: "check_is_fitted(self)" },
+        { lineno: 1083, source: "X = self._validate_X_predict(X)" },
+        {
+          lineno: 1084,
+          source: "return self.classes_.take(np.argmax(proba, axis=1), axis=0)",
+          highlight: true,
+        },
       ],
     },
     {

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { classicTracebackToPayload, TracebackOutput } from "../traceback-output";
 
@@ -71,6 +71,41 @@ describe("TracebackOutput", () => {
     expect(container.textContent).toContain("g · line 5");
     expect(container.textContent).not.toContain("In[");
     expect(container.textContent).not.toContain("/var/folders/x/T/ipykernel_39879");
+  });
+
+  it("wraps long single-line exception values instead of truncating them", () => {
+    const longEvalue =
+      "FlashAttention2 has been toggled on, but it cannot be used due to the following error: the package flash_attn seems to be not installed. Please refer to the documentation to install Flash Attention 2.";
+
+    render(
+      <TracebackOutput
+        data={{
+          ...payload,
+          ename: "ImportError",
+          evalue: longEvalue,
+        }}
+        resolveExecutionTarget={resolveExecutionTarget}
+      />,
+    );
+
+    const message = screen.getByTestId("traceback-message");
+    expect(message).toHaveTextContent(longEvalue);
+    expect(message).toHaveClass("whitespace-pre-wrap");
+    expect(message).toHaveClass("break-words");
+    expect(message).not.toHaveClass("truncate");
+  });
+
+  it("renders traceback frames as a readable list instead of slash breadcrumbs", () => {
+    render(<TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTarget} />);
+
+    const frameList = screen.getByTestId("traceback-frame-list");
+    expect(frameList).toHaveClass("grid");
+    expect(frameList).not.toHaveClass("flex");
+
+    const frameButtons = within(frameList).getAllByRole("button");
+    expect(frameButtons).toHaveLength(2);
+    expect(frameButtons[0]).toHaveTextContent("1current cell · line 1");
+    expect(frameButtons[1]).toHaveTextContent("2g · line 5");
   });
 
   it("shortens displayed Python package paths", () => {

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -194,11 +194,12 @@ export function TracebackOutput({
   const frames = payload?.frames ?? [];
   const clusters = clusterFrames(frames);
   const language = payload?.language ?? "python";
-  // Inline `ename: evalue` on one line when the evalue fits. Multi-line
-  // evalues (pytest diffs, chained SQL errors) fall through to the
-  // two-line layout. Independent of frame count — a short evalue next
-  // to the ename reads better whether we show frames below or not.
-  const inlineEvalue = Boolean(payload?.evalue && !payload.evalue.includes("\n"));
+  // Inline `ename: evalue` only when the evalue is genuinely short.
+  // Long single-line errors from package loaders, HTTP clients, and model
+  // runtimes need wrapping space more than they need a compact header.
+  const inlineEvalue = Boolean(
+    payload?.evalue && !payload.evalue.includes("\n") && payload.evalue.length <= 96,
+  );
   const currentExecutionId = payload?.execution?.execution_id;
   const defaultSelectedFrame = preferredFrameIndex(clusters);
   const [selectedFrame, setSelectedFrame] = useState(defaultSelectedFrame);
@@ -246,7 +247,11 @@ export function TracebackOutput({
           <div className="space-y-1.5 px-1 pb-1">
             <ol
               aria-label="Traceback frames"
-              className="flex flex-wrap items-center gap-x-1 gap-y-1"
+              data-testid="traceback-frame-list"
+              className={cn(
+                "grid max-h-40 gap-0.5 overflow-y-auto rounded-sm bg-background/35 p-1",
+                "border border-destructive/10",
+              )}
             >
               {clusters.map((cluster, i) => (
                 <FrameStep
@@ -309,23 +314,38 @@ function Header({
   // disagree on edge cases.
   const canInline = inlineEvalue && Boolean(evalue);
   return (
-    <div className="flex items-center gap-2 px-1 py-1.5 font-mono">
-      <X aria-hidden="true" className="size-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
-      <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
+    <div className="flex items-start gap-2 px-1 py-1.5 font-mono">
+      <X
+        aria-hidden="true"
+        className="mt-0.5 size-3.5 shrink-0 text-destructive"
+        strokeWidth={2.5}
+      />
+      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
         {canInline ? (
           <>
             <span className="shrink-0 font-semibold text-destructive">{ename}</span>
             <span className="text-destructive/80">: </span>
-            <span className="min-w-0 truncate text-foreground/80">{evalue}</span>
+            <span
+              data-testid="traceback-message"
+              className="min-w-0 whitespace-pre-wrap break-words text-foreground/80"
+            >
+              {evalue}
+            </span>
           </>
         ) : (
           <>
             <div className="shrink-0 font-semibold text-destructive">{ename}</div>
-            {evalue && <div className="min-w-0 truncate text-foreground/80">{evalue}</div>}
+            {evalue && (
+              <div
+                data-testid="traceback-message"
+                className="w-full min-w-0 whitespace-pre-wrap break-words text-foreground/80"
+              >
+                {evalue}
+              </div>
+            )}
           </>
         )}
       </div>
-      <div className="hidden h-px min-w-0 basis-24 shrink grow-0 bg-destructive/10 sm:block" />
       <CopyButton payload={payload} resolveExecutionTarget={resolveExecutionTarget} />
     </div>
   );
@@ -482,30 +502,26 @@ function FrameStep({
   const { frame, count } = cluster;
   const location = sourceLocation(frame, currentExecutionId, resolveExecutionTarget);
   return (
-    <li className="flex min-w-0 items-center gap-1">
-      {index > 0 && (
-        <span aria-hidden="true" className="text-muted-foreground/30">
-          /
+    <li className="min-w-0 font-mono text-xs">
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          "grid w-full min-w-0 grid-cols-[2.25rem_minmax(0,1fr)] items-baseline gap-2",
+          "rounded-sm px-1.5 py-1 text-left transition-colors",
+          active
+            ? "bg-destructive/[0.075] text-destructive"
+            : "text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground",
+          frame.library && !active && "opacity-65",
+        )}
+        aria-current={active ? "step" : undefined}
+        aria-label={`Show source frame ${index + 1}`}
+      >
+        <span className="select-none text-right tabular-nums text-muted-foreground/55">
+          {index + 1}
         </span>
-      )}
-      <div className="group/frame flex min-w-0 items-center gap-1 font-mono text-xs">
-        <button
-          type="button"
-          onClick={onSelect}
-          className={cn(
-            "inline-flex min-w-0 items-baseline gap-1 rounded-sm px-1.5 py-0.5",
-            "transition-colors",
-            active
-              ? "text-destructive hover:bg-destructive/[0.035]"
-              : "border-transparent text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground",
-            frame.library && !active && "opacity-65",
-          )}
-          aria-current={active ? "step" : undefined}
-          aria-label={`Show source frame ${index + 1}`}
-        >
-          <FrameLabel location={location} line={frame.lineno} name={frame.name} count={count} />
-        </button>
-      </div>
+        <FrameLabel location={location} line={frame.lineno} name={frame.name} count={count} />
+      </button>
     </li>
   );
 }
@@ -631,7 +647,7 @@ function FrameLabel({
   const displayName = typeof name === "string" && name !== "<module>" ? name : undefined;
   const visibleLocation = notebookFramePathLabel(location, name);
   return (
-    <span className="min-w-0 truncate">
+    <span className="min-w-0 whitespace-normal break-words">
       <span className="font-medium">{visibleLocation}</span>
       <span className="text-muted-foreground/65"> · line {line}</span>
       {location.kind !== "notebook" && displayName && (


### PR DESCRIPTION
## Summary

- Wrap long traceback exception values instead of truncating them in the header.
- Replace the slash-separated traceback frame breadcrumb with a compact numbered frame list.
- Expand the Elements output renderer fixture so the traceback catalog covers long exception text and package frames.

## Verification

- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx`
- `vp check --fix src/components/outputs/traceback-output.tsx src/components/outputs/__tests__/traceback-output.test.tsx apps/elements/components/notebook-scenarios.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/elements build`
- `git diff --check`
- Playwright screenshot check against `/docs/output-renderers` at wide and narrow viewports

## Review

- `uv run pr-review doctor` passed for `amazon-bedrock/zai.glm-5` in `us-east-1`.
- `uv run pr-review https://github.com/nteract/nteract/pull/3924 --max-turns 120 --out .context/reviews/pr-3924.json` returned `verdict: clear` with no findings.
- GitHub CI passed.
