### PR TITLE
feat(cloud): bootstrap principal profiles at room connection

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -282,7 +282,7 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   },
   {
     match: routePath("/n/:notebookId/sync", { trailingSlash: "optional" }),
-    handler: (_match, request, env) => routeRoomSync(request, env),
+    handler: (_match, request, env, ctx) => routeRoomSync(request, env, ctx),
   },
   {
     match: routePath("/n/:notebookId/debug", { trailingSlash: "optional" }),
@@ -715,7 +715,7 @@ function assetKind(pathname: string): string {
   return "viewer_asset";
 }
 
-async function routeRoomSync(request: Request, env: Env): Promise<Response> {
+async function routeRoomSync(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
     return json({ error: "expected WebSocket upgrade" }, 426);
   }
@@ -733,22 +733,42 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   const appSessionIdentity = await appSessionIdentityFromWebSocketRequest(request, env);
   const identity =
     appSessionIdentity ??
-    (await authenticateRequestOrResponse(request, env, { allowWorkstationCredential: true }));
+    (await authenticateRequestOrResponse(request, env, {
+      allowWorkstationCredential: true,
+      syncProfile: false,
+    }));
   if (identity instanceof Response) {
     return identity;
   }
-  const authorizedIdentity = await authorizeIdentityOrResponse(
+  const roomAuthorizationOptions = {
+    allowViewerDowngrade: true,
+    allowLiveScopeDowngrade: true,
+  } satisfies AuthorizeNotebookAccessOptions;
+  let profileSyncedBeforeAuthorization = false;
+  let authorizedIdentity = await authorizeIdentityOrResponse(
     env,
     notebookId,
     identity,
     identity.scope,
-    {
-      allowViewerDowngrade: true,
-      allowLiveScopeDowngrade: true,
-    },
+    roomAuthorizationOptions,
   );
+  if (authorizedIdentity instanceof Response && authorizedIdentity.status === 403) {
+    await syncAuthenticatedProfile(env, identity);
+    profileSyncedBeforeAuthorization = true;
+    authorizedIdentity = await authorizeIdentityOrResponse(
+      env,
+      notebookId,
+      identity,
+      identity.scope,
+      roomAuthorizationOptions,
+    );
+  }
   if (authorizedIdentity instanceof Response) {
     return authorizedIdentity;
+  }
+
+  if (!profileSyncedBeforeAuthorization) {
+    ctx.waitUntil(syncAuthenticatedProfile(env, authorizedIdentity));
   }
 
   const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
@@ -4997,7 +5017,7 @@ async function safeEnsureCatalogSchema(env: Env, ctx: ExecutionContext): Promise
 async function authenticateRequestOrResponse(
   request: Request,
   env: Env,
-  options?: { allowWorkstationCredential?: boolean },
+  options?: { allowWorkstationCredential?: boolean; syncProfile?: boolean },
 ): Promise<AuthenticatedConnection | Response> {
   try {
     // Workstation credentials are least-privilege by allowlist: only the
@@ -5012,7 +5032,9 @@ async function authenticateRequestOrResponse(
       return await authenticateWorkstationCredentialRequest(env, request, workstationToken);
     }
     const identity = await authenticateRequestWithProviders(request, env);
-    await syncAuthenticatedProfile(env, identity);
+    if (options?.syncProfile !== false) {
+      await syncAuthenticatedProfile(env, identity);
+    }
     return identity;
   } catch (error) {
     if (error instanceof AuthError) {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -5441,6 +5441,7 @@ describe("Worker artifact routes", () => {
       },
       name: "Kyle Kelley",
     });
+    const waitUntilPromises: Promise<unknown>[] = [];
     const env = fakeEnv({
       ...oidcEnv,
       NOTEBOOK_ROOMS: {
@@ -5468,10 +5469,12 @@ describe("Worker artifact routes", () => {
         },
       }),
       env,
-      fakeContext(),
+      fakeContextWithWaitUntil(waitUntilPromises),
     );
 
     assert.equal(response.status, 200);
+    assert.equal(waitUntilPromises.length, 1);
+    await Promise.all(waitUntilPromises);
     const profile = env.DB.profiles.get("user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375");
     assert.equal(profile?.provider, "oidc");
     assert.equal(profile?.email_normalized, "kkelley@anaconda.com");
@@ -5487,6 +5490,7 @@ describe("Worker artifact routes", () => {
       extraPayload: { email_verified: true },
       name: "No Picture",
     });
+    const waitUntilPromises: Promise<unknown>[] = [];
     const env = fakeEnv({
       ...oidcEnv,
       NOTEBOOK_ROOMS: {
@@ -5517,13 +5521,81 @@ describe("Worker artifact routes", () => {
         },
       ),
       env,
-      fakeContext(),
+      fakeContextWithWaitUntil(waitUntilPromises),
     );
 
     assert.equal(response.status, 200);
+    assert.equal(waitUntilPromises.length, 1);
+    await Promise.all(waitUntilPromises);
     const profile = env.DB.profiles.get("user:anaconda:no-picture-user");
     assert.equal(profile?.provider, "oidc");
     assert.equal(profile?.avatar_url, null);
+  });
+
+  it("does not store room connection profiles for dev or anonymous viewers", async () => {
+    const devWaitUntilPromises: Promise<unknown>[] = [];
+    const devEnv = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => new Response("room ok"),
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(devEnv, "dev-profile-demo");
+    seedAcl(devEnv, {
+      notebookId: "dev-profile-demo",
+      subject: "user:dev:alice",
+      scope: "viewer",
+    });
+
+    const devResponse = await worker.fetch(
+      new Request(
+        "http://localhost/n/dev-profile-demo/sync?user=alice&operator=desktop:a&scope=viewer",
+        {
+          headers: {
+            Upgrade: "websocket",
+          },
+        },
+      ),
+      devEnv,
+      fakeContextWithWaitUntil(devWaitUntilPromises),
+    );
+
+    assert.equal(devResponse.status, 200);
+    await Promise.all(devWaitUntilPromises);
+    assert.equal(devEnv.DB.profiles.size, 0);
+
+    const anonymousWaitUntilPromises: Promise<unknown>[] = [];
+    const anonymousEnv = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => new Response("room ok"),
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(anonymousEnv, "anonymous-profile-demo");
+    seedAcl(anonymousEnv, {
+      notebookId: "anonymous-profile-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const anonymousResponse = await worker.fetch(
+      new Request("http://localhost/n/anonymous-profile-demo/sync?viewer_session=anon", {
+        headers: {
+          Upgrade: "websocket",
+        },
+      }),
+      anonymousEnv,
+      fakeContextWithWaitUntil(anonymousWaitUntilPromises),
+    );
+
+    assert.equal(anonymousResponse.status, 200);
+    await Promise.all(anonymousWaitUntilPromises);
+    assert.equal(anonymousEnv.DB.profiles.size, 0);
   });
 
   it("resolves pending email invites for OIDC editor WebSocket requests", async () => {


### PR DESCRIPTION
Closes #3925. Room connects already synced principal profiles, but blocking and inline, before authorization. This moves the provider-backed profile sync to `ctx.waitUntil` on the authorized room-connect path, so a D1 write can never delay room readiness, while keeping the blocking sync in exactly one place it is still load-bearing: a 403 gets one retry after sync, so a first-time invited user's pending email invite still resolves to an ACL before access is decided.

The existing gate is unchanged: `syncAuthenticatedProfile` / `upsertPrincipalProfileWithAccount`, providers `oidc` and `anaconda-api-key` only. New worker-route coverage: OIDC room connects store display name and avatar; dev and anonymous connects never write a row.

With #3923's capture-at-auth this lands the directory warm before first production deploy: every active collaborator gets a profile row on their next room connection.
