### PR TITLE
feat(cloud): local-first /n - sliding session renewal, principal-keyed cache, bounded gates

### DIFF
--- a/apps/notebook-cloud/src/app-session.ts
+++ b/apps/notebook-cloud/src/app-session.ts
@@ -59,6 +59,33 @@ export async function createCloudAppSessionCookie(
   return `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=${value}; Path=/; Max-Age=${NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS}; HttpOnly; Secure; SameSite=Lax`;
 }
 
+export async function appSessionRenewalCookie(
+  env: AppSessionEnvironment,
+  session: CloudAppSession | null | undefined,
+  nowSeconds = currentEpochSeconds(),
+): Promise<string | null> {
+  if (!session || session.expiresAt <= nowSeconds) {
+    return null;
+  }
+  const remainingSeconds = session.expiresAt - nowSeconds;
+  if (remainingSeconds >= NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS / 2) {
+    return null;
+  }
+
+  const payload: CloudAppSessionPayload = {
+    v: 1,
+    provider: "oidc",
+    principal: session.principal,
+    ns: session.principalNamespace,
+    iat: nowSeconds,
+    exp: nowSeconds + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
+    sid: crypto.randomUUID(),
+    ...(session.displayName ? { display_name: session.displayName } : {}),
+  };
+  const value = await signCloudAppSession(env, payload);
+  return `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=${value}; Path=/; Max-Age=${NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS}; HttpOnly; Secure; SameSite=Lax`;
+}
+
 export function clearCloudAppSessionCookie(): string {
   return `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1270,6 +1270,7 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
         roomPresence,
         principalDisplays,
       ),
+      current_user_principal: principal,
       ...(currentUserDisplay ? { current_user_display: currentUserDisplay } : {}),
       ...(currentUserAvatar ? { current_user_avatar: currentUserAvatar } : {}),
     }),

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -150,6 +150,7 @@ import {
   NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME,
   NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
   appSessionConfigured,
+  appSessionRenewalCookie,
   clearCloudAppSessionCookie,
   createCloudAppSessionCookie,
   readCloudAppSession,
@@ -1004,7 +1005,11 @@ function appSessionHealth(env: Env): { status: "configured" | "disabled" } {
 async function routeAppSession(request: Request, env: Env): Promise<Response> {
   if (request.method === "GET") {
     const session = appSessionConfigured(env) ? await readCloudAppSession(env, request) : null;
-    return json({ ok: true, session: session ? appSessionResponse(session) : null });
+    return withAppSessionRenewalCookie(
+      json({ ok: true, session: session ? appSessionResponse(session) : null }),
+      env,
+      session,
+    );
   }
 
   const originRejection = rejectUntrustedMutationOrigin(request, env);
@@ -1254,19 +1259,23 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
     (!isAnonymousViewer(identity) ? identity.metadata.avatarUrl?.trim() : undefined) ||
     currentUserProfile?.avatarUrl ||
     undefined;
-  return json({
-    ok: true,
-    notebooks: notebookListResponseRows(
-      request,
-      notebooks,
-      env,
-      computeSessions,
-      roomPresence,
-      principalDisplays,
-    ),
-    ...(currentUserDisplay ? { current_user_display: currentUserDisplay } : {}),
-    ...(currentUserAvatar ? { current_user_avatar: currentUserAvatar } : {}),
-  });
+  return withAppSessionRenewalCookie(
+    json({
+      ok: true,
+      notebooks: notebookListResponseRows(
+        request,
+        notebooks,
+        env,
+        computeSessions,
+        roomPresence,
+        principalDisplays,
+      ),
+      ...(currentUserDisplay ? { current_user_display: currentUserDisplay } : {}),
+      ...(currentUserAvatar ? { current_user_avatar: currentUserAvatar } : {}),
+    }),
+    env,
+    appSession,
+  );
 }
 
 // Owner name cards resolve through the unified user store (principal_profiles),
@@ -5415,9 +5424,13 @@ async function viewer(
     runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),
     runtimedWasmPath: runtimedWasmAssetPath(env, runtimeWasmAssets.wasm),
   };
-  return responseForRequestMethod(
-    request,
-    viewerShell(shellMetadata, env, authConfigForRequest(request, env), config),
+  return withAppSessionRenewalCookie(
+    responseForRequestMethod(
+      request,
+      viewerShell(shellMetadata, env, authConfigForRequest(request, env), config),
+    ),
+    env,
+    session,
   );
 }
 
@@ -5486,20 +5499,24 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
     return viewerShellHead(env);
   }
 
-  const bootstrap = await notebookListBootstrap(request, env);
-  return responseForRequestMethod(
-    request,
-    viewerShell(
-      {
-        title: "nteract cloud notebooks",
-        description: "Open, create, and manage hosted nteract notebooks.",
-      },
-      env,
-      authConfigForRequest(request, env),
-      null,
-      bootstrap,
-      null,
+  const { bootstrap, session } = await notebookListBootstrap(request, env);
+  return withAppSessionRenewalCookie(
+    responseForRequestMethod(
+      request,
+      viewerShell(
+        {
+          title: "nteract cloud notebooks",
+          description: "Open, create, and manage hosted nteract notebooks.",
+        },
+        env,
+        authConfigForRequest(request, env),
+        null,
+        bootstrap,
+        null,
+      ),
     ),
+    env,
+    session,
   );
 }
 
@@ -5706,13 +5723,13 @@ function viewerShell(
 async function notebookListBootstrap(
   request: Request,
   env: Env,
-): Promise<Record<string, unknown> | null> {
+): Promise<{ bootstrap: Record<string, unknown> | null; session: CloudAppSession | null }> {
   if (!env.DB) {
-    return null;
+    return { bootstrap: null, session: null };
   }
   const session = await readCloudAppSession(env, request);
   if (!session) {
-    return null;
+    return { bootstrap: null, session: null };
   }
   await syncStoredAppSessionProfile(env, session);
   const notebooks = await listNotebooksForPrincipal(
@@ -5726,11 +5743,26 @@ async function notebookListBootstrap(
   // authenticated /api/n fetch that follows carries both.
   const computeSessions = await listNotebookComputeSessionsForOwnedRows(env, notebooks);
   return {
-    kind: "notebook-list",
-    session: appSessionResponse(session),
-    notebooks: notebookListResponseRows(request, notebooks, env, computeSessions),
-    saved_at: new Date().toISOString(),
+    session,
+    bootstrap: {
+      kind: "notebook-list",
+      session: appSessionResponse(session),
+      notebooks: notebookListResponseRows(request, notebooks, env, computeSessions),
+      saved_at: new Date().toISOString(),
+    },
   };
+}
+
+async function withAppSessionRenewalCookie(
+  response: Response,
+  env: Env,
+  session: CloudAppSession | null | undefined,
+): Promise<Response> {
+  const renewalCookie = await appSessionRenewalCookie(env, session);
+  if (renewalCookie) {
+    response.headers.append("Set-Cookie", renewalCookie);
+  }
+  return response;
 }
 
 function viewerResourceHints(config: ViewerShellResourceHints | null): string {

--- a/apps/notebook-cloud/test/app-session.test.ts
+++ b/apps/notebook-cloud/test/app-session.test.ts
@@ -4,6 +4,7 @@ import {
   NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME,
   NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH,
   NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
+  appSessionRenewalCookie,
   clearCloudAppSessionCookie,
   createCloudAppSessionCookie,
   readCloudAppSession,
@@ -102,6 +103,81 @@ describe("cloud app session cookies", () => {
       headers: { Cookie: tampered },
     });
     assert.equal(await readCloudAppSession(env, tamperedRequest, 3_100), null);
+  });
+
+  it("renews a valid session past half its max age", async () => {
+    const env = { NOTEBOOK_CLOUD_APP_SESSION_SECRET: SESSION_SECRET };
+    const issuedAt = 4_000;
+    const renewalAt = issuedAt + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS / 2 + 1;
+    const cookie = await createCloudAppSessionCookie(env, oidcIdentity(), issuedAt);
+    const request = new Request("https://cloud.test/n", {
+      headers: { Cookie: cookie },
+    });
+    const session = await readCloudAppSession(env, request, renewalAt);
+
+    const renewedCookie = await appSessionRenewalCookie(env, session, renewalAt);
+
+    assert.match(renewedCookie ?? "", new RegExp(`^${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=`));
+    assert.match(
+      renewedCookie ?? "",
+      new RegExp(`Max-Age=${NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS}`),
+    );
+    const renewed = await readCloudAppSession(
+      env,
+      new Request("https://cloud.test/n", {
+        headers: { Cookie: renewedCookie ?? "" },
+      }),
+      renewalAt,
+    );
+    assert.equal(renewed?.principal, session?.principal);
+    assert.equal(renewed?.principalNamespace, session?.principalNamespace);
+    assert.equal(renewed?.displayName, session?.displayName);
+    assert.equal(renewed?.issuedAt, renewalAt);
+    assert.equal(renewed?.expiresAt, renewalAt + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS);
+  });
+
+  it("does not renew before half its max age", async () => {
+    const env = { NOTEBOOK_CLOUD_APP_SESSION_SECRET: SESSION_SECRET };
+    const issuedAt = 5_000;
+    const beforeHalfLife = issuedAt + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS / 2;
+    const cookie = await createCloudAppSessionCookie(env, oidcIdentity(), issuedAt);
+    const request = new Request("https://cloud.test/n", {
+      headers: { Cookie: cookie },
+    });
+    const session = await readCloudAppSession(env, request, beforeHalfLife);
+
+    assert.equal(await appSessionRenewalCookie(env, session, beforeHalfLife), null);
+  });
+
+  it("does not renew expired or invalid sessions", async () => {
+    const env = { NOTEBOOK_CLOUD_APP_SESSION_SECRET: SESSION_SECRET };
+    const issuedAt = 6_000;
+    const cookie = await createCloudAppSessionCookie(env, oidcIdentity(), issuedAt);
+    const expiredAt = issuedAt + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS + 1;
+    const expiredSession = await readCloudAppSession(
+      env,
+      new Request("https://cloud.test/n", {
+        headers: { Cookie: cookie },
+      }),
+      expiredAt,
+    );
+
+    const tampered = cookie.replace(
+      `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=`,
+      `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=x`,
+    );
+    const invalidSession = await readCloudAppSession(
+      env,
+      new Request("https://cloud.test/n", {
+        headers: { Cookie: tampered },
+      }),
+      issuedAt + 1,
+    );
+
+    assert.equal(expiredSession, null);
+    assert.equal(invalidSession, null);
+    assert.equal(await appSessionRenewalCookie(env, expiredSession, expiredAt), null);
+    assert.equal(await appSessionRenewalCookie(env, invalidSession, issuedAt + 1), null);
   });
 
   it("requires a configured signing secret and OIDC identity", async () => {

--- a/apps/notebook-cloud/test/notebook-list-cache.test.ts
+++ b/apps/notebook-cloud/test/notebook-list-cache.test.ts
@@ -2,68 +2,78 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
-  CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS,
   clearCachedCloudNotebookList,
   readCachedCloudNotebookList,
   writeCachedCloudNotebookList,
 } from "../viewer/notebook-list-cache";
+import type { CloudAppSession } from "../viewer/app-session";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
 
 describe("cloud notebook list cache", () => {
-  it("round-trips notebooks for the same browser identity", () => {
+  it("seeds notebooks for a matching OIDC principal", () => {
     const storage = new MemoryStorage();
-    const auth = oidcAuth("user-a");
+    const auth = oidcAuth("alice@example.test");
     const notebooks = [notebook("nb-a")];
 
-    writeCachedCloudNotebookList(storage, auth, null, notebooks, 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, notebooks, {
+      now: 1_000,
+      principal: "user:anaconda:alice%40example.test",
+    });
 
-    assert.deepEqual(readCachedCloudNotebookList(storage, auth, null, 2_000), notebooks);
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, null), notebooks);
   });
 
-  it("does not reuse cached catalog rows for another identity", () => {
+  it("refuses cached rows from a mismatched principal", () => {
     const storage = new MemoryStorage();
-    writeCachedCloudNotebookList(storage, oidcAuth("user-a"), null, [notebook("nb-a")], 1_000);
-
-    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-b"), null, 2_000), null);
-  });
-
-  it("prefers the app session cache key over local OIDC claims", () => {
-    const storage = new MemoryStorage();
-    const notebooks = [notebook("nb-a")];
-
     writeCachedCloudNotebookList(
       storage,
-      oidcAuth("user-a"),
-      appSession("session-a"),
-      notebooks,
-      1_000,
+      oidcAuth("alice@example.test"),
+      null,
+      [notebook("nb-a")],
+      {
+        now: 1_000,
+        principal: "user:anaconda:alice%40example.test",
+      },
     );
 
-    assert.deepEqual(
-      readCachedCloudNotebookList(storage, oidcAuth("user-b"), appSession("session-a"), 2_000),
-      notebooks,
-    );
-    assert.equal(
-      readCachedCloudNotebookList(storage, oidcAuth("user-a"), appSession("session-b"), 2_000),
-      null,
-    );
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("bob@example.test"), null), null);
   });
 
-  it("expires retained catalog rows", () => {
+  it("lets an expired OIDC token seed only when an app session backs the subject", () => {
     const storage = new MemoryStorage();
-    const auth = oidcAuth("user-a");
-    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], 1_000);
+    const auth = oidcExpiredAuth("alice@example.test");
+    const notebooks = [notebook("nb-a")];
 
-    assert.equal(
-      readCachedCloudNotebookList(
-        storage,
-        auth,
-        null,
-        1_000 + CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS + 1,
-      ),
-      null,
-    );
+    writeCachedCloudNotebookList(storage, auth, appSession(), notebooks, {
+      now: 1_000,
+      principal: "user:anaconda:alice%40example.test",
+    });
+
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, appSession()), notebooks);
+    assert.equal(readCachedCloudNotebookList(storage, auth, null), null);
+  });
+
+  it("clears retained rows on sign-out", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("alice@example.test");
+    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], {
+      now: 1_000,
+      principal: "user:anaconda:alice%40example.test",
+    });
+
+    clearCachedCloudNotebookList(storage);
+
+    assert.equal(readCachedCloudNotebookList(storage, auth, null), null);
+    assert.equal(storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY), null);
+  });
+
+  it("drops malformed JSON without throwing", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY, "{");
+
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("alice@example.test"), null), null);
+    assert.equal(storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY), null);
   });
 
   it("rejects malformed cached rows", () => {
@@ -71,23 +81,18 @@ describe("cloud notebook list cache", () => {
     storage.setItem(
       CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
       JSON.stringify({
-        authKey: "oidc:user-a",
-        savedAt: 1_000,
-        notebooks: [{ notebook_id: "nb-a" }],
+        entries: [
+          {
+            notebooks: [{ notebook_id: "nb-a" }],
+            principal: "user:anaconda:alice%40example.test",
+            savedAt: 1_000,
+          },
+        ],
+        v: 1,
       }),
     );
 
-    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-a"), null, 2_000), null);
-  });
-
-  it("clears retained catalog rows", () => {
-    const storage = new MemoryStorage();
-    const auth = oidcAuth("user-a");
-    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], 1_000);
-
-    clearCachedCloudNotebookList(storage);
-
-    assert.equal(readCachedCloudNotebookList(storage, auth, null, 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("alice@example.test"), null), null);
   });
 });
 
@@ -101,6 +106,13 @@ function oidcAuth(subject: string): CloudPrototypeAuthState {
     },
     requestedScope: "viewer",
     problem: null,
+  };
+}
+
+function oidcExpiredAuth(subject: string): CloudPrototypeAuthState {
+  return {
+    ...oidcAuth(subject),
+    mode: "oidc_expired",
   };
 }
 
@@ -122,11 +134,11 @@ function notebook(id: string): CloudNotebookListItem {
   };
 }
 
-function appSession(cacheKey: string) {
+function appSession(): CloudAppSession {
   return {
-    provider: "oidc" as const,
+    provider: "oidc",
     expires_at: 1_750_000_000,
-    cache_key: cacheKey,
+    cache_key: "cache-a",
   };
 }
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -804,13 +804,13 @@ test("cloud notebook list trusts server bootstrap on initial app-session paint",
   );
   assert.match(
     sourceText,
-    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToWindow\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap\.notebooks,[\s\S]*\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
+    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToLocalStorage\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap\.notebooks,[\s\S]*\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
     "fresh notebook-home bootstrap should satisfy the initial render without an immediate duplicate /api/n fetch",
   );
   assert.match(
     sourceText,
-    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromWindow\(authState, appSession\);/,
-    "server bootstrap should beat stale sessionStorage cache when both are present",
+    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromLocalStorage\(authState, appSession\);/,
+    "server bootstrap should beat stale localStorage cache when both are present",
   );
 });
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -780,16 +780,21 @@ test("cloud notebook list bounds app-session waits before catalog fetches", () =
 
   assert.match(
     sourceText,
-    /const \{[\s\S]*canFetchCatalog: canFetchNotebookList,[\s\S]*hasAppSession,[\s\S]*signedIn,[\s\S]*waitingForAppSession,[\s\S]*\} = hostedAuth;/,
+    /const \{[\s\S]*canFetchCatalog: cookieCanFetchNotebookList,[\s\S]*hasAppSession,[\s\S]*signedIn,[\s\S]*waitingForAppSession,[\s\S]*\} = hostedAuth;/,
   );
   assert.match(sourceText, /const hostedAuth = useHostedCatalogAuth\(\);/);
+  assert.match(
+    sourceText,
+    /const canFetchNotebookList =[\s\S]*cookieCanFetchNotebookList \|\|[\s\S]*cloudNotebookListCanUseExistingCredentials\(authState, appSessionStatus\.status\);/,
+    "bearer OIDC and still-loading app-session cookies should race the list fetch before the cookie exchange settles",
+  );
   assert.match(
     sourceText,
     /const appSessionWaitDeadline =[\s\S]*appSessionWaitDeadlineMs \?\? CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS;/,
   );
   assert.match(
     sourceText,
-    /if \(!canFetchNotebookList\) \{[\s\S]*if \(waitingForAppSession\) \{[\s\S]*window\.setTimeout\(\(\) => \{[\s\S]*loadNotebookList\(controller, " after app-session wait deadline"\);/,
+    /if \(!canFetchNotebookList\) \{[\s\S]*if \(waitingForAppSession\) \{[\s\S]*window\.setTimeout\([\s\S]*\(\) => \{[\s\S]*loadNotebookList\(controller, " after app-session wait deadline"\);/,
     "waiting for the trusted cookie must have a deadline fallback instead of an eternal skeleton",
   );
   assert.match(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -774,7 +774,7 @@ test("cloud notebook list refresh re-establishes app sessions before listing not
   );
 });
 
-test("cloud notebook list waits for app-session cookies before catalog fetches", () => {
+test("cloud notebook list bounds app-session waits before catalog fetches", () => {
   const sourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
@@ -785,12 +785,22 @@ test("cloud notebook list waits for app-session cookies before catalog fetches",
   assert.match(sourceText, /const hostedAuth = useHostedCatalogAuth\(\);/);
   assert.match(
     sourceText,
-    /if \(!canFetchNotebookList\) \{[\s\S]*if \(waitingForAppSession\) \{[\s\S]*\{ kind: "loading" \}[\s\S]*return;/,
+    /const appSessionWaitDeadline =[\s\S]*appSessionWaitDeadlineMs \?\? CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS;/,
   );
   assert.match(
     sourceText,
-    /fetchCloudNotebookList\(\s*authState,\s*AbortSignal\.any\(\[controller\.signal, AbortSignal\.timeout\(/,
-    "catalog fetch should still use the existing auth helper once the cookie-backed state is ready",
+    /if \(!canFetchNotebookList\) \{[\s\S]*if \(waitingForAppSession\) \{[\s\S]*window\.setTimeout\(\(\) => \{[\s\S]*loadNotebookList\(controller, " after app-session wait deadline"\);/,
+    "waiting for the trusted cookie must have a deadline fallback instead of an eternal skeleton",
+  );
+  assert.match(
+    sourceText,
+    /if \(seededNotebooks\) \{[\s\S]*console\.warn\([\s\S]*keeping cached list/,
+    "stale local-first content should stay visible when a refresh fails",
+  );
+  assert.match(
+    sourceText,
+    /fetchCloudNotebookList\(\s*authState,\s*AbortSignal\.any\(\[[\s\S]*AbortSignal\.timeout\(CLOUD_NOTEBOOK_LIST_FETCH_TIMEOUT_MS\)/,
+    "catalog fetch should still use the existing auth helper on ready and deadline paths",
   );
 });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1958,6 +1958,7 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 200);
     const body = (await response.json()) as {
+      current_user_principal?: string;
       notebooks: Array<{
         endpoints: Record<string, string>;
         notebook_id: string;
@@ -1968,6 +1969,7 @@ describe("Worker artifact routes", () => {
       ok: boolean;
     };
     assert.equal(body.ok, true);
+    assert.equal(body.current_user_principal, "user:dev:alice");
     assert.deepEqual(
       body.notebooks.map((notebook) => [notebook.notebook_id, notebook.scope]),
       [

--- a/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
@@ -1,0 +1,178 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { CloudAuthStoreProvider } from "../cloud-auth-context";
+import { CloudAuthStore } from "../cloud-auth-store";
+import type { CloudViewerAuthConfig } from "../cloud-viewer-types";
+import type { CloudPrototypeAuthState } from "../collaborator-auth";
+import { CloudNotebookListView } from "../notebook-list-view";
+import { writeCachedCloudNotebookList } from "../notebook-list-cache";
+import type { CloudNotebookListItem } from "../notebook-dashboard";
+
+const authConfig: CloudViewerAuthConfig = {
+  localDev: null,
+  oidc: null,
+};
+
+describe("CloudNotebookListView", () => {
+  let storage: MemoryStorage;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storage = new MemoryStorage();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+    window.history.pushState({}, "", "/n");
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn((query: string) => ({
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: false,
+        media: query,
+        onchange: null,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("turns persistent app-session waits into a retryable list error", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: "session unavailable" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 503,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5 });
+
+    expect(screen.getByRole("status", { name: "Loading notebooks" })).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Unable to list notebooks: session unavailable")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("keeps cached notebooks visible when deadline revalidation fails", async () => {
+    const auth = oidcAuth("alice@example.test");
+    const cachedNotebooks = [notebook("nb-cached", "Cached Notebook")];
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    writeCachedCloudNotebookList(storage, auth, null, cachedNotebooks, {
+      principal: "user:anaconda:alice%40example.test",
+    });
+
+    renderNotebookList(auth, { appSessionWaitDeadlineMs: 5 });
+
+    expect(screen.getByText("Cached Notebook")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Cached Notebook")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("notebook list refresh failed after app-session wait deadline"),
+      expect.any(Error),
+    );
+  });
+});
+
+function renderNotebookList(
+  authState: CloudPrototypeAuthState,
+  options: { appSessionWaitDeadlineMs?: number } = {},
+) {
+  const store = new CloudAuthStore({ readAuthState: () => authState });
+  render(
+    <CloudAuthStoreProvider store={store}>
+      <CloudNotebookListView
+        appSessionWaitDeadlineMs={options.appSessionWaitDeadlineMs}
+        authConfig={authConfig}
+      />
+    </CloudAuthStoreProvider>,
+  );
+  return store;
+}
+
+function oidcAuth(subject: string): CloudPrototypeAuthState {
+  return {
+    mode: "oidc",
+    token: "token",
+    user: subject,
+    oidcClaims: {
+      sub: subject,
+    },
+    requestedScope: "viewer",
+    problem: null,
+  };
+}
+
+function notebook(id: string, title: string): CloudNotebookListItem {
+  return {
+    notebook_id: id,
+    title,
+    owner_principal: "user:anaconda:alice%40example.test",
+    scope: "owner",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    latest_revision_id: null,
+    viewer_url: `/n/${id}/notebook`,
+    endpoints: {
+      catalog: `/api/n/${id}`,
+      acl: `/api/n/${id}/acl`,
+      access_requests: `/api/n/${id}/access-requests`,
+    },
+  };
+}
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
@@ -57,7 +57,9 @@ describe("CloudNotebookListView", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5 });
+    renderNotebookList(oidcAuth("alice@example.test", { token: null }), {
+      appSessionWaitDeadlineMs: 5,
+    });
 
     expect(screen.getByRole("status", { name: "Loading notebooks" })).toBeTruthy();
 
@@ -71,7 +73,34 @@ describe("CloudNotebookListView", () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
-  it("keeps cached notebooks visible when deadline revalidation fails", async () => {
+  it("starts the list fetch with OIDC credentials before app-session establishment settles", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          notebooks: [],
+          current_user_principal: "user:anaconda:alice%40example.test",
+        }),
+        {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5_000 });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("No notebooks yet")).toBeTruthy();
+  });
+
+  it("keeps cached notebooks visible when revalidation fails", async () => {
     const auth = oidcAuth("alice@example.test");
     const cachedNotebooks = [notebook("nb-cached", "Cached Notebook")];
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -96,7 +125,7 @@ describe("CloudNotebookListView", () => {
     expect(screen.getByText("Cached Notebook")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("notebook list refresh failed after app-session wait deadline"),
+      expect.stringContaining("notebook list refresh failed"),
       expect.any(Error),
     );
   });
@@ -118,10 +147,13 @@ function renderNotebookList(
   return store;
 }
 
-function oidcAuth(subject: string): CloudPrototypeAuthState {
+function oidcAuth(
+  subject: string,
+  overrides: Partial<Pick<CloudPrototypeAuthState, "token">> = {},
+): CloudPrototypeAuthState {
   return {
     mode: "oidc",
-    token: "token",
+    token: overrides.token === undefined ? "token" : overrides.token,
     user: subject,
     oidcClaims: {
       sub: subject,

--- a/apps/notebook-cloud/viewer/cloud-principal.ts
+++ b/apps/notebook-cloud/viewer/cloud-principal.ts
@@ -1,0 +1,59 @@
+import { devPrincipalLabel, type CloudPrototypeAuthState } from "./collaborator-auth";
+
+const DEV_PRINCIPAL_PREFIX = "user:dev:";
+
+/**
+ * Anonymous principals (`anonymous:<encodedSession>`, minted by the worker
+ * from the per-connection viewer_session nonce) change on every connect,
+ * so persisted browser state can never match the next session.
+ */
+export function isAnonymousCloudPrincipal(principal: string): boolean {
+  return principal.startsWith("anonymous:");
+}
+
+/**
+ * Derive a principal matcher from locally stored auth material, WITHOUT
+ * the room handshake. Returns null when no principal is derivable — the
+ * caller must then skip cached pixels or cached shell data entirely.
+ *
+ * - Dev token: the worker derives the principal deterministically from
+ *   the presented user, so an exact match is available.
+ * - OIDC (valid stored token, or expired claims backed by a live
+ *   app-session cookie): the worker's principal is
+ *   `<namespace>:<encoded sub>` with a server-configured namespace, so
+ *   the matcher pins the encoded subject as the principal's id segment
+ *   and rejects the namespaces it cannot belong to (anonymous, dev).
+ *
+ * HEURISTIC, deliberately weaker than the post-handshake guard. The full
+ * principal equality check after a server handshake compares against the
+ * actual principal; this matcher cannot, because the OIDC namespace is
+ * server configuration that is not client-derivable before the first
+ * handshake. Its namespace-agnostic id-segment match is sound today only
+ * because browser-written records carry exactly one of: `user:dev:*`, the
+ * deployment's single OIDC/API-key namespace, or anonymous (never persisted).
+ * Adding a browser-reachable auth provider whose subject space overlaps the
+ * OIDC sub space widens this match — revisit then.
+ */
+export function cloudInstantPaintPrincipalMatcher(
+  authState: CloudPrototypeAuthState,
+  options: { hasAppSession?: boolean } = {},
+): ((principal: string) => boolean) | null {
+  if (authState.mode === "dev" && authState.token) {
+    const expected = devPrincipalLabel(authState.user ?? "browser-editor");
+    return (principal) => !isAnonymousCloudPrincipal(principal) && principal === expected;
+  }
+
+  const sub = authState.oidcClaims?.sub?.trim();
+  const oidcUsable =
+    authState.mode === "oidc" ||
+    (authState.mode === "oidc_expired" && options.hasAppSession === true);
+  if (oidcUsable && sub) {
+    const encodedSub = encodeURIComponent(sub);
+    return (principal) =>
+      !isAnonymousCloudPrincipal(principal) &&
+      !principal.startsWith(DEV_PRINCIPAL_PREFIX) &&
+      principal.endsWith(`:${encodedSub}`);
+  }
+
+  return null;
+}

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -24,6 +24,8 @@ export type ViewerRuntimeState =
 export interface CloudNotebookListResponse {
   ok: boolean;
   notebooks: CloudNotebookListItem[];
+  /** Requester's worker principal, used only to key local-first shell cache. */
+  current_user_principal?: string;
   /** Requester's unified-profile display name, when the store has one. */
   current_user_display?: string;
   /** Requester's unified-profile avatar URL, when the store has one. */

--- a/apps/notebook-cloud/viewer/instant-paint.ts
+++ b/apps/notebook-cloud/viewer/instant-paint.ts
@@ -35,72 +35,15 @@ import {
   type PersistedNotebookDoc,
   type StorageAdapter,
 } from "runtimed";
-import { devPrincipalLabel, type CloudPrototypeAuthState } from "./collaborator-auth";
-import { isAnonymousCloudPrincipal, withReadyTimeout } from "./live-sync";
+import { withReadyTimeout } from "./live-sync";
+
+export { cloudInstantPaintPrincipalMatcher } from "./cloud-principal";
 
 /**
  * Bound on the instant-paint IndexedDB reads. A hung IDB open must
  * degrade to no-paint; the live room is dialing in parallel regardless.
  */
 const INSTANT_PAINT_READ_TIMEOUT_MS = 2_000;
-
-const DEV_PRINCIPAL_PREFIX = "user:dev:";
-
-/**
- * Derive a principal matcher from locally stored auth material, WITHOUT
- * the room handshake. Returns null when no principal is derivable — the
- * caller must then skip the paint entirely.
- *
- * - Dev token: the worker derives the principal deterministically from
- *   the presented user, so an exact match is available.
- * - OIDC (valid stored token, or expired claims backed by a live
- *   app-session cookie — the cookie was minted from that subject's
- *   token): the worker's principal is `<namespace>:<encoded sub>` with a
- *   server-configured namespace, so the matcher pins the encoded subject
- *   as the principal's id segment and rejects the namespaces it cannot
- *   belong to (anonymous, dev).
- *
- * HEURISTIC, deliberately weaker than the post-handshake guard. The
- * full-principal equality check in `resolveCloudNotebookHandle` compares
- * against the handshake's actual principal; this matcher cannot, because
- * the OIDC namespace is server configuration that is not client-derivable
- * before the first handshake. Its namespace-agnostic id-segment match is
- * sound today only because browser-written records carry exactly one of:
- * `user:dev:*` (rejected here unless dev-derived), the deployment's
- * single OIDC/API-key namespace, or anonymous (never persisted at all).
- * Adding a browser-reachable auth provider whose subject space overlaps
- * the OIDC sub space widens this match — revisit then. The backstops if
- * it ever false-positives: the post-handshake guard clears the mismatched
- * seed, the live materialization replaces the paint wholesale, and an
- * authoritative EMPTY room displaces it too (the zero-cell guard's
- * caught-up displacement) — a foreign paint cannot outlive the handshake.
- *
- * Anonymous principals never match any matcher: they are per-connection
- * nonces and persisted records are never written for them anyway.
- */
-export function cloudInstantPaintPrincipalMatcher(
-  authState: CloudPrototypeAuthState,
-  options: { hasAppSession?: boolean } = {},
-): ((principal: string) => boolean) | null {
-  if (authState.mode === "dev" && authState.token) {
-    const expected = devPrincipalLabel(authState.user ?? "browser-editor");
-    return (principal) => !isAnonymousCloudPrincipal(principal) && principal === expected;
-  }
-
-  const sub = authState.oidcClaims?.sub?.trim();
-  const oidcUsable =
-    authState.mode === "oidc" ||
-    (authState.mode === "oidc_expired" && options.hasAppSession === true);
-  if (oidcUsable && sub) {
-    const encodedSub = encodeURIComponent(sub);
-    return (principal) =>
-      !isAnonymousCloudPrincipal(principal) &&
-      !principal.startsWith(DEV_PRINCIPAL_PREFIX) &&
-      principal.endsWith(`:${encodedSub}`);
-  }
-
-  return null;
-}
 
 /**
  * Zero-cell displacement policy for the live materialization path.

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -28,6 +28,7 @@ import {
   cloudSyncAuthFromPrototypeAuthState,
   type CloudSyncAuth,
 } from "./collaborator-auth";
+import { isAnonymousCloudPrincipal } from "./cloud-principal";
 import {
   createBootstrapNotebookHandle,
   encodeCursorPresenceAfterInit,
@@ -37,6 +38,8 @@ import {
   loadNotebookHandleFromBytes,
   type NotebookHandle,
 } from "./runtimed-wasm-client";
+
+export { isAnonymousCloudPrincipal } from "./cloud-principal";
 
 export type CloudRoomReady = Extract<SessionControlMessage, { type: "cloud_room_ready" }>;
 
@@ -523,18 +526,6 @@ export function startCloudBootstrapSync(
 export function cloudPrincipalFromActorLabel(actorLabel: string): string {
   const [principal] = splitNotebookActorPrincipalOperator(actorLabel);
   return principal;
-}
-
-/**
- * Anonymous principals (`anonymous:<encodedSession>`, minted by the worker
- * from the per-connection viewer_session nonce) change on every connect,
- * so a persisted record can never match the next session — and an
- * anonymous session must never clear a signed-in user's record on
- * principal mismatch. Persistence is skipped entirely for them: no seed,
- * no save, no clear.
- */
-export function isAnonymousCloudPrincipal(principal: string): boolean {
-  return principal.startsWith("anonymous:");
 }
 
 /**

--- a/apps/notebook-cloud/viewer/notebook-list-cache.ts
+++ b/apps/notebook-cloud/viewer/notebook-list-cache.ts
@@ -1,10 +1,10 @@
 import type { CloudAppSession } from "./app-session";
-import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import { devPrincipalLabel, type CloudPrototypeAuthState } from "./collaborator-auth";
+import { cloudInstantPaintPrincipalMatcher } from "./cloud-principal";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
 export const CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY =
   "nteract:notebook-cloud:notebook-list-cache:v1";
-export const CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS = 10 * 60 * 1000;
 
 export interface CloudNotebookListCacheStorage {
   getItem(key: string): string | null;
@@ -13,66 +13,75 @@ export interface CloudNotebookListCacheStorage {
 }
 
 interface CachedCloudNotebookList {
-  authKey: string;
   notebooks: CloudNotebookListItem[];
+  principal: string;
   savedAt: number;
 }
 
+interface CachedCloudNotebookListRoot {
+  entries: CachedCloudNotebookList[];
+  v: 1;
+}
+
 export function readCachedCloudNotebookList(
-  storage: Pick<CloudNotebookListCacheStorage, "getItem">,
+  storage: Pick<CloudNotebookListCacheStorage, "getItem" | "removeItem">,
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
-  now = Date.now(),
 ): CloudNotebookListItem[] | null {
-  const authKey = cloudNotebookListCacheAuthKey(authState, appSession);
-  if (!authKey) {
+  const matchesPrincipal = cloudInstantPaintPrincipalMatcher(authState, {
+    hasAppSession: Boolean(appSession),
+  });
+  if (!matchesPrincipal) {
     return null;
   }
 
-  const raw = storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
-  if (!raw) {
+  const root = readCloudNotebookListCacheRoot(storage);
+  if (!root) {
     return null;
   }
 
-  let parsed: Partial<CachedCloudNotebookList>;
-  try {
-    parsed = JSON.parse(raw) as Partial<CachedCloudNotebookList>;
-  } catch {
-    return null;
-  }
-
-  if (
-    parsed.authKey !== authKey ||
-    !Number.isFinite(parsed.savedAt) ||
-    now - Number(parsed.savedAt) > CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS ||
-    !Array.isArray(parsed.notebooks) ||
-    !parsed.notebooks.every(isCloudNotebookListItem)
-  ) {
-    return null;
-  }
-
-  return parsed.notebooks;
+  return root.entries.find((entry) => matchesPrincipal(entry.principal))?.notebooks ?? null;
 }
 
 export function writeCachedCloudNotebookList(
-  storage: Pick<CloudNotebookListCacheStorage, "setItem">,
+  storage: Pick<CloudNotebookListCacheStorage, "getItem" | "removeItem" | "setItem">,
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
   notebooks: CloudNotebookListItem[],
-  now = Date.now(),
+  input: { now?: number; principal?: string | null } = {},
 ): void {
-  const authKey = cloudNotebookListCacheAuthKey(authState, appSession);
-  if (!authKey) {
+  if (!notebooks.every(isCloudNotebookListItem)) {
     return;
   }
 
+  const matchesPrincipal = cloudInstantPaintPrincipalMatcher(authState, {
+    hasAppSession: Boolean(appSession),
+  });
+  const principal = cloudNotebookListCachePrincipal(authState, {
+    hasAppSession: Boolean(appSession),
+    matchesPrincipal,
+    principal: input.principal,
+  });
+  if (!principal || !matchesPrincipal?.(principal)) {
+    return;
+  }
+
+  const root = readCloudNotebookListCacheRoot(storage) ?? { v: 1, entries: [] };
+  const entry = {
+    notebooks,
+    principal,
+    savedAt: input.now ?? Date.now(),
+  } satisfies CachedCloudNotebookList;
+  const entries = [
+    entry,
+    ...root.entries.filter((candidate) => candidate.principal !== principal),
+  ].slice(0, 8);
   storage.setItem(
     CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
     JSON.stringify({
-      authKey,
-      notebooks,
-      savedAt: now,
-    } satisfies CachedCloudNotebookList),
+      entries,
+      v: 1,
+    } satisfies CachedCloudNotebookListRoot),
   );
 }
 
@@ -82,18 +91,75 @@ export function clearCachedCloudNotebookList(
   storage.removeItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
 }
 
-export function cloudNotebookListCacheAuthKey(
+function readCloudNotebookListCacheRoot(
+  storage: Pick<CloudNotebookListCacheStorage, "getItem" | "removeItem">,
+): CachedCloudNotebookListRoot | null {
+  const raw = storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    storage.removeItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
+    return null;
+  }
+  if (!isCachedCloudNotebookListRoot(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function isCachedCloudNotebookListRoot(value: unknown): value is CachedCloudNotebookListRoot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CachedCloudNotebookListRoot>;
+  return candidate.v === 1 && Array.isArray(candidate.entries) && candidate.entries.every(isEntry);
+}
+
+function isEntry(value: unknown): value is CachedCloudNotebookList {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CachedCloudNotebookList>;
+  return (
+    typeof candidate.principal === "string" &&
+    Number.isFinite(candidate.savedAt) &&
+    Array.isArray(candidate.notebooks) &&
+    candidate.notebooks.every(isCloudNotebookListItem)
+  );
+}
+
+function cloudNotebookListCachePrincipal(
   authState: CloudPrototypeAuthState,
-  appSession: CloudAppSession | null | undefined,
+  options: {
+    hasAppSession: boolean;
+    matchesPrincipal: ((principal: string) => boolean) | null;
+    principal?: string | null;
+  },
 ): string | null {
-  if (appSession?.cache_key) {
-    return `app-session:${appSession.cache_key}`;
+  const explicit = options.principal?.trim();
+  if (explicit) {
+    return explicit;
   }
-  if (authState.mode === "oidc" && authState.oidcClaims?.sub) {
-    return `oidc:${authState.oidcClaims.sub}`;
+  if (authState.mode === "dev" && authState.token) {
+    return devPrincipalLabel(authState.user ?? "browser-editor");
   }
-  if (authState.mode === "dev" && authState.user) {
-    return `dev:${authState.user}`;
+
+  const sub = authState.oidcClaims?.sub?.trim();
+  if (
+    !sub ||
+    (authState.mode !== "oidc" && !(authState.mode === "oidc_expired" && options.hasAppSession))
+  ) {
+    return null;
   }
-  return null;
+  const encodedSub = encodeURIComponent(sub);
+  // SSR bootstrap intentionally does not expose the raw worker principal.
+  // For that path, store a matcher-shaped principal and let the shared
+  // instant-paint matcher remain the validity authority.
+  const syntheticPrincipal = `user:oidc-cache:${encodedSub}`;
+  return options.matchesPrincipal?.(syntheticPrincipal) ? syntheticPrincipal : null;
 }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -122,13 +122,13 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         );
         return;
       }
-      clearCachedCloudNotebookListFromWindow();
+      clearCachedCloudNotebookListFromLocalStorage();
       setListState({ kind: "signed_out" });
       return;
     }
 
     if (refreshIndex === 0 && bootstrap) {
-      writeCachedCloudNotebookListToWindow(
+      writeCachedCloudNotebookListToLocalStorage(
         authState,
         appSessionStatus.session,
         bootstrap.notebooks,
@@ -155,7 +155,12 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         if (!isCloudNotebookListResponse(body)) {
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
-        writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, body.notebooks);
+        writeCachedCloudNotebookListToLocalStorage(
+          authState,
+          appSessionStatus.session,
+          body.notebooks,
+          body.current_user_principal,
+        );
         if (typeof body.current_user_display === "string" && body.current_user_display.trim()) {
           setCurrentUserDisplay(body.current_user_display.trim());
         }
@@ -322,7 +327,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
               }
             : notebook,
         );
-        writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, notebooks);
+        writeCachedCloudNotebookListToLocalStorage(authState, appSessionStatus.session, notebooks);
         return {
           kind: "ready",
           notebooks,
@@ -340,7 +345,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     setBootstrap(null);
     setDashboardQuery("");
     auth.clearAppSessionStatus();
-    clearCachedCloudNotebookListFromWindow();
+    clearCachedCloudNotebookListFromLocalStorage();
     void clearCloudAppSession()
       .catch((error: unknown) => {
         console.warn("[notebook-cloud] app session clear failed", error);
@@ -766,10 +771,10 @@ function cloudNotebookListSeedFromBootstrapOrCache(
   appSession: CloudAppSession | null | undefined,
   bootstrap: CloudNotebookListBootstrap | null,
 ): CloudNotebookListItem[] | null {
-  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromWindow(authState, appSession);
+  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromLocalStorage(authState, appSession);
 }
 
-function readCachedCloudNotebookListFromWindow(
+function readCachedCloudNotebookListFromLocalStorage(
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
 ): CloudNotebookListItem[] | null {
@@ -777,19 +782,20 @@ function readCachedCloudNotebookListFromWindow(
   return storage ? readCachedCloudNotebookList(storage, authState, appSession) : null;
 }
 
-function writeCachedCloudNotebookListToWindow(
+function writeCachedCloudNotebookListToLocalStorage(
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
   notebooks: CloudNotebookListItem[],
+  principal?: string | null,
 ): void {
   const storage = cloudNotebookListCacheStorage();
   if (!storage) {
     return;
   }
-  writeCachedCloudNotebookList(storage, authState, appSession, notebooks);
+  writeCachedCloudNotebookList(storage, authState, appSession, notebooks, { principal });
 }
 
-function clearCachedCloudNotebookListFromWindow(): void {
+function clearCachedCloudNotebookListFromLocalStorage(): void {
   const storage = cloudNotebookListCacheStorage();
   if (!storage) {
     return;
@@ -799,7 +805,7 @@ function clearCachedCloudNotebookListFromWindow(): void {
 
 function cloudNotebookListCacheStorage(): Storage | null {
   try {
-    return window.sessionStorage;
+    return window.localStorage;
   } catch {
     return null;
   }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -71,6 +71,7 @@ import {
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { preloadNotebookRoute } from "./notebook-route-preload";
+import type { CloudAppSessionViewState } from "./use-cloud-auth";
 
 const CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS = 8_000;
 const CLOUD_NOTEBOOK_LIST_FETCH_TIMEOUT_MS = 20_000;
@@ -106,11 +107,14 @@ export function CloudNotebookListView({
   const [renameError, setRenameError] = useState<string | null>(null);
   const hostedAuth = useHostedCatalogAuth();
   const {
-    canFetchCatalog: canFetchNotebookList,
+    canFetchCatalog: cookieCanFetchNotebookList,
     hasAppSession,
     signedIn,
     waitingForAppSession,
   } = hostedAuth;
+  const canFetchNotebookList =
+    cookieCanFetchNotebookList ||
+    cloudNotebookListCanUseExistingCredentials(authState, appSessionStatus.status);
   const appSessionWaitDeadline =
     appSessionWaitDeadlineMs ?? CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS;
   const dashboardModel = useMemo(
@@ -220,6 +224,7 @@ export function CloudNotebookListView({
     };
   }, [
     appSessionStatus.session,
+    appSessionStatus.status,
     appSessionWaitDeadline,
     authState,
     bootstrap,
@@ -766,6 +771,19 @@ function cloudAuthWithScope(
         ...authState,
         requestedScope,
       };
+}
+
+function cloudNotebookListCanUseExistingCredentials(
+  authState: CloudPrototypeAuthState,
+  appSessionStatus: CloudAppSessionViewState["status"],
+): boolean {
+  if (authState.mode === "oidc" && authState.token) {
+    return true;
+  }
+  // The notebook list endpoint can also succeed with a same-origin app-session
+  // cookie before the status probe confirms it. Once that probe settles without
+  // a session, an expired OIDC token is not a durable fetch credential.
+  return authState.mode === "oidc_expired" && appSessionStatus === "loading";
 }
 
 function initialCloudNotebookListState(

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -72,7 +72,18 @@ import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { preloadNotebookRoute } from "./notebook-route-preload";
 
-export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
+const CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS = 8_000;
+const CLOUD_NOTEBOOK_LIST_FETCH_TIMEOUT_MS = 20_000;
+
+export interface CloudNotebookListViewProps {
+  authConfig: CloudViewerAuthConfig;
+  appSessionWaitDeadlineMs?: number;
+}
+
+export function CloudNotebookListView({
+  appSessionWaitDeadlineMs,
+  authConfig,
+}: CloudNotebookListViewProps) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const auth = useCloudAuthStore();
   const [bootstrap, setBootstrap] = useState<CloudNotebookListBootstrap | null>(() =>
@@ -100,6 +111,8 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     signedIn,
     waitingForAppSession,
   } = hostedAuth;
+  const appSessionWaitDeadline =
+    appSessionWaitDeadlineMs ?? CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS;
   const dashboardModel = useMemo(
     () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
     [listState],
@@ -115,43 +128,26 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
       appSessionStatus.session,
       bootstrap,
     );
-    if (!canFetchNotebookList) {
-      if (waitingForAppSession) {
-        setListState(
-          seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" },
-        );
-        return;
-      }
-      clearCachedCloudNotebookListFromLocalStorage();
-      setListState({ kind: "signed_out" });
-      return;
-    }
-
-    if (refreshIndex === 0 && bootstrap) {
-      writeCachedCloudNotebookListToLocalStorage(
-        authState,
-        appSessionStatus.session,
-        bootstrap.notebooks,
-      );
-      setListState({ kind: "ready", notebooks: bootstrap.notebooks });
-      return;
-    }
-
-    const controller = new AbortController();
-    setListState(
-      seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" },
-    );
-    void (async () => {
+    const initialState = seededNotebooks
+      ? { kind: "ready" as const, notebooks: seededNotebooks }
+      : { kind: "loading" as const };
+    const loadNotebookList = async (controller: AbortController, warningLabel: string) => {
       try {
         const response = await fetchCloudNotebookList(
           authState,
-          AbortSignal.any([controller.signal, AbortSignal.timeout(20_000)]),
+          AbortSignal.any([
+            controller.signal,
+            AbortSignal.timeout(CLOUD_NOTEBOOK_LIST_FETCH_TIMEOUT_MS),
+          ]),
         );
         if (controller.signal.aborted) return;
         if (!response.ok) {
-          throw await cloudResponseError(response, "Unable to list notebooks");
+          const responseError = await cloudResponseError(response, "Unable to list notebooks");
+          if (controller.signal.aborted) return;
+          throw responseError;
         }
         const body = (await response.json()) as unknown;
+        if (controller.signal.aborted) return;
         if (!isCloudNotebookListResponse(body)) {
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
@@ -172,23 +168,59 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
-        const timedOut = error instanceof DOMException && error.name === "TimeoutError";
+        if (seededNotebooks) {
+          console.warn(
+            `[notebook-cloud] notebook list refresh failed${warningLabel}; keeping cached list`,
+            error,
+          );
+          return;
+        }
         setListState({
           kind: "error",
-          message: timedOut
-            ? "Loading notebooks timed out - the service may be mid-deploy. Retry, or hard-refresh if this persists."
-            : error instanceof Error
-              ? error.message
-              : String(error),
+          message: notebookListFetchErrorMessage(error),
         });
       }
-    })();
+    };
+    if (!canFetchNotebookList) {
+      if (waitingForAppSession) {
+        const controller = new AbortController();
+        setListState(initialState);
+        const deadline = window.setTimeout(
+          () => {
+            void loadNotebookList(controller, " after app-session wait deadline");
+          },
+          Math.max(0, appSessionWaitDeadline),
+        );
+        return () => {
+          window.clearTimeout(deadline);
+          controller.abort();
+        };
+      }
+      clearCachedCloudNotebookListFromLocalStorage();
+      setListState({ kind: "signed_out" });
+      return;
+    }
+
+    if (refreshIndex === 0 && bootstrap) {
+      writeCachedCloudNotebookListToLocalStorage(
+        authState,
+        appSessionStatus.session,
+        bootstrap.notebooks,
+      );
+      setListState({ kind: "ready", notebooks: bootstrap.notebooks });
+      return;
+    }
+
+    const controller = new AbortController();
+    setListState(initialState);
+    void loadNotebookList(controller, "");
 
     return () => {
       controller.abort();
     };
   }, [
     appSessionStatus.session,
+    appSessionWaitDeadline,
     authState,
     bootstrap,
     canFetchNotebookList,
@@ -764,6 +796,14 @@ function fetchCloudNotebookList(
     headers: { Accept: "application/json" },
     signal,
   });
+}
+
+function notebookListFetchErrorMessage(error: unknown): string {
+  const timedOut = error instanceof DOMException && error.name === "TimeoutError";
+  if (timedOut) {
+    return "Loading notebooks timed out - the service may be mid-deploy. Retry, or hard-refresh if this persists.";
+  }
+  return error instanceof Error ? error.message : String(error);
 }
 
 function cloudNotebookListSeedFromBootstrapOrCache(


### PR DESCRIPTION
Implements the app-shell local-first policy (`docs/memos/app-shell-local-first.md`) for `/n`, closing the client side of #3928. Four commits, in order:

1. **Sliding session renewal.** Cookie-authenticated requests past half the 6h max-age get a re-minted cookie on the response (same principal payload, same secret, fresh horizon, new `sid`; never renews an expired or invalid session). Active users stop aging out; a dormant browser still expires in 6h flat. Renewal rides the session GET, the `/api/n` list, and the viewer shell - WebSocket paths can't carry Set-Cookie and are untouched.
2. **Persistent principal-keyed list cache.** The window-scoped `/n` cache moves to localStorage, keyed by the principal that produced it (server now returns `current_user_principal`; the SSR-bootstrap path keys on a per-identity synthetic derived from the OIDC `sub`), validated by the instant-paint matcher extracted into a shared module. A different principal never inherits a cache; sign-out clears it.
3. **Bounded session wait.** The `waitingForAppSession` gate gets the policy's three exits: an 8s deadline (injectable) falls through to fetching with existing credentials; persistent failure becomes a visible error with Retry; already-seeded cached content stays visible when a refresh fails instead of demoting to an error.
4. **Fetch racing.** `canFetchNotebookList` is now cookie-projection OR usable-existing-credentials, so the list fetch races the cookie exchange instead of serializing behind OIDC refresh -> session establish.

Verified end to end against a local wrangler + dev issuer: with a warm cache and a deleted session cookie, reloading `/n` paints the ready state immediately (signed-in header intact) instead of the skeleton-until-session chain; behavioral tests cover cached-content seeding, principal mismatch refusal, sign-out clearing, the retryable error, and the race.

Gates: typecheck, 1321/1322 node:test (known renderer-artifacts ENOENT), 58 vitest, lint.

The eternal-skeleton and daily cold-load findings in #3928 are addressed by this plus #3930; the remaining item there is the standalone `/oidc` entry (#3929).
