### PR TITLE
feat(cloud): resolve toolbar self-identity through the user store

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -713,6 +713,55 @@ test("cloud shell capabilities prefer OIDC display names and pictures over raw e
   assert.equal(capabilities.access.actor?.principal.imageUrl, "https://profiles.example/alice.png");
 });
 
+test("cloud shell capabilities prefer store-resolved self display over auth claims", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner", {
+      sub: "anaconda-user-123",
+      email: "alice@example.com",
+      email_verified: true,
+      name: "Alice Claims",
+      picture: "https://profiles.example/claims.png",
+    }),
+    selfDisplay: {
+      label: "Alice Profile",
+      imageUrl: "https://profiles.example/profile.png",
+    },
+    connectionScope: "owner",
+    connectionActorLabel: "user:anaconda:alice/browser:tab",
+    hasCodeCells: false,
+  });
+
+  assert.equal(capabilities.access.identityLabel, "Alice Profile");
+  assert.equal(capabilities.access.actor?.principal.label, "Alice Profile");
+  assert.equal(
+    capabilities.access.actor?.principal.imageUrl,
+    "https://profiles.example/profile.png",
+  );
+});
+
+test("cloud shell capabilities fall back to auth display when self display is absent", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor", {
+      sub: "anaconda-user-123",
+      email: "alice@example.com",
+      email_verified: true,
+      name: "Alice Claims",
+      picture: "https://profiles.example/claims.png",
+    }),
+    connectionScope: "editor",
+    connectionActorLabel: "user:anaconda:alice/browser:tab",
+    hasCodeCells: false,
+    selectedMode: "edit",
+  });
+
+  assert.equal(capabilities.access.identityLabel, "Alice Claims");
+  assert.equal(capabilities.access.actor?.principal.label, "Alice Claims");
+  assert.equal(
+    capabilities.access.actor?.principal.imageUrl,
+    "https://profiles.example/claims.png",
+  );
+});
+
 test("cloud shell capabilities return stable frozen objects for equivalent inputs", () => {
   const oidcClaims = {
     sub: "anaconda-user-123",
@@ -723,6 +772,10 @@ test("cloud shell capabilities return stable frozen objects for equivalent input
   };
   const first = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner", oidcClaims),
+    selfDisplay: {
+      label: "Alice Profile",
+      imageUrl: "https://profiles.example/profile.png",
+    },
     connectionScope: "owner",
     connectionActorLabel: "user:anaconda:alice/browser:tab",
     hasCodeCells: true,
@@ -732,6 +785,10 @@ test("cloud shell capabilities return stable frozen objects for equivalent input
   });
   const second = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner", { ...oidcClaims }),
+    selfDisplay: {
+      label: "Alice Profile",
+      imageUrl: "https://profiles.example/profile.png",
+    },
     connectionScope: "owner",
     connectionActorLabel: "user:anaconda:alice/browser:tab",
     hasCodeCells: true,

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-user-store.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-user-store.test.tsx
@@ -1,8 +1,9 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { createElement, type ReactNode } from "react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { createElement, useMemo, type ReactNode } from "react";
 import { BehaviorSubject } from "rxjs";
 import { describe, expect, it, vi } from "vite-plus/test";
 
+import { NotebookToolbarIdentity } from "@/components/notebook";
 import { cloudAccessRequestStore } from "../cloud-access-request-store";
 import { CloudAuthStore } from "../cloud-auth-store";
 import { CloudAuthStoreProvider } from "../cloud-auth-context";
@@ -12,7 +13,12 @@ import { CloudUserStore } from "../cloud-user-store";
 import { cloudWorkstationsStore } from "../cloud-workstations-store";
 import type { CloudPrototypeAuthState } from "../collaborator-auth";
 import type { CloudViewerPresenceState } from "../presence";
-import { useCloudUserStoreController, useResolvedActor } from "../use-cloud-user-store";
+import { useCloudShellCapabilities } from "../use-cloud-shell-capabilities";
+import {
+  useCloudUserStoreController,
+  useResolvedActor,
+  useResolvedActorProfile,
+} from "../use-cloud-user-store";
 
 const STABLE_AUTH: CloudPrototypeAuthState = {
   mode: "dev",
@@ -23,9 +29,26 @@ const STABLE_AUTH: CloudPrototypeAuthState = {
   problem: null,
 };
 
+const OIDC_AUTH: CloudPrototypeAuthState = {
+  mode: "oidc",
+  token: "oidc-token",
+  user: "claims@example.test",
+  oidcClaims: {
+    sub: "actor-1",
+    email: "claims@example.test",
+    email_verified: true,
+    name: "Claims Alice",
+    picture: "https://profiles.example/claims.png",
+  },
+  requestedScope: "owner",
+  problem: null,
+};
+
 function actor(index: number): string {
   return `user:anaconda:actor-${index}`;
 }
+
+const SELF_ACTOR_LABEL = `${actor(1)}/browser:tab`;
 
 function presenceState(
   overrides: Partial<CloudViewerPresenceState> = {},
@@ -58,6 +81,38 @@ function wrapperFor(
       ? createElement(CloudAuthStoreProvider, { store: authStore, children: tree })
       : tree;
   };
+}
+
+function ToolbarSelfIdentityProbe() {
+  const selfProfile = useResolvedActorProfile(SELF_ACTOR_LABEL);
+  const selfDisplay = useMemo(() => {
+    const label = selfProfile?.displayName?.trim() || null;
+    const imageUrl = selfProfile?.avatarUrl?.trim() || null;
+    return label || imageUrl ? { label, imageUrl } : undefined;
+  }, [selfProfile?.avatarUrl, selfProfile?.displayName]);
+  const { shellCapabilities } = useCloudShellCapabilities({
+    authState: OIDC_AUTH,
+    selfDisplay,
+    connectionScope: "owner",
+    connectionActorLabel: SELF_ACTOR_LABEL,
+    connectionPeerId: "peer-1",
+    connectionPeerLabel: null,
+    connectionError: null,
+    status: { kind: "ready", message: "Ready" },
+    selectedMode: "edit",
+    hasAppSession: true,
+    codeCellCount: 1,
+    runtimePeerAvailable: false,
+    runtimePeerCount: 0,
+    kernelStatusLabel: null,
+    workstationAttachment: null,
+    hostCapabilities: { canManageSharing: false },
+  });
+
+  return createElement(NotebookToolbarIdentity, {
+    capabilities: shellCapabilities,
+    variant: "inline",
+  });
 }
 
 describe("useResolvedActor", () => {
@@ -186,6 +241,50 @@ describe("useResolvedActor", () => {
       expect(result.current.imageUrl).toBe("/avatars/profile-peer.png");
       expect(fetchProfiles).toHaveBeenCalledWith(
         "/author-profiles?actor_label=user%3Aanaconda%3Aactor-1",
+        expect.any(AbortSignal),
+      );
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe("self identity convergence", () => {
+  it("updates the toolbar identity label when the user store upgrades the self profile", async () => {
+    const user = new CloudUserStore();
+    const fetchProfiles = vi.fn(async () =>
+      Response.json({
+        profiles: [
+          {
+            principal: actor(1),
+            label: "D1 Alice",
+            image_url: "/avatars/d1-alice.png",
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    const inputs$ = new BehaviorSubject({
+      auth: OIDC_AUTH,
+      authorProfilesEndpoint: "/author-profiles",
+    });
+    const dispose = user.activate(inputs$, { fetchProfiles });
+
+    try {
+      render(createElement(ToolbarSelfIdentityProbe), {
+        wrapper: wrapperFor(user),
+      });
+
+      expect(screen.getByText("Claims Alice")).toBeTruthy();
+
+      act(() => {
+        user.requestResolve([SELF_ACTOR_LABEL]);
+      });
+
+      await waitFor(() => expect(screen.getByText("D1 Alice")).toBeTruthy());
+      expect(screen.queryByText("Claims Alice")).toBeNull();
+      expect(fetchProfiles).toHaveBeenCalledWith(
+        "/author-profiles?actor_label=user%3Aanaconda%3Aactor-1%2Fbrowser%3Atab",
         expect.any(AbortSignal),
       );
     } finally {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -181,7 +181,11 @@ import {
   useCloudNotebookTitle,
   useCloudNotebookTitleError,
 } from "./use-cloud-catalog-store";
-import { useCloudUserProfiles, useCloudUserStoreController } from "./use-cloud-user-store";
+import {
+  useCloudUserProfiles,
+  useCloudUserStoreController,
+  useResolvedActorProfile,
+} from "./use-cloud-user-store";
 import { useCloudShellCapabilities } from "./use-cloud-shell-capabilities";
 import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { cloudSignInMethodForConfig, CloudNotebookSignInButton } from "./cloud-auth-controls";
@@ -456,6 +460,21 @@ export function NotebookViewer({
     () => user.connectPresence(presenceStore, () => auth.authSnapshot),
     [auth, presenceStore, user],
   );
+  const selfProfile = useResolvedActorProfile(connectionActorLabel);
+  useEffect(() => {
+    if (!connectionActorLabel || !config.authorProfilesEndpoint) {
+      return;
+    }
+    user.requestResolve([connectionActorLabel]);
+  }, [config.authorProfilesEndpoint, connectionActorLabel, user]);
+  const selfDisplay = useMemo(() => {
+    const label = selfProfile?.displayName?.trim() || null;
+    const imageUrl = selfProfile?.avatarUrl?.trim() || null;
+    if (!label && !imageUrl) {
+      return undefined;
+    }
+    return { label, imageUrl };
+  }, [connectionActorLabel, selfProfile?.avatarUrl, selfProfile?.displayName]);
   // Mirror the desktop app: expose the local author's comment color and a
   // legible foreground as CSS vars the shared affordance and composer styles
   // read. The cloud viewer previously set neither, so cloud create surfaces fell
@@ -762,6 +781,7 @@ export function NotebookViewer({
       accessConnectionScope,
       authState,
       codeCellCount,
+      selfDisplay,
       connectionActorLabel,
       connectionError,
       connectionPeerId,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -18,6 +18,16 @@ import { cloudFriendlyPeerLabel, cloudVisiblePeerLabel } from "./presence";
 export interface CloudNotebookShellCapabilityInput {
   authState: CloudPrototypeAuthState;
   /**
+   * Viewer self display resolved by the Cloud user store. When provided, these
+   * profile fields win over the legacy auth-claim derivation below; null or
+   * empty fields fall back independently so early connection frames keep the
+   * current auth-derived identity until the store has a better answer.
+   */
+  selfDisplay?: {
+    label?: string | null;
+    imageUrl?: string | null;
+  };
+  /**
    * Document access used for UI projection. During reconnect this can come
    * from the authenticated notebook catalog so owners do not see stale
    * request-access chrome. Actual mutation and execution authority still comes
@@ -78,6 +88,7 @@ export interface CloudNotebookShellCapabilityInput {
 export function cloudNotebookShellCapabilities({
   accessConnectionScope,
   authState,
+  selfDisplay,
   connectionScope,
   connectionActorLabel = null,
   connectionPeerLabel = null,
@@ -106,10 +117,13 @@ export function cloudNotebookShellCapabilities({
   const authenticated = hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention =
     !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired");
-  const identityLabel = connectionPeerLabel?.trim()
-    ? cloudVisiblePeerLabel(connectionPeerLabel, connectionActorLabel)
-    : cloudIdentityDisplayLabel(authState, connectionActorLabel);
-  const identityImageUrl = cloudIdentityImageUrl(authState);
+  const identityLabel =
+    normalizedSelfDisplayValue(selfDisplay?.label) ??
+    (connectionPeerLabel?.trim()
+      ? cloudVisiblePeerLabel(connectionPeerLabel, connectionActorLabel)
+      : cloudIdentityDisplayLabel(authState, connectionActorLabel));
+  const identityImageUrl =
+    normalizedSelfDisplayValue(selfDisplay?.imageUrl) ?? cloudIdentityImageUrl(authState);
   const visibleRuntimePeerCount = Math.max(0, Math.floor(runtimePeerCount));
   const hasRuntimePeer = visibleRuntimePeerCount > 0;
   const attachmentConnected = workstationAttachmentIsConnected(workstationAttachment);
@@ -257,6 +271,12 @@ function cloudRuntimeTarget({
   };
 }
 
+/**
+ * Legacy fallback for the viewer's own label. Cloud callers should pass
+ * `selfDisplay.label` from CloudUserStore when it has a resolved profile,
+ * presence seed, or self seed; this remains the auth-claim fallback for the
+ * first frame and non-store callers.
+ */
 function cloudIdentityDisplayLabel(
   authState: CloudPrototypeAuthState,
   actorLabel?: string | null,
@@ -276,8 +296,17 @@ function cloudIdentityDisplayLabel(
   return looksLikeEmailAddress(user) ? cloudFriendlyPeerLabel({ actorLabel, email: user }) : user;
 }
 
+/**
+ * Legacy fallback for the viewer's own avatar. CloudUserStore's
+ * `selfDisplay.imageUrl` takes precedence when present so D1/profile upgrades
+ * and seeded self avatars flow through the same identity path.
+ */
 function cloudIdentityImageUrl(authState: CloudPrototypeAuthState): string | null {
   return authState.oidcClaims?.picture?.trim() || null;
+}
+
+function normalizedSelfDisplayValue(value: string | null | undefined): string | null {
+  return value?.trim() || null;
 }
 
 function looksLikeEmailAddress(value: string): boolean {

--- a/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
@@ -18,6 +18,10 @@ import { cloudNotebookShellCapabilities } from "./shell-capabilities";
 interface UseCloudShellCapabilitiesInput {
   accessConnectionScope?: string | null;
   authState: CloudPrototypeAuthState;
+  selfDisplay?: {
+    label?: string | null;
+    imageUrl?: string | null;
+  };
   connectionScope: string | null;
   connectionActorLabel: string | null;
   connectionPeerId: string | null;
@@ -50,6 +54,7 @@ export interface CloudShellCapabilities {
 export function useCloudShellCapabilities({
   accessConnectionScope = null,
   authState,
+  selfDisplay,
   connectionScope,
   connectionActorLabel,
   connectionPeerId,
@@ -109,6 +114,7 @@ export function useCloudShellCapabilities({
       cloudNotebookShellCapabilities({
         accessConnectionScope: documentAccessScope,
         authState,
+        selfDisplay,
         connectionScope,
         connectionActorLabel,
         connectionPeerLabel,
@@ -125,6 +131,8 @@ export function useCloudShellCapabilities({
       }),
     [
       authState,
+      selfDisplay?.imageUrl,
+      selfDisplay?.label,
       hasAppSession,
       documentAccessScope,
       codeCellCount,

--- a/apps/notebook-cloud/viewer/use-cloud-user-store.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-user-store.ts
@@ -32,8 +32,8 @@ function useLiveInputs<T>(value: T): BehaviorSubject<T> {
   return subject;
 }
 
-function principalFromActorLabel(actorLabel: string): string {
-  const trimmed = actorLabel.trim();
+function principalFromActorLabel(actorLabel: string | null | undefined): string {
+  const trimmed = actorLabel?.trim();
   if (!trimmed) {
     return "";
   }
@@ -47,12 +47,20 @@ function principalFromActorLabel(actorLabel: string): string {
   }
 }
 
-/** Resolve one actor label through the cloud user directory. */
-export function useResolvedActor(actorLabel: string): ActorDisplay {
+/** Subscribe to one actor label's resolved profile entry. */
+export function useResolvedActorProfile(
+  actorLabel: string | null | undefined,
+): CloudResolvedProfile | undefined {
   const { user } = useCloudStores();
   const principal = principalFromActorLabel(actorLabel);
   const profile$ = useMemo(() => user.profileFor$(principal), [principal, user]);
-  void useObservableProjection(profile$);
+  return useObservableProjection(profile$);
+}
+
+/** Resolve one actor label through the cloud user directory. */
+export function useResolvedActor(actorLabel: string): ActorDisplay {
+  const { user } = useCloudStores();
+  void useResolvedActorProfile(actorLabel);
   return user.resolve(actorLabel);
 }
 


### PR DESCRIPTION
Completes the deferred self-identity piece of `docs/adr/cloud-user-store.md` Decision 5: the cloud toolbar/shell identity now resolves through the CloudUserStore, with precedence store profile > presence > auth claims.

`cloudNotebookShellCapabilities` takes an optional `selfDisplay` input whose fields win over the legacy auth-claim derivation, falling back per-field so early connection frames keep the current identity until the store has a better answer. The viewer resolves its own actor label through a narrow per-principal subscription (`useResolvedActorProfile`) and requests backfill for self, so a D1 display-name or avatar upgrade reaches the toolbar live. The capabilities memo keys on the primitive label/image values, preserving the frozen referential-equality contract (extended in the tests). The auth-claim derivation stays as the documented fallback; desktop keeps its OS-username path untouched.

Gates: typecheck, 1324/1324 node:test, 59 vitest, lint, and the full `apps/notebook` build (shared identity surface blast radius).
