### PR TITLE
fix(notebook): apply pending focus when a new cell's editor registers

### DIFF
--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
@@ -1,12 +1,19 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
+import type { EditorView } from "@codemirror/view";
+import { act, render } from "@testing-library/react";
 import { useEffect } from "react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  clearPendingCellFocus,
+  getAllCellEditors,
+  registerCellEditor,
+  unregisterCellEditor,
+} from "../../lib/editor-registry";
 import { EditorRegistryProvider, useEditorRegistry } from "../useEditorRegistry";
 
 function FocusProbe({
   cellId,
-  cursorPosition = "start",
+  cursorPosition,
 }: {
   cellId: string;
   cursorPosition?: "start" | "end";
@@ -14,11 +21,54 @@ function FocusProbe({
   const { focusCell } = useEditorRegistry();
 
   useEffect(() => {
-    focusCell(cellId, cursorPosition);
+    focusCell(cellId, cursorPosition ?? "start");
   }, [cellId, cursorPosition, focusCell]);
 
   return null;
 }
+
+function RetargetProbe({
+  firstCellId,
+  secondCellId,
+}: {
+  firstCellId: string;
+  secondCellId: string;
+}) {
+  const { focusCell } = useEditorRegistry();
+
+  useEffect(() => {
+    focusCell(firstCellId, "start");
+    focusCell(secondCellId, "end");
+  }, [firstCellId, focusCell, secondCellId]);
+
+  return null;
+}
+
+function createEditorView(docText = ""): EditorView {
+  return {
+    state: {
+      doc: {
+        length: docText.length,
+        lines: docText.split("\n").length,
+        line: vi.fn((lineNumber: number) => {
+          const lines = docText.split("\n");
+          const from = lines.slice(0, lineNumber - 1).reduce((offset, line) => {
+            return offset + line.length + 1;
+          }, 0);
+          return { from };
+        }),
+      },
+    },
+    dispatch: vi.fn(),
+    focus: vi.fn(),
+  } as unknown as EditorView;
+}
+
+afterEach(() => {
+  clearPendingCellFocus();
+  getAllCellEditors().clear();
+  vi.restoreAllMocks();
+});
 
 describe("useEditorRegistry", () => {
   it("focuses a cell focus target when the cell has no CodeMirror editor", () => {
@@ -36,5 +86,65 @@ describe("useEditorRegistry", () => {
     );
 
     expect(document.activeElement?.textContent).toBe("Show hidden cell");
+  });
+
+  it.each(["code", "markdown"] as const)(
+    "applies pending insert focus when a %s cell editor registers",
+    (cellType) => {
+      Element.prototype.scrollIntoView = vi.fn();
+      const cellId = `${cellType}-cell`;
+      const view = createEditorView("hello");
+
+      render(
+        <EditorRegistryProvider>
+          <div data-cell-id={cellId} data-cell-type={cellType} />
+          <FocusProbe cellId={cellId} />
+        </EditorRegistryProvider>,
+      );
+
+      expect(view.focus).not.toHaveBeenCalled();
+
+      act(() => {
+        registerCellEditor(cellId, view);
+      });
+
+      expect(view.dispatch).toHaveBeenCalledWith({
+        selection: { anchor: 0, head: 0 },
+        scrollIntoView: true,
+      });
+      expect(view.focus).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("retargets pending focus when another cell is focused before registration", () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const firstView = createEditorView("first");
+    const secondView = createEditorView("second");
+
+    render(
+      <EditorRegistryProvider>
+        <div data-cell-id="first-cell" />
+        <div data-cell-id="second-cell" />
+        <RetargetProbe firstCellId="first-cell" secondCellId="second-cell" />
+      </EditorRegistryProvider>,
+    );
+
+    act(() => {
+      registerCellEditor("first-cell", firstView);
+    });
+
+    expect(firstView.focus).not.toHaveBeenCalled();
+
+    act(() => {
+      registerCellEditor("second-cell", secondView);
+    });
+
+    expect(secondView.dispatch).toHaveBeenCalledWith({
+      selection: { anchor: 6, head: 6 },
+      scrollIntoView: true,
+    });
+    expect(secondView.focus).toHaveBeenCalledTimes(1);
+
+    unregisterCellEditor("second-cell");
   });
 });

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -1,13 +1,14 @@
 import { EditorView } from "@codemirror/view";
 import { scrollElementIntoView } from "@/components/notebook";
 import { createContext, type ReactNode, useCallback, useContext } from "react";
+import {
+  clearPendingCellFocus,
+  focusEditorView,
+  requestCellEditorFocus,
+  type CellCursorPosition,
+  type CellFocusTarget,
+} from "../lib/editor-registry";
 import { logger } from "../lib/logger";
-
-type CellCursorPosition = "start" | "end";
-export interface CellFocusTarget {
-  cursorPosition?: CellCursorPosition;
-  line?: number;
-}
 
 interface EditorRegistryContextType {
   focusCell: (cellId: string, target?: CellCursorPosition | CellFocusTarget) => void;
@@ -16,23 +17,20 @@ interface EditorRegistryContextType {
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
 
 export function EditorRegistryProvider({ children }: { children: ReactNode }) {
-  // Focus a cell's editor using DOM lookup - bypasses registration timing issues
   const focusCell = useCallback(
     (cellId: string, target: CellCursorPosition | CellFocusTarget = "start") => {
-      const focusTarget =
-        typeof target === "string"
-          ? { cursorPosition: target }
-          : { cursorPosition: "start" as const, ...target };
+      const focusedRegisteredEditor = requestCellEditorFocus(cellId, target);
 
-      // Find the cell element by data attribute
       const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
+      if (cellElement) {
+        scrollElementIntoView(cellElement, { block: "nearest", behavior: "auto" });
+      }
+      if (focusedRegisteredEditor) return;
+
       if (!cellElement) {
         logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
         return;
       }
-
-      // Scroll the cell container into the notebook viewport
-      scrollElementIntoView(cellElement, { block: "nearest", behavior: "auto" });
 
       // Find CodeMirror's content element inside the cell
       const cmContent = cellElement.querySelector(".cm-content");
@@ -41,6 +39,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
           "[data-cell-focus-target]",
         );
         if (fallbackFocusElement) {
+          clearPendingCellFocus(cellId);
           fallbackFocusElement.focus({ preventScroll: true });
           return;
         }
@@ -57,20 +56,8 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      // Set cursor position and focus
-      const doc = view.state.doc;
-      const line = typeof focusTarget.line === "number" ? focusTarget.line : null;
-      const pos =
-        line !== null && Number.isFinite(line) && line > 0
-          ? doc.line(Math.max(1, Math.min(Math.floor(line), doc.lines))).from
-          : focusTarget.cursorPosition === "end"
-            ? doc.length
-            : 0;
-      view.dispatch({
-        selection: { anchor: pos, head: pos },
-        scrollIntoView: true,
-      });
-      view.focus();
+      clearPendingCellFocus(cellId);
+      focusEditorView(view, target);
     },
     [],
   );

--- a/apps/notebook/src/lib/__tests__/notebook-controller.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-controller.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { EditorView } from "@codemirror/view";
 import type { NotebookCell } from "../../types";
 import { createNotebookController, type NotebookControllerHandle } from "../notebook-controller";
 import { getCellById, resetNotebookCells, replaceNotebookCells } from "../notebook-cells";
+import {
+  clearPendingCellFocus,
+  getAllCellEditors,
+  registerCellEditor,
+  requestCellEditorFocus,
+} from "../editor-registry";
 
 function codeCell(id: string, source = ""): NotebookCell {
   return {
@@ -73,7 +80,23 @@ function createHandle(): NotebookControllerHandle & {
 
 afterEach(() => {
   resetNotebookCells();
+  clearPendingCellFocus();
+  getAllCellEditors().clear();
 });
+
+function createEditorView(): EditorView {
+  return {
+    state: {
+      doc: {
+        length: 0,
+        lines: 1,
+        line: vi.fn(() => ({ from: 0 })),
+      },
+    },
+    dispatch: vi.fn(),
+    focus: vi.fn(),
+  } as unknown as EditorView;
+}
 
 describe("createNotebookController", () => {
   it("updates source through the handle and mirrors the shared cell store", () => {
@@ -203,6 +226,31 @@ describe("createNotebookController", () => {
     expect(applyMutationEvent).toHaveBeenCalledWith(event);
     expect(afterMutation).toHaveBeenCalledWith(handle, "structure");
     expect(engine.flush).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears pending focus when deleting a cell before its editor registers", () => {
+    const handle = createHandle();
+    handle.cells.push("cell-b");
+    handle.cellTypes.set("cell-b", "code");
+    const engine = { flush: vi.fn(), scheduleFlush: vi.fn() };
+    const afterMutation = vi.fn();
+    const controller = createNotebookController({
+      getHandle: () => handle,
+      getEngine: () => engine,
+      canWriteCellSource: () => true,
+      canEditStructure: () => true,
+      afterMutation,
+    });
+    const view = createEditorView();
+
+    requestCellEditorFocus("cell-b");
+    controller.deleteCell("cell-b");
+    registerCellEditor("cell-b", view);
+
+    expect(handle.cells).toEqual(["cell-a"]);
+    expect(afterMutation).toHaveBeenCalledWith(handle, "structure");
+    expect(engine.flush).toHaveBeenCalledTimes(1);
+    expect(view.focus).not.toHaveBeenCalled();
   });
 
   it("keeps legacy afterMutation behavior when wrappers are absent", () => {

--- a/apps/notebook/src/lib/editor-registry.ts
+++ b/apps/notebook/src/lib/editor-registry.ts
@@ -1,6 +1,13 @@
 export {
+  clearPendingCellFocus,
+  focusEditorView,
   getAllCellEditors,
   getCellEditor,
   registerCellEditor,
+  requestCellEditorFocus,
   unregisterCellEditor,
+} from "@/components/notebook/state/editor-registry";
+export type {
+  CellCursorPosition,
+  CellFocusTarget,
 } from "@/components/notebook/state/editor-registry";

--- a/src/components/notebook/state/editor-registry.ts
+++ b/src/components/notebook/state/editor-registry.ts
@@ -11,12 +11,93 @@ import type { EditorView } from "@codemirror/view";
 
 const editors = new Map<string, EditorView>();
 
+export type CellCursorPosition = "start" | "end";
+
+export interface CellFocusTarget {
+  cursorPosition?: CellCursorPosition;
+  line?: number;
+}
+
+interface NormalizedCellFocusTarget {
+  cursorPosition: CellCursorPosition;
+  line?: number;
+}
+
+interface PendingCellFocus {
+  cellId: string;
+  target: NormalizedCellFocusTarget;
+}
+
+let pendingCellFocus: PendingCellFocus | null = null;
+
+function normalizeCellFocusTarget(
+  target: CellCursorPosition | CellFocusTarget = "start",
+): NormalizedCellFocusTarget {
+  if (typeof target === "string") {
+    return { cursorPosition: target };
+  }
+  return { cursorPosition: "start", ...target };
+}
+
+export function focusEditorView(
+  view: EditorView,
+  target: CellCursorPosition | CellFocusTarget = "start",
+): void {
+  const focusTarget = normalizeCellFocusTarget(target);
+  const doc = view.state.doc;
+  const line = typeof focusTarget.line === "number" ? focusTarget.line : null;
+  const pos =
+    line !== null && Number.isFinite(line) && line > 0
+      ? doc.line(Math.max(1, Math.min(Math.floor(line), doc.lines))).from
+      : focusTarget.cursorPosition === "end"
+        ? doc.length
+        : 0;
+  view.dispatch({
+    selection: { anchor: pos, head: pos },
+    scrollIntoView: true,
+  });
+  view.focus();
+}
+
+function applyPendingFocus(pending: PendingCellFocus, view: EditorView): void {
+  focusEditorView(view, pending.target);
+  if (pendingCellFocus === pending) {
+    pendingCellFocus = null;
+  }
+}
+
+/**
+ * Focus a registered editor, or remember the request until the cell registers.
+ */
+export function requestCellEditorFocus(
+  cellId: string,
+  target: CellCursorPosition | CellFocusTarget = "start",
+): boolean {
+  const pending = { cellId, target: normalizeCellFocusTarget(target) };
+  pendingCellFocus = pending;
+
+  const view = editors.get(cellId);
+  if (!view) return false;
+
+  applyPendingFocus(pending, view);
+  return true;
+}
+
+export function clearPendingCellFocus(cellId?: string): void {
+  if (cellId !== undefined && pendingCellFocus?.cellId !== cellId) return;
+  pendingCellFocus = null;
+}
+
 /**
  * Register a CodeMirror EditorView for a cell.
  * Both cursor and attribution dispatchers will use this view.
  */
 export function registerCellEditor(cellId: string, view: EditorView): void {
   editors.set(cellId, view);
+  const pending = pendingCellFocus;
+  if (pending?.cellId === cellId) {
+    applyPendingFocus(pending, view);
+  }
 }
 
 /**
@@ -24,6 +105,7 @@ export function registerCellEditor(cellId: string, view: EditorView): void {
  */
 export function unregisterCellEditor(cellId: string): void {
   editors.delete(cellId);
+  clearPendingCellFocus(cellId);
 }
 
 /** Get the EditorView for a cell, or undefined if not registered. */

--- a/src/components/notebook/state/notebook-controller.ts
+++ b/src/components/notebook/state/notebook-controller.ts
@@ -5,6 +5,7 @@ import {
   updateCellSourceById,
   type NotebookStoreCell,
 } from "./cell-store";
+import { clearPendingCellFocus } from "./editor-registry";
 import { createNotebookCellId } from "./notebook-cell-id";
 
 type NotebookCell = NotebookStoreCell;
@@ -232,13 +233,16 @@ export function createNotebookController<THandle extends NotebookControllerHandl
     },
 
     deleteCell(cellId) {
-      commit("structure", canEditStructure, (handle) => {
+      const deleted = commit("structure", canEditStructure, (handle) => {
         if (handle.cell_count() <= 1) return { changed: false, eventApplied: false };
         if (handle.delete_cell_with_changeset && applyMutationEvent) {
           return localMutationOutcome(handle.delete_cell_with_changeset(cellId), Boolean);
         }
         return { changed: !!handle.delete_cell(cellId), eventApplied: false };
       });
+      if (deleted) {
+        clearPendingCellFocus(cellId);
+      }
     },
 
     clearOutputs(cellIds) {


### PR DESCRIPTION
Fixes #3919. Focus-on-insert resolved the new cell's editor with a one-shot `EditorView.findFromDOM` and silently dropped the focus when the editor had not mounted yet - markdown cells lost the race every time, code cells intermittently, and focus stayed on the Add-cell button where Space/Enter re-fired the click and spawned extra empty cells.

The focus flow now lives in a shared pending-focus registry (`src/components/notebook/state/editor-registry.ts`): `requestCellEditorFocus` focuses immediately when the editor is registered, otherwise records the cell as the single pending target; `registerCellEditor` applies the pending focus the moment the new cell's editor mounts (the registration path MarkdownCell's poll already drives). A newer request retargets the pending slot; unregister/deliberate clears drop it. `useEditorRegistry`'s DOM-lookup fallback and scroll-into-view behavior are preserved.

Shared desktop+cloud surface, so the full blast radius ran: complete vitest suite (2635 tests), `apps/notebook` build, notebook-cloud typecheck, lint - all green, plus new insert-then-focus coverage for code and markdown, retargeting, and deleted-cell clearing.
