### PR TITLE
fix(cloud): show the true notebook count, not the query limit

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1235,7 +1235,8 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
     await syncStoredAppSessionProfile(env, appSession);
   }
 
-  const notebooks = await listNotebooksForPrincipal(env, principal, limit);
+  const notebookList = await listNotebooksForPrincipal(env, principal, limit);
+  const { notebooks, totalCount } = notebookList;
   // The hydrations are independent fan-outs (owner-bucketed DO calls, bounded
   // R2 GETs, one batched D1 profile lookup) - overlap them instead of paying
   // the latencies in series.
@@ -1270,6 +1271,7 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
         roomPresence,
         principalDisplays,
       ),
+      total_count: totalCount,
       current_user_principal: principal,
       ...(currentUserDisplay ? { current_user_display: currentUserDisplay } : {}),
       ...(currentUserAvatar ? { current_user_avatar: currentUserAvatar } : {}),
@@ -5733,11 +5735,12 @@ async function notebookListBootstrap(
     return { bootstrap: null, session: null };
   }
   await syncStoredAppSessionProfile(env, session);
-  const notebooks = await listNotebooksForPrincipal(
+  const notebookList = await listNotebooksForPrincipal(
     env,
     session.principal,
     DEFAULT_NOTEBOOK_LIST_LIMIT,
   );
+  const { notebooks, totalCount } = notebookList;
   // The SSR bootstrap is embedded in served HTML, which is PII-free by
   // invariant (see the "bootstraps the notebook home" leak-guard test): no
   // profile display names and no presence occupant identities here. The
@@ -5749,6 +5752,7 @@ async function notebookListBootstrap(
       kind: "notebook-list",
       session: appSessionResponse(session),
       notebooks: notebookListResponseRows(request, notebooks, env, computeSessions),
+      total_count: totalCount,
       saved_at: new Date().toISOString(),
     },
   };

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -62,6 +62,11 @@ export interface ListedNotebookRow extends NotebookRow {
   scope: NotebookAclRow["scope"];
 }
 
+export interface ListedNotebookPage {
+  notebooks: ListedNotebookRow[];
+  totalCount: number;
+}
+
 export interface NotebookRoomSummaryOccupant {
   participant_key: string;
   actor_label: string;
@@ -744,12 +749,13 @@ export async function listNotebooksForPrincipal(
   env: Env,
   principal: string,
   limit: number,
-): Promise<ListedNotebookRow[]> {
+): Promise<ListedNotebookPage> {
   if (!env.DB) {
-    return [];
+    return { notebooks: [], totalCount: 0 };
   }
 
   await ensureCatalogSchema(env);
+  const visibility = notebookPrincipalVisibilityPredicate(principal);
   const rows = await env.DB.prepare(
     `SELECT n.id,
             n.owner_principal,
@@ -781,15 +787,7 @@ export async function listNotebooksForPrincipal(
          ON a.notebook_id = n.id
        LEFT JOIN notebook_revisions r
          ON r.id = n.latest_revision_id
-      WHERE a.subject_kind = 'principal'
-        AND (
-          a.subject = ?
-          OR a.subject IN (
-            SELECT canonical_principal
-              FROM principal_account_links
-             WHERE transport_principal = ?
-          )
-        )
+      WHERE ${visibility.sql}
       GROUP BY n.id,
                n.owner_principal,
                n.title,
@@ -804,9 +802,44 @@ export async function listNotebooksForPrincipal(
       ORDER BY n.updated_at DESC, n.created_at DESC, n.id DESC
       LIMIT ?`,
   )
-    .bind(principal, principal, limit)
+    .bind(...visibility.bindings, limit)
     .all<ListedNotebookRow>();
-  return rows.results ?? [];
+  const count = await env.DB.prepare(
+    `SELECT COUNT(*) AS total_count
+       FROM (
+         SELECT n.id
+           FROM notebooks n
+           JOIN notebook_acl a
+             ON a.notebook_id = n.id
+          WHERE ${visibility.sql}
+          GROUP BY n.id
+       ) visible_notebooks`,
+  )
+    .bind(...visibility.bindings)
+    .first<{ total_count: number }>();
+  const totalCount = Number(count?.total_count ?? rows.results?.length ?? 0);
+  return {
+    notebooks: rows.results ?? [],
+    totalCount: Number.isFinite(totalCount) ? totalCount : (rows.results ?? []).length,
+  };
+}
+
+function notebookPrincipalVisibilityPredicate(principal: string): {
+  bindings: [string, string];
+  sql: string;
+} {
+  return {
+    bindings: [principal, principal],
+    sql: `a.subject_kind = 'principal'
+        AND (
+          a.subject = ?
+          OR a.subject IN (
+            SELECT canonical_principal
+              FROM principal_account_links
+             WHERE transport_principal = ?
+          )
+        )`,
+  };
 }
 
 export async function getPublicNotebookAclRows(

--- a/apps/notebook-cloud/test/notebook-list-cache.test.ts
+++ b/apps/notebook-cloud/test/notebook-list-cache.test.ts
@@ -11,7 +11,7 @@ import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
 
 describe("cloud notebook list cache", () => {
-  it("seeds notebooks for a matching OIDC principal", () => {
+  it("seeds notebooks and total count for a matching OIDC principal", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("alice@example.test");
     const notebooks = [notebook("nb-a")];
@@ -19,9 +19,13 @@ describe("cloud notebook list cache", () => {
     writeCachedCloudNotebookList(storage, auth, null, notebooks, {
       now: 1_000,
       principal: "user:anaconda:alice%40example.test",
+      totalCount: 342,
     });
 
-    assert.deepEqual(readCachedCloudNotebookList(storage, auth, null), notebooks);
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, null), {
+      notebooks,
+      totalCount: 342,
+    });
   });
 
   it("refuses cached rows from a mismatched principal", () => {
@@ -50,7 +54,10 @@ describe("cloud notebook list cache", () => {
       principal: "user:anaconda:alice%40example.test",
     });
 
-    assert.deepEqual(readCachedCloudNotebookList(storage, auth, appSession()), notebooks);
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, appSession()), {
+      notebooks,
+      totalCount: notebooks.length,
+    });
     assert.equal(readCachedCloudNotebookList(storage, auth, null), null);
   });
 
@@ -88,7 +95,7 @@ describe("cloud notebook list cache", () => {
             savedAt: 1_000,
           },
         ],
-        v: 1,
+        v: 2,
       }),
     );
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -799,7 +799,7 @@ test("cloud notebook list bounds app-session waits before catalog fetches", () =
   );
   assert.match(
     sourceText,
-    /if \(seededNotebooks\) \{[\s\S]*console\.warn\([\s\S]*keeping cached list/,
+    /if \(seed\) \{[\s\S]*console\.warn\([\s\S]*keeping cached list/,
     "stale local-first content should stay visible when a refresh fails",
   );
   assert.match(
@@ -815,16 +815,16 @@ test("cloud notebook list trusts server bootstrap on initial app-session paint",
 
   assert.match(
     sourceText,
-    /const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap,[\s\S]*\);/,
+    /const seed = cloudNotebookListSeedFromBootstrapOrCache\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap,[\s\S]*\);/,
   );
   assert.match(
     sourceText,
-    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToLocalStorage\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap\.notebooks,[\s\S]*\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
+    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*const totalCount = normalizeCloudNotebookListTotalCount\([\s\S]*bootstrap\.notebooks,[\s\S]*bootstrap\.total_count,[\s\S]*\);[\s\S]*writeCachedCloudNotebookListToLocalStorage\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*notebooks: bootstrap\.notebooks,[\s\S]*totalCount,[\s\S]*\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks, totalCount \}\);[\s\S]*return;/,
     "fresh notebook-home bootstrap should satisfy the initial render without an immediate duplicate /api/n fetch",
   );
   assert.match(
     sourceText,
-    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromLocalStorage\(authState, appSession\);/,
+    /return bootstrap[\s\S]*\? \{[\s\S]*notebooks: bootstrap\.notebooks,[\s\S]*totalCount: normalizeCloudNotebookListTotalCount\([\s\S]*bootstrap\.notebooks,[\s\S]*bootstrap\.total_count,[\s\S]*\),[\s\S]*\}[\s\S]*: readCachedCloudNotebookListFromLocalStorage\(authState, appSession\);/,
     "server bootstrap should beat stale localStorage cache when both are present",
   );
 });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1967,9 +1967,12 @@ describe("Worker artifact routes", () => {
         viewer_url: string;
       }>;
       ok: boolean;
+      total_count: number;
     };
     assert.equal(body.ok, true);
     assert.equal(body.current_user_principal, "user:dev:alice");
+    assert.equal(body.total_count, 3);
+    assert.equal(body.notebooks.length, 2);
     assert.deepEqual(
       body.notebooks.map((notebook) => [notebook.notebook_id, notebook.scope]),
       [
@@ -8964,6 +8967,25 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async first<T = unknown>(): Promise<T | null> {
+    if (
+      this.query.includes("COUNT(*) AS total_count") &&
+      this.query.includes("FROM notebooks n") &&
+      this.query.includes("JOIN notebook_acl a")
+    ) {
+      const [principal, linkedPrincipal] = this.values as [string, string];
+      const linked = this.db.accountLinks.get(linkedPrincipal)?.canonical_principal;
+      const subjects = new Set([principal, ...(linked ? [linked] : [])]);
+      const notebookIds = new Set<string>();
+      for (const row of this.db.acl) {
+        if (row.subject_kind !== "principal" || !subjects.has(row.subject)) {
+          continue;
+        }
+        if (this.db.notebooks.has(row.notebook_id)) {
+          notebookIds.add(row.notebook_id);
+        }
+      }
+      return { total_count: notebookIds.size } as T;
+    }
     if (this.query.includes("FROM notebook_access_requests")) {
       if (this.query.includes("requester_principal = ?")) {
         const [notebookId, requesterPrincipal] = this.values as [string, string];

--- a/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
@@ -100,6 +100,34 @@ describe("CloudNotebookListView", () => {
     expect(screen.getByText("No notebooks yet")).toBeTruthy();
   });
 
+  it("renders the true total count and visible cap in the dashboard header", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          notebooks: [notebook("nb-a", "Notebook A"), notebook("nb-b", "Notebook B")],
+          total_count: 342,
+          current_user_principal: "user:anaconda:alice%40example.test",
+        }),
+        {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5_000 });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("342 notebooks · showing 2 · 0 active now")).toBeTruthy();
+  });
+
   it("keeps cached notebooks visible when revalidation fails", async () => {
     const auth = oidcAuth("alice@example.test");
     const cachedNotebooks = [notebook("nb-cached", "Cached Notebook")];

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -80,7 +80,7 @@ export function CloudNotebookDashboard({
     [filterId, model, activeQuery],
   );
   const continued = view.filterId === "all" && view.query.length === 0 ? model.continueRow : null;
-  const totalCount = model.notebooks.length;
+  const totalCount = model.totalCount;
   const activeCount = model.filters.find((filter) => filter.id === "compute")?.count ?? 0;
   const hasNoMatches = !continued && view.sections.length === 0;
 
@@ -95,7 +95,8 @@ export function CloudNotebookDashboard({
         <div>
           <h1>Notebooks</h1>
           <p>
-            {totalCount} notebook{totalCount === 1 ? "" : "s"} · {activeCount} active now
+            {cloudNotebookDashboardCountSummary(totalCount, model.loadedCount)} · {activeCount}{" "}
+            active now
           </p>
         </div>
         {view.showResultCount ? (
@@ -138,6 +139,11 @@ export function CloudNotebookDashboard({
       )}
     </div>
   );
+}
+
+function cloudNotebookDashboardCountSummary(totalCount: number, loadedCount: number): string {
+  const total = `${totalCount} notebook${totalCount === 1 ? "" : "s"}`;
+  return totalCount > loadedCount ? `${total} · showing ${loadedCount}` : total;
 }
 
 export function CloudNotebookDashboardSearchInput({

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -1,6 +1,9 @@
 import { isCloudAppSession } from "./app-session";
 import type { CloudRendererAssetNames, CloudViewerConfig } from "./cloud-viewer-session";
-import { isCloudNotebookListItem } from "./notebook-dashboard";
+import {
+  isCloudNotebookListItem,
+  isOptionalCloudNotebookListTotalCount,
+} from "./notebook-dashboard";
 import { normalizeOidcAuthConfig, type CloudOidcAuthConfig } from "./oidc-auth";
 import type {
   CloudNotebookListBootstrap,
@@ -212,6 +215,7 @@ function isCloudNotebookListBootstrap(value: unknown): value is CloudNotebookLis
     typeof candidate.saved_at === "string" &&
     Array.isArray(candidate.notebooks) &&
     candidate.notebooks.every(isCloudNotebookListItem) &&
+    isOptionalCloudNotebookListTotalCount(candidate.total_count, candidate.notebooks.length) &&
     (candidate.session === undefined ||
       candidate.session === null ||
       isCloudAppSession(candidate.session))

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -24,6 +24,7 @@ export type ViewerRuntimeState =
 export interface CloudNotebookListResponse {
   ok: boolean;
   notebooks: CloudNotebookListItem[];
+  total_count?: number;
   /** Requester's worker principal, used only to key local-first shell cache. */
   current_user_principal?: string;
   /** Requester's unified-profile display name, when the store has one. */
@@ -37,6 +38,12 @@ export interface CloudNotebookListBootstrap {
   notebooks: CloudNotebookListItem[];
   saved_at: string;
   session?: CloudAppSession | null;
+  total_count?: number;
+}
+
+export interface CloudNotebookListSnapshot {
+  notebooks: CloudNotebookListItem[];
+  totalCount: number;
 }
 
 export interface CloudNotebookCreateResponse {
@@ -55,7 +62,7 @@ export interface CloudNotebookUpdateResponse {
 
 export type CloudNotebookListState =
   | { kind: "loading" }
-  | { kind: "ready"; notebooks: CloudNotebookListItem[] }
+  | { kind: "ready"; notebooks: CloudNotebookListItem[]; totalCount: number }
   | { kind: "signed_out" }
   | { kind: "error"; message: string };
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -99,7 +99,9 @@ export interface CloudNotebookDashboardModel {
   continueRow: CloudNotebookDashboardRow | null;
   filterGroups: readonly CloudNotebookDashboardFilterGroup[];
   filters: readonly CloudNotebookDashboardFilter[];
+  loadedCount: number;
   notebooks: readonly CloudNotebookListItem[];
+  totalCount: number;
 }
 
 export interface CloudNotebookDashboardSection {
@@ -161,6 +163,9 @@ export interface CloudNotebookDashboardView {
 
 export function projectCloudNotebookDashboard(
   notebooks: readonly CloudNotebookListItem[],
+  input?: {
+    totalCount?: number | null;
+  },
 ): CloudNotebookDashboardModel {
   const sorted = [...notebooks].sort((left, right) => {
     const leftTime = Date.parse(left.updated_at);
@@ -176,13 +181,16 @@ export function projectCloudNotebookDashboard(
   const titled = sorted.filter(cloudNotebookHasTitle);
   const namedWork = titled.filter((notebook) => !cloudNotebookIsGeneratedRun(notebook));
   const filters = cloudNotebookDashboardFilters(notebooks);
+  const loadedCount = sorted.length;
 
   return {
     continueNotebook: namedWork[0] ?? titled[0] ?? sorted[0] ?? null,
     continueRow: dashboardRow(namedWork[0] ?? titled[0] ?? sorted[0] ?? null),
     filterGroups: cloudNotebookDashboardFilterGroups(filters),
     filters,
+    loadedCount,
     notebooks: sorted,
+    totalCount: normalizeCloudNotebookListTotalCount(notebooks, input?.totalCount),
   };
 }
 
@@ -342,6 +350,26 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
     typeof candidate.endpoints?.acl === "string" &&
     typeof candidate.endpoints?.access_requests === "string"
   );
+}
+
+export function isOptionalCloudNotebookListTotalCount(
+  value: unknown,
+  loadedCount: number,
+): value is number | undefined {
+  return (
+    value === undefined ||
+    (typeof value === "number" && Number.isSafeInteger(value) && value >= loadedCount)
+  );
+}
+
+export function normalizeCloudNotebookListTotalCount(
+  notebooks: readonly CloudNotebookListItem[],
+  totalCount: unknown,
+): number {
+  return isOptionalCloudNotebookListTotalCount(totalCount, notebooks.length) &&
+    totalCount !== undefined
+    ? totalCount
+    : notebooks.length;
 }
 
 function isCloudNotebookPresencePeer(value: unknown): value is CloudNotebookPresencePeer {

--- a/apps/notebook-cloud/viewer/notebook-list-cache.ts
+++ b/apps/notebook-cloud/viewer/notebook-list-cache.ts
@@ -1,10 +1,16 @@
 import type { CloudAppSession } from "./app-session";
 import { devPrincipalLabel, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { cloudInstantPaintPrincipalMatcher } from "./cloud-principal";
-import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
+import type { CloudNotebookListSnapshot } from "./cloud-viewer-types";
+import {
+  isCloudNotebookListItem,
+  isOptionalCloudNotebookListTotalCount,
+  normalizeCloudNotebookListTotalCount,
+  type CloudNotebookListItem,
+} from "./notebook-dashboard";
 
 export const CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY =
-  "nteract:notebook-cloud:notebook-list-cache:v1";
+  "nteract:notebook-cloud:notebook-list-cache:v2";
 
 export interface CloudNotebookListCacheStorage {
   getItem(key: string): string | null;
@@ -16,18 +22,19 @@ interface CachedCloudNotebookList {
   notebooks: CloudNotebookListItem[];
   principal: string;
   savedAt: number;
+  totalCount: number;
 }
 
 interface CachedCloudNotebookListRoot {
   entries: CachedCloudNotebookList[];
-  v: 1;
+  v: 2;
 }
 
 export function readCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "getItem" | "removeItem">,
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
-): CloudNotebookListItem[] | null {
+): CloudNotebookListSnapshot | null {
   const matchesPrincipal = cloudInstantPaintPrincipalMatcher(authState, {
     hasAppSession: Boolean(appSession),
   });
@@ -40,7 +47,8 @@ export function readCachedCloudNotebookList(
     return null;
   }
 
-  return root.entries.find((entry) => matchesPrincipal(entry.principal))?.notebooks ?? null;
+  const entry = root.entries.find((candidate) => matchesPrincipal(candidate.principal));
+  return entry ? { notebooks: entry.notebooks, totalCount: entry.totalCount } : null;
 }
 
 export function writeCachedCloudNotebookList(
@@ -48,7 +56,7 @@ export function writeCachedCloudNotebookList(
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
   notebooks: CloudNotebookListItem[],
-  input: { now?: number; principal?: string | null } = {},
+  input: { now?: number; principal?: string | null; totalCount?: number | null } = {},
 ): void {
   if (!notebooks.every(isCloudNotebookListItem)) {
     return;
@@ -66,11 +74,12 @@ export function writeCachedCloudNotebookList(
     return;
   }
 
-  const root = readCloudNotebookListCacheRoot(storage) ?? { v: 1, entries: [] };
+  const root = readCloudNotebookListCacheRoot(storage) ?? { v: 2, entries: [] };
   const entry = {
     notebooks,
     principal,
     savedAt: input.now ?? Date.now(),
+    totalCount: normalizeCloudNotebookListTotalCount(notebooks, input.totalCount),
   } satisfies CachedCloudNotebookList;
   const entries = [
     entry,
@@ -80,7 +89,7 @@ export function writeCachedCloudNotebookList(
     CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
     JSON.stringify({
       entries,
-      v: 1,
+      v: 2,
     } satisfies CachedCloudNotebookListRoot),
   );
 }
@@ -117,7 +126,7 @@ function isCachedCloudNotebookListRoot(value: unknown): value is CachedCloudNote
     return false;
   }
   const candidate = value as Partial<CachedCloudNotebookListRoot>;
-  return candidate.v === 1 && Array.isArray(candidate.entries) && candidate.entries.every(isEntry);
+  return candidate.v === 2 && Array.isArray(candidate.entries) && candidate.entries.every(isEntry);
 }
 
 function isEntry(value: unknown): value is CachedCloudNotebookList {
@@ -129,7 +138,9 @@ function isEntry(value: unknown): value is CachedCloudNotebookList {
     typeof candidate.principal === "string" &&
     Number.isFinite(candidate.savedAt) &&
     Array.isArray(candidate.notebooks) &&
-    candidate.notebooks.every(isCloudNotebookListItem)
+    candidate.notebooks.every(isCloudNotebookListItem) &&
+    isOptionalCloudNotebookListTotalCount(candidate.totalCount, candidate.notebooks.length) &&
+    candidate.totalCount !== undefined
   );
 }
 

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -53,6 +53,7 @@ import type {
   CloudNotebookCreateResponse,
   CloudNotebookListBootstrap,
   CloudNotebookListResponse,
+  CloudNotebookListSnapshot,
   CloudNotebookListState,
   CloudNotebookRenameState,
   CloudNotebookUpdateResponse,
@@ -60,6 +61,9 @@ import type {
 } from "./cloud-viewer-types";
 import {
   cloudNotebookOpenUrlWithMode,
+  isCloudNotebookListItem,
+  isOptionalCloudNotebookListTotalCount,
+  normalizeCloudNotebookListTotalCount,
   projectCloudNotebookDashboard,
   type CloudNotebookListItem,
 } from "./notebook-dashboard";
@@ -118,7 +122,10 @@ export function CloudNotebookListView({
   const appSessionWaitDeadline =
     appSessionWaitDeadlineMs ?? CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS;
   const dashboardModel = useMemo(
-    () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
+    () =>
+      listState.kind === "ready"
+        ? projectCloudNotebookDashboard(listState.notebooks, { totalCount: listState.totalCount })
+        : null,
     [listState],
   );
 
@@ -127,13 +134,13 @@ export function CloudNotebookListView({
   }, [resolvedTheme]);
 
   useEffect(() => {
-    const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(
+    const seed = cloudNotebookListSeedFromBootstrapOrCache(
       authState,
       appSessionStatus.session,
       bootstrap,
     );
-    const initialState = seededNotebooks
-      ? { kind: "ready" as const, notebooks: seededNotebooks }
+    const initialState = seed
+      ? { kind: "ready" as const, notebooks: seed.notebooks, totalCount: seed.totalCount }
       : { kind: "loading" as const };
     const loadNotebookList = async (controller: AbortController, warningLabel: string) => {
       try {
@@ -155,12 +162,12 @@ export function CloudNotebookListView({
         if (!isCloudNotebookListResponse(body)) {
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
-        writeCachedCloudNotebookListToLocalStorage(
-          authState,
-          appSessionStatus.session,
-          body.notebooks,
-          body.current_user_principal,
-        );
+        const totalCount = normalizeCloudNotebookListTotalCount(body.notebooks, body.total_count);
+        writeCachedCloudNotebookListToLocalStorage(authState, appSessionStatus.session, {
+          notebooks: body.notebooks,
+          principal: body.current_user_principal,
+          totalCount,
+        });
         if (typeof body.current_user_display === "string" && body.current_user_display.trim()) {
           setCurrentUserDisplay(body.current_user_display.trim());
         }
@@ -169,10 +176,10 @@ export function CloudNotebookListView({
             ? body.current_user_avatar.trim()
             : null,
         );
-        setListState({ kind: "ready", notebooks: body.notebooks });
+        setListState({ kind: "ready", notebooks: body.notebooks, totalCount });
       } catch (error) {
         if (controller.signal.aborted) return;
-        if (seededNotebooks) {
+        if (seed) {
           console.warn(
             `[notebook-cloud] notebook list refresh failed${warningLabel}; keeping cached list`,
             error,
@@ -206,12 +213,15 @@ export function CloudNotebookListView({
     }
 
     if (refreshIndex === 0 && bootstrap) {
-      writeCachedCloudNotebookListToLocalStorage(
-        authState,
-        appSessionStatus.session,
+      const totalCount = normalizeCloudNotebookListTotalCount(
         bootstrap.notebooks,
+        bootstrap.total_count,
       );
-      setListState({ kind: "ready", notebooks: bootstrap.notebooks });
+      writeCachedCloudNotebookListToLocalStorage(authState, appSessionStatus.session, {
+        notebooks: bootstrap.notebooks,
+        totalCount,
+      });
+      setListState({ kind: "ready", notebooks: bootstrap.notebooks, totalCount });
       return;
     }
 
@@ -364,10 +374,14 @@ export function CloudNotebookListView({
               }
             : notebook,
         );
-        writeCachedCloudNotebookListToLocalStorage(authState, appSessionStatus.session, notebooks);
+        writeCachedCloudNotebookListToLocalStorage(authState, appSessionStatus.session, {
+          notebooks,
+          totalCount: current.totalCount,
+        });
         return {
           kind: "ready",
           notebooks,
+          totalCount: current.totalCount,
         };
       });
       setRenameState(null);
@@ -795,7 +809,13 @@ function initialCloudNotebookListState(
     bootstrap?.session ?? null,
     bootstrap,
   );
-  return seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" };
+  return seededNotebooks
+    ? {
+        kind: "ready",
+        notebooks: seededNotebooks.notebooks,
+        totalCount: seededNotebooks.totalCount,
+      }
+    : { kind: "loading" };
 }
 
 function fetchCloudNotebookList(
@@ -828,14 +848,22 @@ function cloudNotebookListSeedFromBootstrapOrCache(
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
   bootstrap: CloudNotebookListBootstrap | null,
-): CloudNotebookListItem[] | null {
-  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromLocalStorage(authState, appSession);
+): CloudNotebookListSnapshot | null {
+  return bootstrap
+    ? {
+        notebooks: bootstrap.notebooks,
+        totalCount: normalizeCloudNotebookListTotalCount(
+          bootstrap.notebooks,
+          bootstrap.total_count,
+        ),
+      }
+    : readCachedCloudNotebookListFromLocalStorage(authState, appSession);
 }
 
 function readCachedCloudNotebookListFromLocalStorage(
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
-): CloudNotebookListItem[] | null {
+): CloudNotebookListSnapshot | null {
   const storage = cloudNotebookListCacheStorage();
   return storage ? readCachedCloudNotebookList(storage, authState, appSession) : null;
 }
@@ -843,14 +871,20 @@ function readCachedCloudNotebookListFromLocalStorage(
 function writeCachedCloudNotebookListToLocalStorage(
   authState: CloudPrototypeAuthState,
   appSession: CloudAppSession | null | undefined,
-  notebooks: CloudNotebookListItem[],
-  principal?: string | null,
+  input: {
+    notebooks: CloudNotebookListItem[];
+    principal?: string | null;
+    totalCount: number;
+  },
 ): void {
   const storage = cloudNotebookListCacheStorage();
   if (!storage) {
     return;
   }
-  writeCachedCloudNotebookList(storage, authState, appSession, notebooks, { principal });
+  writeCachedCloudNotebookList(storage, authState, appSession, input.notebooks, {
+    principal: input.principal,
+    totalCount: input.totalCount,
+  });
 }
 
 function clearCachedCloudNotebookListFromLocalStorage(): void {
@@ -887,5 +921,10 @@ function isCloudNotebookListResponse(value: unknown): value is CloudNotebookList
     return false;
   }
   const candidate = value as Record<string, unknown>;
-  return candidate.ok === true && Array.isArray(candidate.notebooks);
+  return (
+    candidate.ok === true &&
+    Array.isArray(candidate.notebooks) &&
+    candidate.notebooks.every(isCloudNotebookListItem) &&
+    isOptionalCloudNotebookListTotalCount(candidate.total_count, candidate.notebooks.length)
+  );
 }


### PR DESCRIPTION
The /n header reported "100 notebooks" for any account with more than 100 - that number was `DEFAULT_NOTEBOOK_LIST_LIMIT`, the query cap, rendered as if it were the total.

The list query's visibility predicate is now factored into one shared helper feeding both the limited SELECT and a `COUNT(*)` over a `GROUP BY n.id` subquery (deduping the ACL join), so the two cannot drift. `total_count` rides the `/api/n` response and the SSR bootstrap, flows through the viewer types and the persistent list cache (key bumped to v2 for the shape change), and the header renders the truth: `342 notebooks · showing 100` when capped, plain `342 notebooks` when not.

Filter chips still count loaded rows - they filter what is on screen. No pagination changes.

Gates: typecheck, 1321/1322 node:test (known renderer-artifacts ENOENT), 59 vitest, lint; new coverage for the over-limit count, the showing-N rendering, and the cache round-trip.
