### PR TITLE
fix(cloud): constrain blob upload content types

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -194,6 +194,18 @@ const SNAPSHOT_BLOB_HEAD_CONCURRENCY = 16;
 // operations. Sized ~10x the largest blob_ref_count observed in
 // snapshot_pair.validation.completed logs; raise it if legitimate notebooks hit it.
 const MAX_SNAPSHOT_BLOB_REFS = 2000;
+const DEFAULT_BLOB_UPLOAD_CONTENT_TYPE = "application/octet-stream";
+const ALLOWED_EXACT_BLOB_UPLOAD_CONTENT_TYPES = new Set([
+  DEFAULT_BLOB_UPLOAD_CONTENT_TYPE,
+  "application/ecmascript",
+  "application/javascript",
+  "application/json",
+  "application/pdf",
+  "application/vnd.apache.arrow.stream",
+  "application/vnd.apache.parquet",
+  "application/wasm",
+]);
+const ALLOWED_PREFIXED_BLOB_UPLOAD_CONTENT_TYPES = ["audio/", "image/", "text/", "video/"];
 const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const CREATE_NOTEBOOK_ID_ATTEMPTS = 8;
 
@@ -1537,6 +1549,26 @@ function isNotebookCoverMime(
 
 function isRasterCoverMime(value: unknown): value is "image/png" | "image/jpeg" {
   return value === "image/png" || value === "image/jpeg";
+}
+
+function normalizedBlobUploadContentType(contentType: string | null): string | null {
+  const mediaType =
+    contentType == null
+      ? DEFAULT_BLOB_UPLOAD_CONTENT_TYPE
+      : (contentType.split(";")[0]?.trim().toLowerCase() ?? "");
+  if (mediaType.length === 0) {
+    return null;
+  }
+  if (ALLOWED_EXACT_BLOB_UPLOAD_CONTENT_TYPES.has(mediaType)) {
+    return mediaType;
+  }
+  if (ALLOWED_PREFIXED_BLOB_UPLOAD_CONTENT_TYPES.some((prefix) => mediaType.startsWith(prefix))) {
+    return mediaType;
+  }
+  if (mediaType.startsWith("application/") && mediaType.endsWith("+json")) {
+    return mediaType;
+  }
+  return null;
 }
 
 function parseNotebookCellComposition(
@@ -4739,6 +4771,19 @@ async function routeBlob(
     return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
   }
 
+  const contentType = normalizedBlobUploadContentType(request.headers.get("content-type"));
+  if (contentType == null) {
+    cloudLog("warn", "blob.upload.rejected", {
+      notebook_id: notebookId,
+      hash,
+      reason: "unsupported_content_type",
+      content_type: request.headers.get("content-type"),
+      counter: "blob_upload_rejections",
+      counter_delta: 1,
+    });
+    return json({ error: "unsupported blob content type" }, 415);
+  }
+
   const body = await request.arrayBuffer();
   const digest = await sha256Hex(body);
   if (hash !== digest) {
@@ -4768,7 +4813,6 @@ async function routeBlob(
     return authorizedIdentity;
   }
 
-  const contentType = request.headers.get("content-type");
   // Content-addressed first-writer-wins: an existing object already holds
   // these exact bytes (the hash was verified above), and its stored metadata
   // (Content-Type) must not be rewritable by later writers. Skip the R2 write;
@@ -4796,7 +4840,7 @@ async function routeBlob(
 
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
-      contentType: contentType ?? "application/octet-stream",
+      contentType,
       cacheControl: "public, max-age=31536000, immutable",
     },
     customMetadata: {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3838,6 +3838,78 @@ describe("Worker artifact routes", () => {
     });
   });
 
+  it("allows blob upload content types used by current runtime and publish producers", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-demo");
+    seedAcl(env, {
+      notebookId: "runtime-demo",
+      subject: "user:dev:runtime-service",
+      scope: "runtime_peer",
+    });
+    const cases = [
+      "application/octet-stream",
+      "application/vnd.apache.arrow.stream",
+      "application/vnd.nteract.arrow-stream-manifest+json",
+      "application/vnd.apache.parquet",
+      "application/json",
+      "application/vnd.plotly.v1+json",
+      "application/javascript",
+      "text/javascript",
+      "text/css",
+      "text/html",
+      "text/markdown",
+      "text/plain",
+      "image/png",
+      "image/svg+xml",
+      "application/pdf",
+      "audio/wav",
+      "video/mp4",
+    ];
+
+    for (const contentType of cases) {
+      const body = new TextEncoder().encode(`blob ${contentType}`);
+      const hash = await sha256Hex(body);
+      const response = await scopedPut(env, `/api/n/runtime-demo/blobs/${hash}`, body, {
+        "Content-Type": `${contentType}; charset=utf-8`,
+        "X-Scope": "runtime_peer",
+        "X-User": "runtime-service",
+        "X-Operator": "runtime:py-3.12",
+      });
+
+      assert.equal(response.status, 201, contentType);
+      assert.equal(
+        env.NOTEBOOK_SNAPSHOTS.objects.get(blobKey("runtime-demo", hash))?.httpMetadata
+          ?.contentType,
+        contentType,
+      );
+      assert.equal(env.DB.blobs.get(`runtime-demo:${hash}`)?.content_type, contentType);
+    }
+  });
+
+  it("rejects unsupported blob upload content types without writing bytes or catalog rows", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-demo");
+    seedAcl(env, {
+      notebookId: "runtime-demo",
+      subject: "user:dev:runtime-service",
+      scope: "runtime_peer",
+    });
+    const body = new Uint8Array([1, 2, 3, 4]);
+    const hash = await sha256Hex(body);
+
+    const response = await scopedPut(env, `/api/n/runtime-demo/blobs/${hash}`, body, {
+      "Content-Type": "application/xhtml+xml",
+      "X-Scope": "runtime_peer",
+      "X-User": "runtime-service",
+      "X-Operator": "runtime:py-3.12",
+    });
+
+    assert.equal(response.status, 415);
+    assert.deepEqual(await response.json(), { error: "unsupported blob content type" });
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.has(blobKey("runtime-demo", hash)), false);
+    assert.equal(env.DB.blobs.size, 0);
+  });
+
   it("keeps blob metadata first-writer-wins on duplicate put", async () => {
     const env = fakeEnv();
     seedNotebook(env, "runtime-demo");


### PR DESCRIPTION
Fixes #3887. `PUT /api/n/:id/blobs/:hash` persisted any caller-supplied Content-Type verbatim. Uploads now normalize the media type (parameters stripped, lowercased) and gate it against an allow-list before any R2 or catalog write: the media families outputs actually produce (text/, image/, audio/, video/), the exact application types in use (json, +json suffixes, pdf, javascript/ecmascript, wasm, Arrow, Parquet), and application/octet-stream as the absent-header default. Disallowed types get 415 with no write.

Every legitimate producer was enumerated and stays allowed: the runtimed output blob publisher's media types, runt-publish snapshot refs (explicit media_type or octet-stream fallback), and the publish/smoke scripts. text/html remains allowed by design - blob serving stays on the isolated output origin per docs/adr/hosted-output-origin-isolation.md, which this change does not touch.

Gates: typecheck, 1325/1326 node:test (known renderer-artifacts ENOENT), lint; new route coverage for allowed pass-through and 415-no-write rejection.
