### PR TITLE
fix(cloud): persist the pending-local-edit marker across reloads

### DIFF
--- a/apps/notebook-cloud/test/offline-merge-tracker.test.ts
+++ b/apps/notebook-cloud/test/offline-merge-tracker.test.ts
@@ -37,6 +37,32 @@ describe("offline merge tracker", () => {
     tracker.dispose();
   });
 
+  it("fires after a restored pending-local-edit marker reaches online", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.notePersistedPendingLocalWork();
+    tracker.noteConnectionStatus("online");
+
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.deepEqual(notices[0], { mergedRemoteCellCount: 0, removedEditedCellCount: 0 });
+    tracker.dispose();
+  });
+
+  it("ignores a restored pending marker while the session is ineligible", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteSessionEligibility(false);
+    tracker.notePersistedPendingLocalWork();
+    tracker.noteConnectionStatus("online");
+
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
   it("stays silent on a clean reconnect with nothing pending", (t) => {
     t.mock.timers.enable({ apis: ["setTimeout"] });
     const { notices, tracker } = tracked();

--- a/apps/notebook-cloud/test/pending-local-edit-marker.test.ts
+++ b/apps/notebook-cloud/test/pending-local-edit-marker.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { NotebookDocPersistenceMeta } from "runtimed";
+import {
+  CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY,
+  clearPendingLocalEditMarker,
+  readPendingLocalEditMarker,
+  writePendingLocalEditMarker,
+} from "../viewer/pending-local-edit-marker";
+
+describe("pending local edit marker", () => {
+  it("restores a marker for the same notebook, principal, and persisted heads", () => {
+    const storage = new MemoryStorage();
+
+    writePendingLocalEditMarker(storage, {
+      headsHex: ["head-a"],
+      notebookId: "nb-1",
+      now: 1_000,
+      principal: "user:oidc:alice",
+    });
+
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-1",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["head-a"], principal: "user:oidc:alice" }),
+      }),
+      true,
+    );
+  });
+
+  it("refuses markers from another principal or notebook", () => {
+    const storage = new MemoryStorage();
+
+    writePendingLocalEditMarker(storage, {
+      headsHex: ["head-a"],
+      notebookId: "nb-1",
+      principal: "user:oidc:alice",
+    });
+
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-1",
+        principal: "user:oidc:bob",
+        seedMeta: meta({ headsHex: ["head-a"], principal: "user:oidc:bob" }),
+      }),
+      false,
+    );
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-2",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["head-a"], principal: "user:oidc:alice" }),
+      }),
+      false,
+    );
+  });
+
+  it("clears a marker that no longer matches the restored persistence record", () => {
+    const storage = new MemoryStorage();
+
+    writePendingLocalEditMarker(storage, {
+      headsHex: ["pending-head"],
+      notebookId: "nb-1",
+      principal: "user:oidc:alice",
+    });
+
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-1",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["different-head"], principal: "user:oidc:alice" }),
+      }),
+      false,
+    );
+    assert.equal(storage.getItem(CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY), null);
+  });
+
+  it("drops malformed JSON without throwing", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY, "{");
+
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-1",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["head-a"], principal: "user:oidc:alice" }),
+      }),
+      false,
+    );
+    assert.equal(storage.getItem(CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY), null);
+  });
+
+  it("rejects malformed marker rows", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY,
+      JSON.stringify({
+        entries: [{ notebookId: "nb-1", principal: "user:oidc:alice", savedAt: 1_000 }],
+        v: 1,
+      }),
+    );
+
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-1",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["head-a"], principal: "user:oidc:alice" }),
+      }),
+      false,
+    );
+  });
+
+  it("clears only the matching notebook and principal entry", () => {
+    const storage = new MemoryStorage();
+
+    writePendingLocalEditMarker(storage, {
+      headsHex: ["head-a"],
+      notebookId: "nb-1",
+      principal: "user:oidc:alice",
+    });
+    writePendingLocalEditMarker(storage, {
+      headsHex: ["head-b"],
+      notebookId: "nb-2",
+      principal: "user:oidc:alice",
+    });
+
+    clearPendingLocalEditMarker(storage, {
+      notebookId: "nb-1",
+      principal: "user:oidc:alice",
+    });
+
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-1",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["head-a"], principal: "user:oidc:alice" }),
+      }),
+      false,
+    );
+    assert.equal(
+      readPendingLocalEditMarker(storage, {
+        notebookId: "nb-2",
+        principal: "user:oidc:alice",
+        seedMeta: meta({ headsHex: ["head-b"], principal: "user:oidc:alice" }),
+      }),
+      true,
+    );
+  });
+});
+
+function meta(overrides: Partial<NotebookDocPersistenceMeta> = {}): NotebookDocPersistenceMeta {
+  return {
+    headsHex: overrides.headsHex ?? ["head-a"],
+    principal: overrides.principal ?? "user:oidc:alice",
+    savedAt: overrides.savedAt ?? 1_000,
+    schemaVersion: 1,
+    ...(overrides.generation !== undefined ? { generation: overrides.generation } : {}),
+  };
+}
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -70,6 +70,11 @@ import {
   loadCloudPersistedNotebookSeed,
   type CloudNotebookPersistenceController,
 } from "./notebook-persistence";
+import {
+  clearPendingLocalEditMarker,
+  readPendingLocalEditMarker,
+  writePendingLocalEditMarker,
+} from "./pending-local-edit-marker";
 import { NOTEBOOK_DOC_HEAL_KEY, SyncHealScheduler } from "./sync-heal";
 import { createCloudNotebookTabBridge } from "./tab-bridge";
 import {
@@ -311,17 +316,37 @@ export function useCloudViewerSession({
   const clearOfflineMergeNotice = useCallback(() => {
     setOfflineMergeNotice(null);
   }, []);
+  const markPendingLocalEditForCurrentRuntime = useCallback(() => {
+    if (connectionStatusBridge.getCurrent() !== "reconnecting") return;
+    const liveRuntime = liveRuntimeRef.current;
+    if (!liveRuntime) return;
+    const principal = cloudPrincipalFromActorLabel(liveRuntime.actorLabel);
+    if (isAnonymousCloudPrincipal(principal)) return;
+    const storage = cloudPendingLocalEditMarkerStorage();
+    if (!storage) return;
+    try {
+      writePendingLocalEditMarker(storage, {
+        headsHex: liveRuntime.handle.get_heads_hex(),
+        notebookId: config.notebookId,
+        principal,
+      });
+    } catch (error) {
+      console.warn("[notebook-cloud] failed to mark pending local edit", error);
+    }
+  }, [config.notebookId, connectionStatusBridge]);
   const noteLocalCellEdit = useCallback(
     (cellId: string, options?: OfflineMergeLocalCellEditOptions) => {
       offlineMergeTracker.noteLocalCellEdit(cellId, options);
+      markPendingLocalEditForCurrentRuntime();
     },
-    [offlineMergeTracker],
+    [markPendingLocalEditForCurrentRuntime, offlineMergeTracker],
   );
   const noteLocalCellDelete = useCallback(
     (cellId: string, options?: OfflineMergeLocalCellEditOptions) => {
       offlineMergeTracker.noteLocalCellDelete(cellId, options);
+      markPendingLocalEditForCurrentRuntime();
     },
-    [offlineMergeTracker],
+    [markPendingLocalEditForCurrentRuntime, offlineMergeTracker],
   );
   // Terminal heal-exhaustion surface (one quiet line; see sync-heal.ts).
   const [syncHealStalled, setSyncHealStalled] = useState(false);
@@ -729,6 +754,39 @@ export function useCloudViewerSession({
           clear: () => clearPersistedNotebookDoc(persistenceAdapter, config.notebookId),
         }
       : undefined;
+    const clearPendingLocalEditMarkerForRuntime = (liveRuntime: CloudSyncRuntime) => {
+      const principal = cloudPrincipalFromActorLabel(liveRuntime.actorLabel);
+      if (isAnonymousCloudPrincipal(principal)) return;
+      const storage = cloudPendingLocalEditMarkerStorage();
+      if (!storage) return;
+      try {
+        clearPendingLocalEditMarker(storage, { notebookId: config.notebookId, principal });
+      } catch (error) {
+        console.warn("[notebook-cloud] failed to clear pending local edit marker", error);
+      }
+    };
+    const armRestoredPendingLocalEditMarker = (
+      liveRuntime: CloudSyncRuntime,
+      principal: string,
+    ) => {
+      const storage = cloudPendingLocalEditMarkerStorage();
+      if (!storage) return;
+      let hasPendingMarker = false;
+      try {
+        hasPendingMarker = readPendingLocalEditMarker(storage, {
+          notebookId: config.notebookId,
+          principal,
+          seedMeta: liveRuntime.persistenceSeedMeta,
+        });
+      } catch (error) {
+        console.warn("[notebook-cloud] failed to read pending local edit marker", error);
+      }
+      if (!hasPendingMarker) return;
+      offlineMergeTracker.notePersistedPendingLocalWork();
+      // The transport may already have reached "online" before the runtime
+      // promise resolved; replay the snapshot so the restored marker settles.
+      offlineMergeTracker.noteConnectionStatus(connectionStatusBridge.getCurrent());
+    };
     // Consume the poison-pill marker: after a seeded session's changes were
     // rejected by the room, the next attempt bootstraps even though the
     // adapter is healthy (the record was cleared, but don't race the clear).
@@ -1322,6 +1380,11 @@ export function useCloudViewerSession({
         }
         liveRuntimeRef.current = liveRuntime;
         installCloudWidgetCommWriter(liveRuntime);
+        const runtimePrincipal = cloudPrincipalFromActorLabel(liveRuntime.actorLabel);
+        const offlineMergeEligible = !isAnonymousCloudPrincipal(runtimePrincipal);
+        // Anonymous sessions are out of scope for offline-merge surfacing
+        // (per-connection principals; persistence never arms for them).
+        offlineMergeTracker.noteSessionEligibility(offlineMergeEligible);
         armPersistence(liveRuntime);
         armTabBridge(liveRuntime);
         // Arm convergence verification for the INITIAL bootstrap exchange.
@@ -1332,11 +1395,6 @@ export function useCloudViewerSession({
         // or surface — and the cold load is the most common connection
         // event.
         syncHeal.noteResyncKicked(NOTEBOOK_DOC_HEAL_KEY);
-        // Anonymous sessions are out of scope for offline-merge surfacing
-        // (per-connection principals; persistence never arms for them).
-        offlineMergeTracker.noteSessionEligibility(
-          !isAnonymousCloudPrincipal(cloudPrincipalFromActorLabel(liveRuntime.actorLabel)),
-        );
         const stopWidgetLiveRuntimeDiagnostics =
           installCloudWidgetLiveRuntimeDiagnostics(liveRuntime);
         setConnectionScope(liveRuntime.connectionScope);
@@ -1453,12 +1511,18 @@ export function useCloudViewerSession({
           liveRuntime.engine.notebookDocChanged$.subscribe(() => {
             offlineMergeTracker.noteLocalDocActivity();
           }),
+          liveRuntime.engine.notebookDocFlushDelivered$.subscribe(() => {
+            clearPendingLocalEditMarkerForRuntime(liveRuntime);
+          }),
           liveRuntime.engine.cellChanges$.subscribe((changeset) => {
             offlineMergeTracker.noteRemoteCellChanges(changeset);
           }),
           { unsubscribe: () => stopCursorDispatch() },
           { unsubscribe: stopWidgetLiveRuntimeDiagnostics },
         ];
+        if (offlineMergeEligible) {
+          armRestoredPendingLocalEditMarker(liveRuntime, runtimePrincipal);
+        }
         liveRuntime.engine.reProjectComms();
         materializeLiveCellsSafely(liveRuntime);
       })
@@ -1782,6 +1846,14 @@ function summarizeWidgetStateDiagnostic(state: unknown): unknown {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function cloudPendingLocalEditMarkerStorage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 }
 
 function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {

--- a/apps/notebook-cloud/viewer/offline-merge-tracker.ts
+++ b/apps/notebook-cloud/viewer/offline-merge-tracker.ts
@@ -80,11 +80,11 @@ export interface OfflineMergeTrackerOptions {
  * elapses fires, once, and firing resets everything. A reconnect with
  * nothing pending resets silently — flaps surface nothing.
  *
- * Out of scope here (recorded in the local-first ADR): cross-reload seeded
- * offline edits (every signed-in reload seeds from the persisted record, so
- * "seeded" alone cannot distinguish offline work from a routine reload
- * without room heads in the handshake) and edits made in the zombie-socket
- * seconds before the transport notices a drop.
+ * Cross-reload seeded offline edits arrive through the durable
+ * pending-local-edit marker: the marker is validated against the loaded
+ * persistence record before calling `notePersistedPendingLocalWork()`, so a
+ * routine signed-in seed stays silent. Edits made in the zombie-socket seconds
+ * before the transport notices a drop remain out of scope.
  */
 export class OfflineMergeTracker {
   private phase: "idle" | "offline" | "settling" = "idle";
@@ -158,6 +158,21 @@ export class OfflineMergeTracker {
     if (!this.eligible) return;
     if (this.phase === "offline") {
       this.pendingLocalFlush = true;
+    }
+  }
+
+  /**
+   * A locally persisted seed carried work that was pending remote acceptance
+   * before this page loaded. Treat the initial connection as the recovery leg
+   * for that prior outage; callers should replay the current connection status
+   * afterward because the bridge may already be "online" by the time the seed
+   * is resolved.
+   */
+  notePersistedPendingLocalWork(): void {
+    if (!this.eligible) return;
+    this.pendingLocalFlush = true;
+    if (this.phase === "idle") {
+      this.phase = "offline";
     }
   }
 

--- a/apps/notebook-cloud/viewer/pending-local-edit-marker.ts
+++ b/apps/notebook-cloud/viewer/pending-local-edit-marker.ts
@@ -1,0 +1,188 @@
+import type { NotebookDocPersistenceMeta } from "runtimed";
+
+export const CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY =
+  "nteract:notebook-cloud:pending-local-edit-marker:v1";
+
+export interface PendingLocalEditMarkerStorage {
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+interface PendingLocalEditMarkerEntry {
+  headsHex: string[];
+  notebookId: string;
+  principal: string;
+  savedAt: number;
+}
+
+interface PendingLocalEditMarkerRoot {
+  entries: PendingLocalEditMarkerEntry[];
+  v: 1;
+}
+
+export function readPendingLocalEditMarker(
+  storage: Pick<PendingLocalEditMarkerStorage, "getItem" | "removeItem" | "setItem">,
+  input: {
+    notebookId: string;
+    principal: string;
+    seedMeta: NotebookDocPersistenceMeta | null | undefined;
+  },
+): boolean {
+  const root = readPendingLocalEditMarkerRoot(storage);
+  if (!root) {
+    return false;
+  }
+  const entry = root.entries.find(
+    (candidate) =>
+      candidate.notebookId === input.notebookId && candidate.principal === input.principal,
+  );
+  if (!entry) {
+    return false;
+  }
+  if (!pendingLocalEditMarkerMatchesSeed(entry, input.seedMeta)) {
+    writePendingLocalEditMarkerRoot(
+      storage,
+      root.entries.filter((candidate) => candidate !== entry),
+    );
+    return false;
+  }
+  return true;
+}
+
+export function writePendingLocalEditMarker(
+  storage: Pick<PendingLocalEditMarkerStorage, "getItem" | "removeItem" | "setItem">,
+  input: {
+    headsHex: string[];
+    notebookId: string;
+    now?: number;
+    principal: string;
+  },
+): void {
+  if (!isPendingLocalEditMarkerInput(input)) {
+    return;
+  }
+  const root = readPendingLocalEditMarkerRoot(storage) ?? { v: 1, entries: [] };
+  const entry = {
+    headsHex: input.headsHex,
+    notebookId: input.notebookId,
+    principal: input.principal,
+    savedAt: input.now ?? Date.now(),
+  } satisfies PendingLocalEditMarkerEntry;
+  writePendingLocalEditMarkerRoot(storage, [
+    entry,
+    ...root.entries.filter(
+      (candidate) =>
+        candidate.notebookId !== input.notebookId || candidate.principal !== input.principal,
+    ),
+  ]);
+}
+
+export function clearPendingLocalEditMarker(
+  storage: Pick<PendingLocalEditMarkerStorage, "getItem" | "removeItem" | "setItem">,
+  input: { notebookId: string; principal: string },
+): void {
+  const root = readPendingLocalEditMarkerRoot(storage);
+  if (!root) {
+    return;
+  }
+  writePendingLocalEditMarkerRoot(
+    storage,
+    root.entries.filter(
+      (candidate) =>
+        candidate.notebookId !== input.notebookId || candidate.principal !== input.principal,
+    ),
+  );
+}
+
+function readPendingLocalEditMarkerRoot(
+  storage: Pick<PendingLocalEditMarkerStorage, "getItem" | "removeItem">,
+): PendingLocalEditMarkerRoot | null {
+  const raw = storage.getItem(CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    storage.removeItem(CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY);
+    return null;
+  }
+  if (!isPendingLocalEditMarkerRoot(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function writePendingLocalEditMarkerRoot(
+  storage: Pick<PendingLocalEditMarkerStorage, "removeItem" | "setItem">,
+  entries: PendingLocalEditMarkerEntry[],
+): void {
+  const retained = entries.slice(0, 16);
+  if (retained.length === 0) {
+    storage.removeItem(CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY);
+    return;
+  }
+  storage.setItem(
+    CLOUD_PENDING_LOCAL_EDIT_MARKER_STORAGE_KEY,
+    JSON.stringify({ entries: retained, v: 1 } satisfies PendingLocalEditMarkerRoot),
+  );
+}
+
+function pendingLocalEditMarkerMatchesSeed(
+  entry: PendingLocalEditMarkerEntry,
+  seedMeta: NotebookDocPersistenceMeta | null | undefined,
+): boolean {
+  return (
+    seedMeta?.principal === entry.principal && headsHexSetsEqual(seedMeta.headsHex, entry.headsHex)
+  );
+}
+
+function headsHexSetsEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const rightSet = new Set(right);
+  return left.every((head) => rightSet.has(head));
+}
+
+function isPendingLocalEditMarkerRoot(value: unknown): value is PendingLocalEditMarkerRoot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<PendingLocalEditMarkerRoot>;
+  return (
+    candidate.v === 1 &&
+    Array.isArray(candidate.entries) &&
+    candidate.entries.every(isPendingLocalEditMarkerEntry)
+  );
+}
+
+function isPendingLocalEditMarkerEntry(value: unknown): value is PendingLocalEditMarkerEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<PendingLocalEditMarkerEntry>;
+  return (
+    typeof candidate.notebookId === "string" &&
+    typeof candidate.principal === "string" &&
+    Number.isFinite(candidate.savedAt) &&
+    Array.isArray(candidate.headsHex) &&
+    candidate.headsHex.every((head) => typeof head === "string")
+  );
+}
+
+function isPendingLocalEditMarkerInput(value: {
+  headsHex: string[];
+  notebookId: string;
+  principal: string;
+}): boolean {
+  return (
+    value.notebookId.trim() !== "" &&
+    value.principal.trim() !== "" &&
+    Array.isArray(value.headsHex) &&
+    value.headsHex.every((head) => typeof head === "string")
+  );
+}

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -447,6 +447,18 @@ export class SyncEngine {
   readonly notebookDocChanged$: Observable<void>;
 
   /**
+   * Fires when a local NotebookDoc sync flush was accepted by the transport.
+   * Replays the latest delivery to late subscribers so hosts can observe an
+   * initial bootstrap flush that completed before their app shell mounted.
+   *
+   * This is paired with the outbound side of `notebookDocChanged$`: hosts
+   * that persist "local work is still pending remote acceptance" markers can
+   * set them on local flush attempts and clear them only after confirmed
+   * delivery. Failed or timed-out deliveries are silent here.
+   */
+  readonly notebookDocFlushDelivered$: Observable<void>;
+
+  /**
    * Fires once per APPLIED inbound NotebookDoc sync frame, whether or not
    * the document changed.
    *
@@ -478,6 +490,7 @@ export class SyncEngine {
   }>();
   private readonly _executionViewChanges$ = new Subject<ExecutionViewChangeset>();
   private readonly _notebookDocChanged$ = new Subject<void>();
+  private readonly _notebookDocFlushDelivered$ = new ReplaySubject<void>(1);
   private readonly _notebookSyncApplied$ = new Subject<void>();
 
   constructor(opts: SyncEngineOptions) {
@@ -502,6 +515,7 @@ export class SyncEngine {
     this.outputIdChanges$ = this._outputIdChanges$.asObservable();
     this.executionViewChanges$ = this._executionViewChanges$.asObservable();
     this.notebookDocChanged$ = this._notebookDocChanged$.asObservable();
+    this.notebookDocFlushDelivered$ = this._notebookDocFlushDelivered$.asObservable();
     this.notebookSyncApplied$ = this._notebookSyncApplied$.asObservable();
 
     // Typed broadcast sub-observables (derived from broadcasts$)
@@ -1368,6 +1382,11 @@ export class SyncEngine {
         "sync to relay",
         () => handle.cancel_last_flush(),
       );
+      done.then((delivered) => {
+        if (delivered) {
+          this._notebookDocFlushDelivered$.next();
+        }
+      });
       // Track the in-flight flush so flushAndWait() can await it.
       this.trackInflightFlush("notebook", done);
     }
@@ -1466,6 +1485,7 @@ export class SyncEngine {
       if (!delivered) {
         return false;
       }
+      this._notebookDocFlushDelivered$.next();
     }
 
     // Also flush RuntimeStateDoc sync.

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1542,6 +1542,64 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("fires delivery after a local flush is accepted", async () => {
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Uint8Array([1, 2, 3]),
+      );
+
+      const engine = createEngine();
+      engine.start();
+
+      let deliveries = 0;
+      engine.notebookDocFlushDelivered$.subscribe(() => {
+        deliveries++;
+      });
+
+      engine.flush();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(deliveries).toBe(1);
+      engine.stop();
+    });
+
+    it("replays the latest accepted local flush to late subscribers", async () => {
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Uint8Array([1, 2, 3]),
+      );
+
+      const engine = createEngine();
+      engine.start();
+
+      engine.flush();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      let deliveries = 0;
+      engine.notebookDocFlushDelivered$.subscribe(() => {
+        deliveries++;
+      });
+      expect(deliveries).toBe(1);
+      engine.stop();
+    });
+
+    it("does not fire delivery when a local flush fails", async () => {
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Uint8Array([1, 2, 3]),
+      );
+      transport.simulateFailure = true;
+
+      const engine = createEngine();
+      engine.start();
+
+      let deliveries = 0;
+      engine.notebookDocFlushDelivered$.subscribe(() => {
+        deliveries++;
+      });
+
+      engine.flush();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(deliveries).toBe(0);
+      engine.stop();
+    });
+
     it("does not fire on a no-op flush", () => {
       (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(null);
 
@@ -1597,6 +1655,24 @@ describe("SyncEngine", () => {
 
       await engine.flushAndWait();
       expect(emissions).toBe(1);
+      engine.stop();
+    });
+
+    it("fires delivery after flushAndWait succeeds", async () => {
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Uint8Array([1, 2, 3]),
+      );
+
+      const engine = createEngine();
+      engine.start();
+
+      let deliveries = 0;
+      engine.notebookDocFlushDelivered$.subscribe(() => {
+        deliveries++;
+      });
+
+      await engine.flushAndWait();
+      expect(deliveries).toBe(1);
       engine.stop();
     });
 


### PR DESCRIPTION
Fixes #3598. The pending-local-edit marker only lived in memory, so a reload during the window between a local edit and its confirmed remote delivery silently dropped the "local work is still pending" signal - the exact liveness-over-durability gap docs/memos/app-shell-local-first.md exists to close.

The marker now persists (principal/notebook-keyed, versioned key, parse-defensive, mirroring the notebook-list cache discipline) and clears on confirmed delivery. The sync engine gains `notebookDocFlushDelivered$` - a replay-1 observable that fires when a local NotebookDoc flush is accepted by the transport - so hosts can set the marker on flush attempts and clear it only on confirmed delivery; failed or timed-out deliveries stay pending.

Shared-package change (`packages/runtimed/src/sync-engine.ts`), so the full blast radius ran: complete vitest suite (only the pre-existing useSyncedSettings flakes, verified identical on main), `apps/notebook` tsc + build, notebook-cloud typecheck/tests (1331 pass), sync-engine suite (115), lint.
