### PR TITLE
fix(runtimed): retry Deno launch transport resets

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -894,6 +894,12 @@ pub enum RuntimeAgentResponse {
     /// Kernel restarted successfully (same runtime agent, new kernel).
     KernelRestarted { env_source: EnvSource },
 
+    /// Kernel launch failed with a typed classification for coordinator policy.
+    KernelLaunchFailed {
+        kind: KernelLaunchFailureKind,
+        error: String,
+    },
+
     /// Code completion result.
     CompletionResult {
         items: Vec<CompletionItem>,
@@ -915,6 +921,19 @@ pub enum RuntimeAgentResponse {
 
     /// Error response.
     Error { error: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KernelLaunchFailureKind {
+    RetryableStartupTransport,
+    PortBind,
+    ProcessExited,
+    StartupTimeout,
+    ToolBootstrap,
+    Misconfiguration,
+    Unsupported,
+    Other,
 }
 
 /// Envelope around a `RuntimeAgentRequest` carrying a correlation ID.
@@ -1583,6 +1602,31 @@ mod tests {
 
         let parsed: RuntimeAgentResponseEnvelope = serde_json::from_value(json).unwrap();
         assert_eq!(parsed.id, "req-42");
+    }
+
+    #[test]
+    fn runtime_agent_launch_failed_response_round_trip_preserves_kind() {
+        let envelope = RuntimeAgentResponseEnvelope {
+            id: "req-42".to_string(),
+            response: RuntimeAgentResponse::KernelLaunchFailed {
+                kind: KernelLaunchFailureKind::RetryableStartupTransport,
+                error: "Failed to launch kernel: Connection reset by peer".to_string(),
+            },
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(json["id"], "req-42");
+        assert_eq!(json["result"], "kernel_launch_failed");
+        assert_eq!(json["kind"], "retryable_startup_transport");
+
+        let parsed: RuntimeAgentResponseEnvelope = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.id, "req-42");
+        assert!(matches!(
+            parsed.response,
+            RuntimeAgentResponse::KernelLaunchFailed {
+                kind: KernelLaunchFailureKind::RetryableStartupTransport,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/runtimed/src/kernel_launch_failure.rs
+++ b/crates/runtimed/src/kernel_launch_failure.rs
@@ -1,0 +1,177 @@
+use std::io::ErrorKind;
+
+use notebook_protocol::protocol::KernelLaunchFailureKind;
+
+pub(crate) fn classify(error: &anyhow::Error) -> KernelLaunchFailureKind {
+    if error.chain().any(is_retryable_startup_transport_cause) {
+        return KernelLaunchFailureKind::RetryableStartupTransport;
+    }
+
+    let message = error
+        .chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    classify_message(&message)
+}
+
+pub(crate) fn uses_fresh_port_retry(kind: KernelLaunchFailureKind) -> bool {
+    matches!(
+        kind,
+        KernelLaunchFailureKind::PortBind | KernelLaunchFailureKind::RetryableStartupTransport
+    )
+}
+
+fn classify_message(message: &str) -> KernelLaunchFailureKind {
+    let lower = message.to_ascii_lowercase();
+
+    if crate::kernel_ports::is_kernel_port_bind_error(&lower) {
+        return KernelLaunchFailureKind::PortBind;
+    }
+
+    if contains_retryable_startup_transport_text(&lower) {
+        return KernelLaunchFailureKind::RetryableStartupTransport;
+    }
+
+    if lower.contains("kernel process exited") || lower.contains("kernel process died") {
+        return KernelLaunchFailureKind::ProcessExited;
+    }
+
+    if lower.contains("timed out")
+        || lower.contains("did not respond within")
+        || lower.contains("connect timed out")
+    {
+        return KernelLaunchFailureKind::StartupTimeout;
+    }
+
+    if lower.contains("unsupported kernel type") {
+        return KernelLaunchFailureKind::Unsupported;
+    }
+
+    if lower.contains("no such file or directory")
+        || lower.contains("command not found")
+        || lower.contains("failed to execute")
+    {
+        return KernelLaunchFailureKind::ToolBootstrap;
+    }
+
+    KernelLaunchFailureKind::Other
+}
+
+fn is_retryable_startup_transport_cause(error: &(dyn std::error::Error + 'static)) -> bool {
+    if let Some(io) = error.downcast_ref::<std::io::Error>() {
+        return is_retryable_startup_io_error(io.kind());
+    }
+
+    if let Some(jupyter) = error.downcast_ref::<jupyter_zmq_client::RuntimeError>() {
+        return is_retryable_jupyter_startup_transport_error(jupyter);
+    }
+
+    false
+}
+
+fn is_retryable_jupyter_startup_transport_error(error: &jupyter_zmq_client::RuntimeError) -> bool {
+    match error {
+        jupyter_zmq_client::RuntimeError::IoError(source) => {
+            is_retryable_startup_io_error(source.kind())
+        }
+        jupyter_zmq_client::RuntimeError::ZmqError(source) => {
+            contains_retryable_startup_transport_text(&source.to_string().to_ascii_lowercase())
+        }
+        _ => false,
+    }
+}
+
+fn is_retryable_startup_io_error(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
+        ErrorKind::ConnectionReset
+            | ErrorKind::UnexpectedEof
+            | ErrorKind::BrokenPipe
+            | ErrorKind::ConnectionAborted
+    )
+}
+
+fn contains_retryable_startup_transport_text(lowercase_message: &str) -> bool {
+    lowercase_message.contains("connection reset")
+        || lowercase_message.contains("broken pipe")
+        || lowercase_message.contains("connection aborted")
+        || lowercase_message.contains("unexpected eof")
+        || lowercase_message.contains("unexpected end of file")
+        || lowercase_message.contains("early eof")
+        || lowercase_message.contains("failed to fill whole buffer")
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn classifies_typed_io_connection_reset_as_retryable_startup_transport() {
+        let error = anyhow::Error::new(jupyter_zmq_client::RuntimeError::IoError(
+            std::io::Error::from(ErrorKind::ConnectionReset),
+        ));
+
+        assert_eq!(
+            classify(&error),
+            KernelLaunchFailureKind::RetryableStartupTransport
+        );
+    }
+
+    #[test]
+    fn classifies_issue_reset_message_as_retryable_startup_transport() {
+        let error = anyhow!(
+            "Failed to launch kernel: Codec/Network Error: Connection reset by peer (os error 104)"
+        );
+
+        assert_eq!(
+            classify(&error),
+            KernelLaunchFailureKind::RetryableStartupTransport
+        );
+    }
+
+    #[test]
+    fn classifies_port_bind_as_port_bind() {
+        let error = anyhow!("Failed to launch kernel: Address already in use (os error 48)");
+
+        assert_eq!(classify(&error), KernelLaunchFailureKind::PortBind);
+    }
+
+    #[test]
+    fn classifies_process_exit_as_process_exited() {
+        let error = anyhow!("Kernel process exited: exit status: 1");
+
+        assert_eq!(classify(&error), KernelLaunchFailureKind::ProcessExited);
+    }
+
+    #[test]
+    fn classifies_startup_timeout_without_retryable_transport() {
+        let error = anyhow!("Kernel did not respond within 30s");
+
+        assert_eq!(classify(&error), KernelLaunchFailureKind::StartupTimeout);
+    }
+
+    #[test]
+    fn fresh_port_retry_applies_only_to_retryable_launch_kinds() {
+        assert!(uses_fresh_port_retry(
+            KernelLaunchFailureKind::RetryableStartupTransport
+        ));
+        assert!(uses_fresh_port_retry(KernelLaunchFailureKind::PortBind));
+        assert!(!uses_fresh_port_retry(
+            KernelLaunchFailureKind::ProcessExited
+        ));
+        assert!(!uses_fresh_port_retry(
+            KernelLaunchFailureKind::StartupTimeout
+        ));
+        assert!(!uses_fresh_port_retry(
+            KernelLaunchFailureKind::ToolBootstrap
+        ));
+        assert!(!uses_fresh_port_retry(
+            KernelLaunchFailureKind::Misconfiguration
+        ));
+        assert!(!uses_fresh_port_retry(KernelLaunchFailureKind::Unsupported));
+        assert!(!uses_fresh_port_retry(KernelLaunchFailureKind::Other));
+    }
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -38,6 +38,7 @@ pub(crate) mod ipykernel_error;
 pub mod jupyter_kernel;
 pub mod kernel_connection;
 pub mod kernel_dispatch;
+pub(crate) mod kernel_launch_failure;
 pub(crate) mod kernel_ports;
 pub mod kernel_state;
 pub mod launcher_cache;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -4219,7 +4219,13 @@ pub(crate) async fn auto_launch_kernel(
                             kernel_type, es_label
                         );
                     }
-                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
+                    Ok(
+                        notebook_protocol::protocol::RuntimeAgentResponse::Error { error }
+                        | notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunchFailed {
+                            error,
+                            ..
+                        },
+                    ) => {
                         warn!("[notebook-sync] Agent kernel launch failed: {}", error);
                         // Surface the failure through CRDT so the UI
                         // doesn't sit on "starting" forever. The error

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+const KERNEL_LAUNCH_RETRY_BACKOFF_INITIAL: std::time::Duration =
+    std::time::Duration::from_millis(100);
+const KERNEL_LAUNCH_RETRY_BACKOFF_MAX: std::time::Duration = std::time::Duration::from_millis(500);
+
 pub(crate) async fn send_runtime_agent_command(
     room: &NotebookRoom,
     request: notebook_protocol::protocol::RuntimeAgentRequest,
@@ -73,7 +77,8 @@ pub(crate) async fn send_runtime_agent_request(
 }
 
 /// Reserve daemon-owned kernel ports, send a launch/restart request, and retry
-/// with a fresh reservation if the runtime agent loses a port bind race.
+/// with a fresh reservation if the runtime agent reports a retryable launch
+/// failure.
 pub(crate) async fn send_runtime_agent_request_with_kernel_ports<F>(
     room: &NotebookRoom,
     mut build_request: F,
@@ -88,29 +93,74 @@ where
         let response =
             send_runtime_agent_request(room, build_request(port_reservation.ports())).await?;
 
-        match &response {
-            notebook_protocol::protocol::RuntimeAgentResponse::Error { error }
-                if crate::kernel_ports::is_kernel_port_bind_error(error)
-                    && attempt < crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS =>
-            {
-                warn!(
-                    "[notebook-sync] Runtime agent hit kernel port bind race on attempt {}/{}; retrying with fresh ports: {}",
-                    attempt,
-                    crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS,
-                    error
-                );
-                continue;
-            }
-            _ => return Ok(response),
+        if let Some(delay) = kernel_launch_retry_delay(
+            &response,
+            attempt,
+            crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS,
+        ) {
+            warn!(
+                "[notebook-sync] Runtime agent reported retryable kernel launch failure on attempt {}/{}; retrying with fresh ports after {:?}: {}",
+                attempt,
+                crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS,
+                delay,
+                kernel_launch_failure_error(&response).unwrap_or("unknown launch failure")
+            );
+            tokio::time::sleep(delay).await;
+            continue;
         }
+
+        return Ok(response);
     }
 
     unreachable!("kernel port launch retry loop must return from the final attempt")
 }
 
+fn kernel_launch_retry_delay(
+    response: &notebook_protocol::protocol::RuntimeAgentResponse,
+    attempt: usize,
+    max_attempts: usize,
+) -> Option<std::time::Duration> {
+    use notebook_protocol::protocol::RuntimeAgentResponse;
+
+    let RuntimeAgentResponse::KernelLaunchFailed { kind, .. } = response else {
+        return None;
+    };
+
+    if attempt >= max_attempts {
+        return None;
+    }
+
+    if crate::kernel_launch_failure::uses_fresh_port_retry(*kind) {
+        Some(kernel_launch_backoff(attempt))
+    } else {
+        None
+    }
+}
+
+fn kernel_launch_backoff(attempt: usize) -> std::time::Duration {
+    let multiplier = 1_u32
+        .checked_shl(attempt.saturating_sub(1) as u32)
+        .unwrap_or(u32::MAX);
+    KERNEL_LAUNCH_RETRY_BACKOFF_INITIAL
+        .saturating_mul(multiplier)
+        .min(KERNEL_LAUNCH_RETRY_BACKOFF_MAX)
+}
+
+fn kernel_launch_failure_error(
+    response: &notebook_protocol::protocol::RuntimeAgentResponse,
+) -> Option<&str> {
+    match response {
+        notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunchFailed { error, .. } => {
+            Some(error.as_str())
+        }
+        notebook_protocol::protocol::RuntimeAgentResponse::Error { error } => Some(error.as_str()),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use notebook_protocol::protocol::RuntimeAgentResponse;
+    use notebook_protocol::protocol::{KernelLaunchFailureKind, RuntimeAgentResponse};
 
     use super::*;
 
@@ -148,5 +198,55 @@ mod tests {
             .expect_err("timeout should fail");
 
         assert_eq!(error.to_string(), "Runtime agent query timed out");
+    }
+
+    #[test]
+    fn kernel_launch_retry_delay_retries_startup_transport_before_final_attempt() {
+        let response = RuntimeAgentResponse::KernelLaunchFailed {
+            kind: KernelLaunchFailureKind::RetryableStartupTransport,
+            error: "Failed to launch kernel: Connection reset by peer".to_string(),
+        };
+
+        assert_eq!(
+            kernel_launch_retry_delay(&response, 1, 4),
+            Some(std::time::Duration::from_millis(100))
+        );
+        assert_eq!(
+            kernel_launch_retry_delay(&response, 3, 4),
+            Some(std::time::Duration::from_millis(400))
+        );
+    }
+
+    #[test]
+    fn kernel_launch_retry_delay_retries_port_bind_before_final_attempt() {
+        let response = RuntimeAgentResponse::KernelLaunchFailed {
+            kind: KernelLaunchFailureKind::PortBind,
+            error: "Failed to launch kernel: Address already in use".to_string(),
+        };
+
+        assert_eq!(
+            kernel_launch_retry_delay(&response, 2, 4),
+            Some(std::time::Duration::from_millis(200))
+        );
+    }
+
+    #[test]
+    fn kernel_launch_retry_delay_stops_on_final_attempt() {
+        let response = RuntimeAgentResponse::KernelLaunchFailed {
+            kind: KernelLaunchFailureKind::RetryableStartupTransport,
+            error: "Failed to launch kernel: Connection reset by peer".to_string(),
+        };
+
+        assert_eq!(kernel_launch_retry_delay(&response, 4, 4), None);
+    }
+
+    #[test]
+    fn kernel_launch_retry_delay_does_not_retry_process_exit() {
+        let response = RuntimeAgentResponse::KernelLaunchFailed {
+            kind: KernelLaunchFailureKind::ProcessExited,
+            error: "Failed to launch kernel: Kernel process exited: exit status: 1".to_string(),
+        };
+
+        assert_eq!(kernel_launch_retry_delay(&response, 1, 4), None);
     }
 }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1593,7 +1593,13 @@ pub(crate) async fn handle(
                         launched_config,
                     };
                 }
-                Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
+                Ok(
+                    notebook_protocol::protocol::RuntimeAgentResponse::Error { error }
+                    | notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunchFailed {
+                        error,
+                        ..
+                    },
+                ) => {
                     reset_starting_state(room, None).await;
                     return NotebookResponse::Error {
                         error: format!("Agent restart failed: {}", error),
@@ -1763,7 +1769,13 @@ pub(crate) async fn handle(
                             launched_config,
                         }
                     }
-                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
+                    Ok(
+                        notebook_protocol::protocol::RuntimeAgentResponse::Error { error }
+                        | notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunchFailed {
+                            error,
+                            ..
+                        },
+                    ) => {
                         // Mirror the response into CRDT so UIs that
                         // watch RuntimeStateDoc (not the RPC reply)
                         // also see the failure.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -55,6 +55,14 @@ use crate::protocol::QueueEntry;
 mod echo_suppression;
 use echo_suppression::EchoSuppressor;
 
+fn runtime_agent_response_error(response: &RuntimeAgentResponse) -> Option<&str> {
+    match response {
+        RuntimeAgentResponse::Error { error }
+        | RuntimeAgentResponse::KernelLaunchFailed { error, .. } => Some(error.as_str()),
+        _ => None,
+    }
+}
+
 /// Minimum interval between reconnect cycles on a recoverable transport,
 /// covering *both* recoverable-failure arms: a clean EOF and a stream framing
 /// error. `reconnect_with_backoff` only delays between *failed* connects, so a
@@ -813,7 +821,8 @@ where
                                             interrupt_handle = kernel
                                                 .as_ref()
                                                 .and_then(|k| k.interrupt_handle());
-                                            if let RuntimeAgentResponse::Error { error } = response
+                                            if let Some(error) =
+                                                runtime_agent_response_error(&response)
                                             {
                                                 warn!(
                                                     "[runtime-agent] Launch-on-attach failed: {}",
@@ -1764,23 +1773,30 @@ async fn handle_runtime_agent_request(
                     )
                 }
                 Err(e) => {
+                    let kind = crate::kernel_launch_failure::classify(&e);
                     warn!(
-                        "[runtime-agent] LaunchKernel failed: type={} source={} elapsed_ms={} error={}",
+                        "[runtime-agent] LaunchKernel failed: type={} source={} elapsed_ms={} kind={:?} error={}",
                         launch_kernel_type,
                         launch_env_source,
                         launch_started.elapsed().as_millis(),
+                        kind,
                         e
                     );
                     let error = format!("Failed to launch kernel: {e}");
-                    if let Err(write_error) = record_kernel_launch_failed_state(
-                        ctx,
-                        &launch_kernel_type,
-                        &launch_env_source,
-                        &error,
-                    ) {
-                        warn!("[runtime-state] {}", write_error);
+                    if !crate::kernel_launch_failure::uses_fresh_port_retry(kind) {
+                        if let Err(write_error) = record_kernel_launch_failed_state(
+                            ctx,
+                            &launch_kernel_type,
+                            &launch_env_source,
+                            &error,
+                        ) {
+                            warn!("[runtime-state] {}", write_error);
+                        }
                     }
-                    (RuntimeAgentResponse::Error { error }, None)
+                    (
+                        RuntimeAgentResponse::KernelLaunchFailed { kind, error },
+                        None,
+                    )
                 }
             }
         }
@@ -1924,23 +1940,30 @@ async fn handle_runtime_agent_request(
                     )
                 }
                 Err(e) => {
+                    let kind = crate::kernel_launch_failure::classify(&e);
                     warn!(
-                        "[runtime-agent] RestartKernel failed: type={} source={} elapsed_ms={} error={}",
+                        "[runtime-agent] RestartKernel failed: type={} source={} elapsed_ms={} kind={:?} error={}",
                         launch_kernel_type,
                         launch_env_source,
                         launch_started.elapsed().as_millis(),
+                        kind,
                         e
                     );
                     let error = format!("Failed to restart kernel: {e}");
-                    if let Err(write_error) = record_kernel_launch_failed_state(
-                        ctx,
-                        &launch_kernel_type,
-                        &launch_env_source,
-                        &error,
-                    ) {
-                        warn!("[runtime-state] {}", write_error);
+                    if !crate::kernel_launch_failure::uses_fresh_port_retry(kind) {
+                        if let Err(write_error) = record_kernel_launch_failed_state(
+                            ctx,
+                            &launch_kernel_type,
+                            &launch_env_source,
+                            &error,
+                        ) {
+                            warn!("[runtime-state] {}", write_error);
+                        }
                     }
-                    (RuntimeAgentResponse::Error { error }, None)
+                    (
+                        RuntimeAgentResponse::KernelLaunchFailed { kind, error },
+                        None,
+                    )
                 }
             }
         }


### PR DESCRIPTION
Fixes #3665. Deno auto-launch treated startup transport resets (connection reset by peer during the ZMQ handshake window) as terminal, so a transient reset left the kernel dead instead of retrying.

Launch failures are now classified: a typed `RetryableStartupTransport` kind, derived from the error cause chain (retryable io::ErrorKinds, jupyter zmq transport errors) with a message-text fallback, distinct from genuine startup timeouts. The runtime-agent launch path retries retryable classifications with fresh kernel ports and bounded backoff, reusing the existing reconnect_with_backoff discipline; non-retryable failures surface exactly as before.

Gates: full runtimed lib suite (1050 tests, including the new classification coverage), tokio mutex lint, cargo xtask lint.
