### PR TITLE
docs: stop pointing workstation pairing examples at app.runt.run

### DIFF
--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -57,11 +57,14 @@ The pairing flow needs no externally issued credential
 (`docs/adr/hosted-credential-transport.md`, Decision 9):
 
 1. In the hosted workstation panel, mint a pairing code. Codes look like
-   `XXXX-XXXX-XXXX`, live 10 minutes, and are single use.
-2. On the workstation:
+   `XXXX-XXXX-XXXX`, live 10 minutes, and are single use. The panel's
+   "Connect a machine" card shows these commands with the correct cloud host
+   filled in - prefer copying from there.
+2. On the workstation, using the cloud host you signed in to (currently
+   `https://preview.runt.run`):
 
 ```bash
-runt workstation connect https://app.runt.run --code XXXX-XXXX-XXXX
+runt workstation connect https://<cloud-host> --code XXXX-XXXX-XXXX
 ```
 
    (Omit `--code` to be prompted.) This redeems the code for a long-lived
@@ -171,7 +174,7 @@ deployments that issue their own credentials:
 
 ```bash
 RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
-  --cloud-url https://app.runt.run \
+  --cloud-url https://<cloud-host> \
   --notebook-id <id> \
   --python-path "$(command -v python3)"
 ```


### PR DESCRIPTION
The workstation runbook's pairing examples pointed at `app.runt.run`, which is a retired deployment of the pre-nteract stack - following the doc verbatim pairs a workstation against the wrong service. Examples now use a `<cloud-host>` placeholder (live host named once: preview.runt.run, until n.anaconda.com), and direct operators to the workstation panel's Connect-a-machine card, which renders the commands with the correct host filled in.
