### PR TITLE
feat(cloud): surface room link health in the workstation panel

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -228,6 +228,7 @@ test("cloud shell capabilities require live runtime peer presence for executable
     selectedMode: "edit",
     runtimeAvailable: false,
     runtimePeerCount: 0,
+    runtimeLastSeenAt: "2026-06-07T21:02:00Z",
     workstationAttachment: {
       workstation_id: "ws-lab2",
       display_name: "Lab 2",
@@ -251,9 +252,14 @@ test("cloud shell capabilities require live runtime peer presence for executable
   assert.equal(capabilities.runtime.target?.statusLabel, "Needs attention");
   assert.equal(
     capabilities.runtime.target?.detail,
-    "Runtime peer disconnected: no compute session is currently attached to the room.",
+    "Room link lost: no compute session is currently attached to the room.",
   );
   assert.equal(capabilities.runtime.target?.runtimePeerCount, null);
+  assert.deepEqual(capabilities.runtime.target?.roomLink, {
+    status: "lost",
+    statusLabel: "Lost",
+    lastSeenAt: "2026-06-07T21:02:00Z",
+  });
   assert.equal(capabilities.canExecute, false);
 });
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -790,6 +790,7 @@ export function NotebookViewer({
       hasAppSession,
       hostCapabilities: config.hostCapabilities,
       kernelStatusLabel: cloudKernelStatusLabel,
+      runtimeLastSeenAt: runtimeState.kernel.last_seen,
       runtimePeerAvailable,
       runtimePeerCount,
       selectedMode: selectedInteractionModeForAccess,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -70,6 +70,10 @@ export interface CloudNotebookShellCapabilityInput {
    */
   kernelStatusLabel?: string | null;
   /**
+   * RuntimeStateDoc-derived room-link heartbeat from the runtime peer.
+   */
+  runtimeLastSeenAt?: string | null;
+  /**
    * Room-host-owned RuntimeStateDoc workstation attachment snapshot. When
    * present this is the durable notebook-visible source for the selected
    * compute target; live presence remains the fallback while older rooms have
@@ -100,6 +104,7 @@ export function cloudNotebookShellCapabilities({
   runtimeAvailable = false,
   runtimePeerCount = runtimeAvailable ? 1 : 0,
   kernelStatusLabel = null,
+  runtimeLastSeenAt = null,
   workstationAttachment = null,
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
@@ -159,6 +164,7 @@ export function cloudNotebookShellCapabilities({
       runtimeAvailable: effectiveRuntimeAvailable,
       runtimePeerCount,
       kernelStatusLabel,
+      runtimeLastSeenAt,
       workstationAttachment,
       canChooseHostedWorkstation,
     }),
@@ -209,6 +215,7 @@ function cloudRuntimeTarget({
   runtimeAvailable,
   runtimePeerCount,
   kernelStatusLabel,
+  runtimeLastSeenAt,
   workstationAttachment,
   canChooseHostedWorkstation,
 }: {
@@ -216,6 +223,7 @@ function cloudRuntimeTarget({
   runtimeAvailable: boolean;
   runtimePeerCount: number;
   kernelStatusLabel: string | null;
+  runtimeLastSeenAt: string | null;
   workstationAttachment: WorkstationAttachmentState | null;
   canChooseHostedWorkstation: boolean;
 }): NotebookShellRuntimeTargetProjection {
@@ -232,11 +240,21 @@ function cloudRuntimeTarget({
       defaultEnvironmentLabel: "Runtime peer",
       environmentLabel: "Runtime peer",
       runtimePeerCount: visibleRuntimePeerCount || 1,
+      roomLink: {
+        status: "connected",
+        statusLabel: "Connected",
+        lastSeenAt: runtimeLastSeenAt,
+      },
     };
   }
   const attachmentTarget = projectNotebookRuntimeTargetFromWorkstationAttachment(
     workstationAttachment,
-    { runtimePeerCount: visibleRuntimePeerCount, kernelStatusLabel, requireRuntimePeer: true },
+    {
+      runtimePeerCount: visibleRuntimePeerCount,
+      kernelStatusLabel,
+      requireRuntimePeer: true,
+      runtimeLastSeenAt,
+    },
   );
   if (attachmentTarget) {
     return attachmentTarget;
@@ -254,6 +272,11 @@ function cloudRuntimeTarget({
       environmentLabel: "Current Python",
       kernelStatusLabel,
       runtimePeerCount: visibleRuntimePeerCount || 1,
+      roomLink: {
+        status: "connected",
+        statusLabel: "Connected",
+        lastSeenAt: runtimeLastSeenAt,
+      },
     };
   }
   return {

--- a/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
@@ -34,6 +34,7 @@ interface UseCloudShellCapabilitiesInput {
   runtimePeerAvailable: boolean;
   runtimePeerCount: number;
   kernelStatusLabel: string | null;
+  runtimeLastSeenAt?: string | null;
   workstationAttachment: WorkstationAttachmentState | null;
   hostCapabilities: CloudViewerConfig["hostCapabilities"];
 }
@@ -67,6 +68,7 @@ export function useCloudShellCapabilities({
   runtimePeerAvailable,
   runtimePeerCount,
   kernelStatusLabel,
+  runtimeLastSeenAt = null,
   workstationAttachment,
   hostCapabilities,
 }: UseCloudShellCapabilitiesInput): CloudShellCapabilities {
@@ -126,6 +128,7 @@ export function useCloudShellCapabilities({
         runtimeAvailable: runtimePeerAvailable,
         runtimePeerCount,
         kernelStatusLabel,
+        runtimeLastSeenAt,
         workstationAttachment,
         hostCapabilities,
       }),
@@ -143,6 +146,7 @@ export function useCloudShellCapabilities({
       editReadiness.canAcceptCellMutations,
       editReadiness.editAccessRequestPending,
       kernelStatusLabel,
+      runtimeLastSeenAt,
       runtimePeerCount,
       runtimePeerAvailable,
       selectedMode,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -42,6 +42,7 @@ use notebook_protocol::protocol::{NotebookBroadcast, RuntimeAgentRequest, Runtim
 use runtime_doc::{CommsDoc, CommsDocHandle, ExecutionState, RuntimeLifecycle, RuntimeStateDoc};
 use runtime_doc::{KernelActivity, RuntimeStateHandle};
 use tokio::sync::{broadcast, mpsc, RwLock};
+use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, warn};
 
 use crate::blob_store::BlobStore;
@@ -75,6 +76,11 @@ fn runtime_agent_response_error(response: &RuntimeAgentResponse) -> Option<&str>
 /// is gated out of the floor by `clean_eof_is_recoverable() == false`).
 const RECOVERABLE_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// Cloud runtime peers stamp their room-link heartbeat into RuntimeStateDoc.
+/// The UDS path is local daemon transport and stays out of this hosted-room
+/// signal.
+const RUNTIME_ROOM_LINK_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Runtime-agent-local buffer for live kernel broadcasts. These carry
 /// ephemeral custom widget events such as ipympl PNG frames. Match the
 /// coordinator room broadcast capacity so the runtime-agent bridge can absorb
@@ -99,6 +105,13 @@ fn reconnect_floor_delay(
     match since_last_reconnect {
         Some(since) if since < floor => Some(floor - since),
         _ => None,
+    }
+}
+
+fn record_runtime_room_link_seen(state: &RuntimeStateHandle) {
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    if let Err(error) = state.with_doc(|sd| sd.set_last_seen(Some(&timestamp))) {
+        warn!("[runtime-agent] Failed to stamp runtime room link heartbeat: {error}");
     }
 }
 
@@ -522,6 +535,15 @@ where
     let mut orphan_comm_candidates: HashSet<String> = HashSet::new();
     let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<&'static str>();
     install_runtime_agent_shutdown_signal_handlers(shutdown_tx);
+    let runtime_room_link_heartbeat_enabled = transport.clean_eof_is_recoverable();
+    let mut runtime_room_link_heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + RUNTIME_ROOM_LINK_HEARTBEAT,
+        RUNTIME_ROOM_LINK_HEARTBEAT,
+    );
+    runtime_room_link_heartbeat.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    if runtime_room_link_heartbeat_enabled {
+        record_runtime_room_link_seen(&state);
+    }
 
     // -- 3b. Launch-on-attach gate (cloud only) -----------------------------
     //
@@ -1220,6 +1242,10 @@ where
                         }
                     }
                 }
+            }
+
+            _ = runtime_room_link_heartbeat.tick(), if runtime_room_link_heartbeat_enabled => {
+                record_runtime_room_link_seen(&ctx.state);
             }
 
             // Process-level shutdown from the workstation agent or host. This

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -344,6 +344,8 @@ export {
   type NotebookShellControlPolicy,
   type NotebookShellExecutionPolicy,
   type NotebookShellPackagePolicy,
+  type NotebookShellRoomLinkProjection,
+  type NotebookShellRoomLinkStatus,
   type NotebookShellRuntimeCapabilities,
   type NotebookShellRuntimeTargetKind,
   type NotebookShellRuntimeTargetProjection,

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -57,6 +57,14 @@ export type NotebookShellRuntimeTargetStatus =
   | "offline"
   | "attention";
 
+export type NotebookShellRoomLinkStatus = "connected" | "reconnecting" | "lost";
+
+export interface NotebookShellRoomLinkProjection {
+  status: NotebookShellRoomLinkStatus;
+  statusLabel: string;
+  lastSeenAt: string | null;
+}
+
 export interface NotebookShellRuntimeTargetProjection {
   /**
    * Stable host-owned workstation identifier. This is intentionally not a
@@ -96,6 +104,12 @@ export interface NotebookShellRuntimeTargetProjection {
    * is presence/runtime state, not an ACL or workstation registry fact.
    */
   runtimePeerCount?: number | null;
+  /**
+   * Host-observed link between a hosted runtime/workstation peer and the room.
+   * The host projects this from durable runtime state and room presence; shared
+   * UI should not infer transport health from React-local socket state.
+   */
+  roomLink?: NotebookShellRoomLinkProjection | null;
   workingDirectoryLabel?: string | null;
 }
 
@@ -144,6 +158,7 @@ export interface ProjectNotebookRuntimeTargetFromWorkstationAttachmentOptions {
    */
   requireRuntimePeer?: boolean;
   runtimePeerCount?: number | null;
+  runtimeLastSeenAt?: string | null;
 }
 
 export interface NotebookShellCapabilities {
@@ -286,6 +301,7 @@ export function projectNotebookRuntimeTargetFromWorkstationAttachment(
   if (!attachment) return null;
 
   const runtimePeerCount = normalizePositiveInteger(options.runtimePeerCount);
+  const runtimeLastSeenAt = trimToNull(options.runtimeLastSeenAt);
   const missingRequiredRuntimePeer =
     Boolean(options.requireRuntimePeer) &&
     workstationAttachmentCanExecute(attachment) &&
@@ -316,6 +332,12 @@ export function projectNotebookRuntimeTargetFromWorkstationAttachment(
     cpuCount: normalizePositiveInteger(attachment.cpu_count),
     memoryBytes: normalizePositiveInteger(attachment.memory_bytes),
     runtimePeerCount,
+    roomLink: projectRuntimeRoomLink({
+      attachmentStatus: attachment.status,
+      missingRequiredRuntimePeer,
+      runtimeLastSeenAt,
+      runtimePeerCount,
+    }),
     workingDirectoryLabel: trimToNull(attachment.working_directory),
   };
 }
@@ -325,6 +347,52 @@ export function workstationAttachmentCanExecute(
 ): boolean {
   if (!attachment) return false;
   return attachment.status === "ready" || attachment.status === "busy";
+}
+
+function projectRuntimeRoomLink({
+  attachmentStatus,
+  missingRequiredRuntimePeer,
+  runtimeLastSeenAt,
+  runtimePeerCount,
+}: {
+  attachmentStatus: string | null | undefined;
+  missingRequiredRuntimePeer: boolean;
+  runtimeLastSeenAt: string | null;
+  runtimePeerCount: number | null;
+}): NotebookShellRoomLinkProjection | null {
+  if (runtimePeerCount !== null) {
+    return {
+      status: "connected",
+      statusLabel: "Connected",
+      lastSeenAt: runtimeLastSeenAt,
+    };
+  }
+
+  if (missingRequiredRuntimePeer) {
+    return {
+      status: "lost",
+      statusLabel: "Lost",
+      lastSeenAt: runtimeLastSeenAt,
+    };
+  }
+
+  if (attachmentStatus === "connecting") {
+    return {
+      status: "reconnecting",
+      statusLabel: "Reconnecting",
+      lastSeenAt: runtimeLastSeenAt,
+    };
+  }
+
+  if (runtimeLastSeenAt) {
+    return {
+      status: "lost",
+      statusLabel: "Lost",
+      lastSeenAt: runtimeLastSeenAt,
+    };
+  }
+
+  return null;
 }
 
 export function workstationAttachmentIsConnected(
@@ -499,6 +567,12 @@ const NOTEBOOK_SHELL_RUNTIME_TARGET_CACHE_FIELDS = {
   memoryBytes: (target) => target.memoryBytes ?? null,
   resourceLabel: (target) => target.resourceLabel ?? null,
   runtimePeerCount: (target) => target.runtimePeerCount ?? null,
+  roomLink: (target) =>
+    stableCacheKey([
+      target.roomLink?.status ?? null,
+      target.roomLink?.statusLabel ?? null,
+      target.roomLink?.lastSeenAt ?? null,
+    ]),
   workingDirectoryLabel: (target) => target.workingDirectoryLabel ?? null,
   runtimeSessionId: (target) => target.runtimeSessionId ?? null,
 } satisfies ProjectionCacheFieldReaders<NotebookShellRuntimeTargetProjection>;
@@ -794,6 +868,13 @@ function stableNotebookShellRuntimeTarget(
     memoryBytes: target.memoryBytes ?? null,
     resourceLabel: target.resourceLabel ?? null,
     runtimePeerCount: target.runtimePeerCount ?? null,
+    roomLink: target.roomLink
+      ? Object.freeze({
+          status: target.roomLink.status,
+          statusLabel: target.roomLink.statusLabel,
+          lastSeenAt: target.roomLink.lastSeenAt,
+        })
+      : null,
     workingDirectoryLabel: target.workingDirectoryLabel ?? null,
   });
   setBoundedCacheValue(SHELL_RUNTIME_TARGET_CACHE, cacheKey, stableTarget, SHELL_PART_CACHE_LIMIT);
@@ -875,7 +956,7 @@ function workstationAttachmentStatusProjection(
     return {
       status: "attention",
       statusLabel: "Needs attention",
-      detail: "Runtime peer disconnected: no compute session is currently attached to the room.",
+      detail: "Room link lost: no compute session is currently attached to the room.",
     };
   }
 

--- a/packages/runtimed/src/notebook-workstation-panel.ts
+++ b/packages/runtimed/src/notebook-workstation-panel.ts
@@ -17,6 +17,7 @@ export type NotebookWorkstationFactKind =
   | "cpu"
   | "memory"
   | "resource"
+  | "room_link"
   | "runtime_peers"
   | "working_directory"
   | "execution_state"
@@ -74,6 +75,9 @@ export function projectNotebookWorkstationPanel(
     target.memoryBytes ?? null,
     target.resourceLabel ?? null,
     target.runtimePeerCount ?? null,
+    target.roomLink?.status ?? null,
+    target.roomLink?.statusLabel ?? null,
+    target.roomLink?.lastSeenAt ?? null,
     target.workingDirectoryLabel ?? null,
     target.runtimeSessionId ?? null,
   ]);
@@ -105,6 +109,9 @@ export function projectNotebookWorkstationPanel(
   }
   if (!hasCpuCount && !memoryLabel && target.resourceLabel) {
     facts.push(workstationFact("resource", "Resources", target.resourceLabel));
+  }
+  if (target.roomLink) {
+    facts.push(roomLinkFact(target.roomLink));
   }
   if (typeof target.runtimePeerCount === "number" && target.runtimePeerCount > 0) {
     facts.push(workstationFact("runtime_peers", "Compute sessions", `${target.runtimePeerCount}`));
@@ -241,7 +248,21 @@ function isRuntimePeerDisconnectDetail(detail: string): boolean {
   const normalized = detail.trim().toLowerCase();
   return (
     normalized.startsWith("runtime peer disconnected") ||
-    normalized.includes("runtime peer left the room")
+    normalized.includes("runtime peer left the room") ||
+    normalized.startsWith("room link lost")
+  );
+}
+
+function roomLinkFact(
+  roomLink: NonNullable<ReturnType<typeof resolveNotebookShellRuntimeTarget>["roomLink"]>,
+): NotebookWorkstationFactProjection {
+  const suffix = roomLink.lastSeenAt ? ` - last seen ${roomLink.lastSeenAt}` : "";
+  return workstationFact(
+    "room_link",
+    "Room link",
+    `${roomLink.statusLabel}${suffix}`,
+    false,
+    roomLink.status === "connected" ? "positive" : "attention",
   );
 }
 

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -100,6 +100,12 @@ export interface KernelState {
   name: string;
   language: string;
   env_source: string;
+  /**
+   * Runtime-peer liveness heartbeat. Cloud runtime peers stamp this when their
+   * room link is alive so viewers can distinguish "never attached" from
+   * "previously attached, now stale."
+   */
+  last_seen: string | null;
 }
 
 export interface QueueEntry {
@@ -338,6 +344,7 @@ export const DEFAULT_RUNTIME_STATE: RuntimeState = {
     name: "",
     language: "",
     env_source: "",
+    last_seen: null,
   },
   queue: {
     executing: null,

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -499,8 +499,30 @@ describe("projectNotebookRuntimeTargetFromWorkstationAttachment", () => {
       id: "ws-lab2",
       status: "attention",
       statusLabel: "Needs attention",
-      detail: "Runtime peer disconnected: no compute session is currently attached to the room.",
+      detail: "Room link lost: no compute session is currently attached to the room.",
       runtimePeerCount: null,
+      roomLink: {
+        status: "lost",
+        statusLabel: "Lost",
+        lastSeenAt: null,
+      },
+    });
+  });
+
+  it("carries room-link last-seen state for stale hosted attachments", () => {
+    const target = projectNotebookRuntimeTargetFromWorkstationAttachment(attachment(), {
+      requireRuntimePeer: true,
+      runtimePeerCount: 0,
+      runtimeLastSeenAt: "2026-06-07T21:02:00Z",
+    });
+
+    expect(target).toMatchObject({
+      status: "attention",
+      roomLink: {
+        status: "lost",
+        statusLabel: "Lost",
+        lastSeenAt: "2026-06-07T21:02:00Z",
+      },
     });
   });
 });

--- a/packages/runtimed/tests/notebook-workstation-panel.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-panel.test.ts
@@ -218,10 +218,14 @@ describe("projectNotebookWorkstationPanel", () => {
       status: "attention" as const,
       label: "Lab2",
       statusLabel: "Needs attention",
-      detail:
-        "runtime peer disconnected: runtime peer left the room and did not return within the grace window",
+      detail: "Room link lost: no compute session is currently attached to the room.",
       providerLabel: "Workstation",
       defaultEnvironmentLabel: "Current Python",
+      roomLink: {
+        status: "lost" as const,
+        statusLabel: "Lost",
+        lastSeenAt: "2026-06-07T21:02:00Z",
+      },
     };
     const ownerProjection = projectNotebookWorkstationPanel(
       capabilities({
@@ -257,6 +261,9 @@ describe("projectNotebookWorkstationPanel", () => {
     );
     expect(ownerProjection.detail).not.toContain("runtime peer");
     expect(viewerProjection.detail).not.toContain("grace window");
+    expect(ownerProjection.facts.map((fact) => [fact.kind, fact.label, fact.value])).toContainEqual(
+      ["room_link", "Room link", "Lost - last seen 2026-06-07T21:02:00Z"],
+    );
     expect(ownerProjection).not.toBe(viewerProjection);
   });
 });

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -138,6 +138,7 @@ function makeRuntimeState(
       name: "python3",
       language: "python",
       env_source: "",
+      last_seen: null,
     },
     queue: { executing: null, queued: [] },
     env: {
@@ -791,6 +792,7 @@ describe("SyncEngine", () => {
           name: "python3",
           language: "python",
           env_source: "",
+          last_seen: null,
         },
         queue: { executing: null, queued: [] },
         env: {
@@ -883,6 +885,7 @@ describe("SyncEngine", () => {
           name: "python3",
           language: "python",
           env_source: "",
+          last_seen: null,
         },
         queue: { executing: null, queued: [] },
         env: {


### PR DESCRIPTION
Implements the runtime-context slice of #3599. When a hosted compute session's link to the room degrades, the UI said nothing - compute just looked stuck. Cloud runtime peers now stamp a room-link heartbeat (15s, hosted transports only - UDS stays out of the signal) into `RuntimeStateDoc.kernel.last_seen`; `packages/runtimed` projects it as structured `roomLink` state (connected / reconnecting / lost, with lastSeenAt); the workstation panel shows it as a quiet "Room link" fact alongside the existing stale-session copy.

The heartbeat lives in the agent's own select loop (owned state, synchronous doc write, missed ticks skipped) per the runtimed concurrency rules.

Remaining for the fuller version (recorded on the issue): the daemon-side `HostedBridgeHandle` has no health event path to the desktop webview yet, so the desktop connection dot cannot reflect bridge state independently of the runtime-peer heartbeat.

Gates: notebook-cloud typecheck + 1334 tests, viewer vitest 62, `cargo test -p runtimed runtime_agent` (69), apps/notebook build, full vitest suite (2644 tests - passing locally once Node gets a localStorage backing file, the long-standing local flake root-caused along the way), lint.
