### PR TITLE
fix(cloud): require an explicit workstation start target - never fall back to default

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2049,35 +2049,31 @@ async function routeNotebookWorkstationAttachment(
     return identity;
   }
 
-  const payload = await readOptionalJsonObject(request, "workstation attachment body");
+  const payload = await readRequiredJsonObject(request, "workstation attachment body");
   if (payload instanceof Response) {
     return payload;
   }
 
   const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
-  const explicitWorkstationId = optionalBoundedStringField(
-    payload?.workstation_id ?? payload?.workstationId,
+  const workstationId = boundedStringField(
+    payload.workstation_id ?? payload.workstationId,
     "workstation_id",
     128,
   );
-  if (explicitWorkstationId instanceof Response) {
-    return explicitWorkstationId;
-  }
-  const workstationId =
-    explicitWorkstationId ?? (await getDefaultWorkstationId(env, ownerPrincipal));
-  if (!workstationId) {
-    return json({ error: "choose a default workstation before attaching compute" }, 409);
+  if (workstationId instanceof Response) {
+    return workstationId;
   }
   const replaceExisting =
-    payload?.replace_existing === true ||
-    payload?.replaceExisting === true ||
-    payload?.intent === "restart";
+    payload.replace_existing === true ||
+    payload.replaceExisting === true ||
+    payload.intent === "restart";
 
   const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
   if (!workstation) {
     return json({ error: "workstation not found" }, 404);
   }
 
+  const defaultWorkstationId = await getDefaultWorkstationId(env, ownerPrincipal);
   const eventPresence = await workstationEventPresence(env, ownerPrincipal, workstationId);
   const projectedStatus = workstationStatusForResponse(workstation, Date.now(), eventPresence);
   if (projectedStatus !== "online") {
@@ -2089,7 +2085,7 @@ async function routeNotebookWorkstationAttachment(
       {
         error: "workstation is not online",
         workstation: workstationResponseRow(workstation, {
-          defaultWorkstationId: workstationId,
+          defaultWorkstationId,
           now: Date.now(),
           eventPresence,
         }),
@@ -2135,7 +2131,7 @@ async function routeNotebookWorkstationAttachment(
       ok: true,
       job: workstationAttachJobResponseRow(request, job),
       workstation: workstationResponseRow(workstation, {
-        defaultWorkstationId: workstationId,
+        defaultWorkstationId,
         now: Date.now(),
         eventPresence,
       }),

--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -98,6 +98,10 @@ function registry(overrides: Partial<CloudWorkstationsRegistry> = {}): CloudWork
   return { defaultWorkstationId: null, workstations: [], ...overrides };
 }
 
+function attachResult(workstationId: string | null = null) {
+  return { jobId: "job-1", status: "pending", workstationId };
+}
+
 function baseInputs(overrides: Partial<CloudWorkstationsInputs> = {}): CloudWorkstationsInputs {
   return {
     auth: STABLE_AUTH,
@@ -119,7 +123,7 @@ function baseDeps(overrides: Partial<CloudWorkstationsStoreDeps> = {}): CloudWor
     origin: "https://viewer.test",
     loadWorkstations: async () => registry(),
     setDefaultWorkstation: async () => null,
-    attachWorkstation: async () => undefined,
+    attachWorkstation: async () => attachResult(),
     mintPairing: async () => ({
       id: "pair-1",
       code: "AAAA-BBBB",
@@ -356,7 +360,7 @@ describe("CloudWorkstationsStore registry cadence", () => {
           return registry({ workstations: [workstation("ws-1", "Lab")] });
         },
         // Hangs so the attach mutation stays in flight and never refetches.
-        attachWorkstation: () => new Promise<void>(() => {}),
+        attachWorkstation: () => new Promise<never>(() => {}),
       }),
     );
     await drainMicrotasks();
@@ -487,7 +491,7 @@ describe("CloudWorkstationsStore mutations", () => {
       baseDeps({
         workstation$,
         loadWorkstations: async () => registry({ workstations: [workstation("ws-1", "Lab")] }),
-        attachWorkstation: async () => undefined,
+        attachWorkstation: async () => attachResult("ws-1"),
       }),
     );
     await drainMicrotasks();
@@ -500,6 +504,62 @@ describe("CloudWorkstationsStore mutations", () => {
 
     workstation$.next(attachment("ws-1"));
     assert.equal(store.snapshot.mutation.kind, "idle");
+
+    dispose();
+  });
+
+  it("passes the requested workstation id through the attach mutation", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const requested: string[] = [];
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        loadWorkstations: async () =>
+          registry({
+            defaultWorkstationId: "ws-default",
+            workstations: [workstation("ws-lab1", "Lab1"), workstation("ws-default", "Default")],
+          }),
+        attachWorkstation: async ({ workstationId }) => {
+          requested.push(workstationId);
+          return attachResult(workstationId);
+        },
+      }),
+    );
+    await drainMicrotasks();
+
+    const started = await store.attach("ws-lab1");
+    await drainMicrotasks();
+
+    assert.equal(started, true);
+    assert.deepEqual(requested, ["ws-lab1"]);
+    assert.equal(store.snapshot.mutation.workstationId, "ws-lab1");
+
+    dispose();
+  });
+
+  it("moves optimistic attach attribution to the workstation acknowledged by the server", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        loadWorkstations: async () =>
+          registry({
+            defaultWorkstationId: "ws-default",
+            workstations: [workstation("ws-lab1", "Lab1"), workstation("ws-default", "Default")],
+          }),
+        attachWorkstation: async () => attachResult("ws-default"),
+      }),
+    );
+    await drainMicrotasks();
+
+    const started = await store.attach("ws-lab1");
+    await drainMicrotasks();
+
+    assert.equal(started, true);
+    assert.equal(store.snapshot.mutation.kind, "attach");
+    assert.equal(store.snapshot.mutation.workstationId, "ws-default");
 
     dispose();
   });
@@ -935,8 +995,8 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
         scheduler,
         loadWorkstations,
         attachWorkstation: () =>
-          new Promise<void>((resolve) => {
-            attachCalls.push({ resolve: () => resolve() });
+          new Promise<ReturnType<typeof attachResult>>((resolve) => {
+            attachCalls.push({ resolve: () => resolve(attachResult("ws-1")) });
           }),
       }),
     );
@@ -985,8 +1045,8 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
         scheduler,
         loadWorkstations,
         attachWorkstation: () =>
-          new Promise<void>((resolve) => {
-            attachCalls.push({ resolve: () => resolve() });
+          new Promise<ReturnType<typeof attachResult>>((resolve) => {
+            attachCalls.push({ resolve: () => resolve(attachResult("ws-1")) });
           }),
       }),
     );
@@ -1152,7 +1212,7 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
           new Promise<MintedCloudWorkstationPairing>((resolve) => {
             mintCalls.push({ resolve });
           }),
-        attachWorkstation: () => new Promise<void>(() => {}),
+        attachWorkstation: () => new Promise<never>(() => {}),
       }),
     );
     await drainMicrotasks();
@@ -1268,7 +1328,7 @@ describe("CloudWorkstationsStore stale-completion guards", () => {
           expiresAt: new Date(600_000).toISOString(),
         }),
         // Hangs so the attach mutation stays in flight across the gate close.
-        attachWorkstation: () => new Promise<void>(() => {}),
+        attachWorkstation: () => new Promise<never>(() => {}),
       }),
     );
     await drainMicrotasks();

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2699,12 +2699,12 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.workstationDefaults.get("user:dev:alice"), undefined);
   });
 
-  it("creates workstation attach jobs through notebook owner authority", async () => {
+  it("requires an explicit workstation id for notebook attach requests", async () => {
     const env = fakeEnv();
     seedNotebook(env, "attach-demo");
     seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
-    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
-    env.DB.workstationDefaults.set("user:dev:alice", "ws-lab2");
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-default" });
+    env.DB.workstationDefaults.set("user:dev:alice", "ws-default");
 
     const attach = await worker.fetch(
       new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
@@ -2721,13 +2721,55 @@ describe("Worker artifact routes", () => {
       fakeContext(),
     );
 
+    assert.equal(attach.status, 400);
+    assert.deepEqual(await attach.json(), { error: "workstation_id must be a non-empty string" });
+    assert.equal(env.DB.workstationAttachJobs.size, 0);
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "attach-demo" &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "runtime_peer",
+      ),
+      false,
+    );
+  });
+
+  it("creates workstation attach jobs for the requested workstation, not the default", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab1");
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-default" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab1" });
+    env.DB.workstationDefaults.set("user:dev:alice", "ws-default");
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab1" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
     assert.equal(attach.status, 202);
     const body = (await attach.json()) as {
       job: { job_id: string; notebook_id: string; status: string };
+      workstation: { is_default?: boolean; workstation_id?: string };
     };
     assert.equal(body.job.notebook_id, "attach-demo");
     assert.equal(body.job.status, "pending");
-    assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.workstation_id, "ws-lab2");
+    assert.equal(body.workstation.workstation_id, "ws-lab1");
+    assert.equal(body.workstation.is_default, false);
+    assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.workstation_id, "ws-lab1");
     assert.equal(
       env.DB.acl.some(
         (row) =>
@@ -2737,11 +2779,19 @@ describe("Worker artifact routes", () => {
       ),
       true,
     );
+    const notifyRequest = events.requests.find(
+      (entry) => new URL(entry.url).pathname === "/notify",
+    );
+    assert.equal(notifyRequest?.objectName, objectName);
+    assert.equal(
+      (notifyRequest?.body as { workstation_id?: string } | null)?.workstation_id,
+      "ws-lab1",
+    );
 
     const poll = await worker.fetch(
-      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+      new Request("http://localhost/api/workstations/ws-lab1/attach-jobs", {
         headers: {
-          "X-Operator": "workstation:lab2",
+          "X-Operator": "workstation:lab1",
           "X-Scope": "owner",
           "X-User": "alice",
         },
@@ -2755,6 +2805,63 @@ describe("Worker artifact routes", () => {
       polled.jobs.map((job) => job.job_id),
       [body.job.job_id],
     );
+  });
+
+  it("does not fall back to the default when the requested workstation has no connected agent", async () => {
+    const requestedObjectName = workstationEventsObjectName("user:dev:alice", "ws-lab1");
+    const defaultObjectName = workstationEventsObjectName("user:dev:alice", "ws-default");
+    const events = new FakeWorkstationEventsNamespace({
+      connectedObjectNames: [defaultObjectName],
+    });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-default" });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab1",
+      lastSeenAt: "2026-05-22T00:00:00.000Z",
+    });
+    env.DB.workstationDefaults.set("user:dev:alice", "ws-default");
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab1" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 409);
+    const body = (await attach.json()) as {
+      error?: string;
+      workstation?: { workstation_id?: string; status?: string };
+    };
+    assert.equal(body.error, "workstation is not online");
+    assert.equal(body.workstation?.workstation_id, "ws-lab1");
+    assert.equal(body.workstation?.status, "offline");
+    assert.equal(env.DB.workstationAttachJobs.size, 0);
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "attach-demo" &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "runtime_peer",
+      ),
+      false,
+    );
+    const statusRequest = events.requests.find(
+      (entry) => new URL(entry.url).pathname === "/status",
+    );
+    assert.equal(statusRequest?.objectName, requestedObjectName);
+    assert.ok(!events.requests.some((entry) => entry.objectName === defaultObjectName));
   });
 
   it("does not attach another principal's workstation to an owned notebook", async () => {
@@ -6936,7 +7043,7 @@ describe("Workstation pairing", () => {
       new Request("http://localhost/api/n/pairing-attach-demo/workstation-attachments", {
         method: "POST",
         headers: { "Content-Type": "application/json", ...OWNER_HEADERS },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ workstation_id: "ws-paired" }),
       }),
       env,
       fakeContext(),

--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -118,6 +118,7 @@ describe("cloud workstations client", () => {
       return jsonResponse({
         job: {
           job_id: "job-1",
+          workstation_id: "ws-lab2",
           status: "pending",
         },
       });
@@ -129,7 +130,7 @@ describe("cloud workstations client", () => {
         devAuth,
         "ws-lab2",
       ),
-      { jobId: "job-1", status: "pending" },
+      { jobId: "job-1", status: "pending", workstationId: "ws-lab2" },
     );
   });
 
@@ -145,6 +146,7 @@ describe("cloud workstations client", () => {
       return jsonResponse({
         job: {
           job_id: "job-restart",
+          workstation_id: "ws-lab2",
           status: "pending",
         },
       });
@@ -157,7 +159,7 @@ describe("cloud workstations client", () => {
         "ws-lab2",
         { replaceExisting: true },
       ),
-      { jobId: "job-restart", status: "pending" },
+      { jobId: "job-restart", status: "pending", workstationId: "ws-lab2" },
     );
   });
 

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -59,6 +59,7 @@ import {
   mintCloudWorkstationPairingCode,
   requestCloudWorkstationAttachment,
   setCloudDefaultWorkstation,
+  type CloudWorkstationAttachmentRequestResult,
   type CloudWorkstationPairingCommand,
   type CloudWorkstationPairingStatus,
   type CloudWorkstationPairingStatusState,
@@ -185,7 +186,7 @@ export interface CloudWorkstationsStoreDeps {
     auth: CloudPrototypeAuthState;
     workstationId: string;
     replaceExisting: boolean;
-  }) => Promise<unknown>;
+  }) => Promise<CloudWorkstationAttachmentRequestResult>;
   mintPairing?: (params: {
     endpoint: string;
     auth: CloudPrototypeAuthState;
@@ -721,7 +722,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
     };
     this.setMutation(mutation);
     try {
-      await deps.attachWorkstation({
+      const attached = await deps.attachWorkstation({
         endpoint: inputs.attachEndpoint,
         auth: inputs.auth,
         workstationId,
@@ -730,6 +731,10 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
       if (!this.mutationStillCurrent(issue, this.latestInputs?.attachEndpoint)) {
         this.clearMutationIfOwned(mutation);
         return false;
+      }
+      const acknowledgedWorkstationId = trimToNull(attached.workstationId) ?? workstationId;
+      if (acknowledgedWorkstationId !== mutation.workstationId) {
+        this.setMutation({ ...mutation, workstationId: acknowledgedWorkstationId });
       }
       this.clearError();
       await this.refreshNow();
@@ -1057,6 +1062,12 @@ interface PairingStatusTick {
   pairingId: string;
   auth: CloudPrototypeAuthState;
   status: CloudWorkstationPairingStatusState;
+}
+
+function trimToNull(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 /**

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -39,12 +39,22 @@ interface CloudWorkstationsResponse {
 interface CloudWorkstationAttachmentResponse {
   job?: {
     job_id?: unknown;
+    workstation_id?: unknown;
     status?: unknown;
+  };
+  workstation?: {
+    workstation_id?: unknown;
   };
 }
 
 export interface RequestCloudWorkstationAttachmentOptions {
   replaceExisting?: boolean;
+}
+
+export interface CloudWorkstationAttachmentRequestResult {
+  jobId: string | null;
+  status: string | null;
+  workstationId: string | null;
 }
 
 export async function fetchCloudWorkstations(
@@ -102,7 +112,7 @@ export async function requestCloudWorkstationAttachment(
   authState: CloudPrototypeAuthState,
   workstationId: string,
   options: RequestCloudWorkstationAttachmentOptions = {},
-): Promise<{ jobId: string | null; status: string | null }> {
+): Promise<CloudWorkstationAttachmentRequestResult> {
   const response = await fetchWithCloudPrototypeAuth(
     endpoint,
     {
@@ -125,6 +135,9 @@ export async function requestCloudWorkstationAttachment(
   return {
     jobId: scalarString(payload.job?.job_id),
     status: scalarString(payload.job?.status),
+    workstationId:
+      scalarString(payload.job?.workstation_id) ??
+      scalarString(payload.workstation?.workstation_id),
   };
 }
 


### PR DESCRIPTION
Fixes #3942, reproduced live on preview: Start on a freshly-paired workstation produced a session on the owner's default workstation instead (the clicked box never received a launch), with the rail attributing the session to the clicked workstation and the toolbar to the actual one.

Root cause: `/api/n/:notebookId/workstation-attachments` accepted an optional body and substituted the owner default workstation when `workstation_id` was absent - so any start request that lost the clicked id silently created the attach job, runtime-state attachment, and workstation event for the default box. When the default box is flaky, the visible result is "started compute, offline moments later, no idea why."

The route now requires `workstation_id`, presence-checks exactly the requested workstation, and returns 400/404/409 instead of falling back - a start either lands on the workstation you clicked or fails loudly. The viewer client and store carry the server-acknowledged workstation id, so rail attribution follows the accepted session target rather than optimistic local state.

Full rail/toolbar convergence on one durable compute-session fact is the remaining follow-up (noted on the issue) - the two surfaces still read separate projection seams.

Gates: typecheck, 1337/1338 node:test (known renderer-artifacts ENOENT), 62 viewer vitest, lint; new route coverage for required-id, offline-target 409, and missing-target 404, plus store tests for acknowledged-id attribution.
