### PR TITLE
fix(runtimed): refuse autosave path collisions between live daemons

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4772,6 +4772,9 @@ impl Daemon {
             // of the oneshot signal.
             room.file_binding.shutdown_notebook_watcher().await;
             room.file_binding.shutdown_project_file_watcher().await;
+            if let Some(path) = path.as_ref() {
+                crate::notebook_sync_server::release_autosave_owner_marker_for_path(path).await;
+            }
 
             // Step 5: take the persist debouncer out so its senders
             // drop and the task exits via its shutdown arm with one

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -1,10 +1,13 @@
 use super::*;
 use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 
 pub(crate) const JUPYTER_WIDGET_TARGET: &str = "jupyter.widget";
 pub(crate) const WIDGET_STATE_MIME: &str = "application/vnd.jupyter.widget-state+json";
 const WIDGET_STATE_VERSION_MAJOR: i64 = 2;
 const WIDGET_STATE_VERSION_MINOR: i64 = 0;
+const AUTOSAVE_OWNER_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug)]
 pub(crate) enum SaveError {
@@ -124,6 +127,18 @@ pub(crate) async fn save_notebook_to_disk(
                 )));
             }
         }
+    }
+
+    if is_primary_path {
+        if let Some(parent) = notebook_path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                SaveError::Unrecoverable(format!(
+                    "Failed to create directory '{}': {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+        claim_autosave_owner(&notebook_path).await?;
     }
 
     // Read cells, metadata, and per-cell execution_ids from the doc.
@@ -463,6 +478,300 @@ pub(crate) async fn save_notebook_to_disk(
     );
 
     Ok(notebook_path.to_string_lossy().to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AutosaveOwnerMarker {
+    pub(crate) schema_version: u32,
+    pub(crate) daemon_id: String,
+    pub(crate) pid: u32,
+    pub(crate) notebook_path: PathBuf,
+    pub(crate) claimed_at_unix_ms: u64,
+}
+
+impl AutosaveOwnerMarker {
+    fn current(notebook_path: &Path) -> Self {
+        Self {
+            schema_version: AUTOSAVE_OWNER_SCHEMA_VERSION,
+            daemon_id: current_autosave_owner_id().to_string(),
+            pid: std::process::id(),
+            notebook_path: notebook_path.to_path_buf(),
+            claimed_at_unix_ms: unix_now_ms(),
+        }
+    }
+
+    fn is_current_daemon(&self) -> bool {
+        self.pid == std::process::id() && self.daemon_id == current_autosave_owner_id()
+    }
+}
+
+fn current_autosave_owner_id() -> &'static str {
+    static OWNER_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    OWNER_ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}
+
+fn unix_now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn autosave_owner_marker_path(notebook_path: &Path) -> PathBuf {
+    let file_name = notebook_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "notebook.ipynb".to_string());
+    notebook_path.with_file_name(format!("{file_name}.runtlock"))
+}
+
+async fn claim_autosave_owner(notebook_path: &Path) -> Result<(), SaveError> {
+    let marker_path = autosave_owner_marker_path(notebook_path);
+    loop {
+        let marker = AutosaveOwnerMarker::current(notebook_path);
+        let marker_bytes = serde_json::to_vec_pretty(&marker).map_err(|e| {
+            SaveError::Retryable(format!("failed to serialize autosave owner: {e}"))
+        })?;
+
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker_path)
+            .await
+        {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(&marker_bytes).await {
+                    let _ = tokio::fs::remove_file(&marker_path).await;
+                    return Err(save_error_for_owner_io(
+                        "write autosave owner marker",
+                        &marker_path,
+                        e,
+                    ));
+                }
+                if let Err(e) = file.write_all(b"\n").await {
+                    let _ = tokio::fs::remove_file(&marker_path).await;
+                    return Err(save_error_for_owner_io(
+                        "write autosave owner marker",
+                        &marker_path,
+                        e,
+                    ));
+                }
+                return Ok(());
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => {
+                return Err(save_error_for_owner_io(
+                    "create autosave owner marker",
+                    &marker_path,
+                    e,
+                ));
+            }
+        }
+
+        let existing = match read_autosave_owner_marker(&marker_path).await {
+            Ok(marker) => marker,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] Reclaiming unreadable autosave owner marker {:?}: {}",
+                    marker_path, e
+                );
+                remove_stale_autosave_owner_marker(&marker_path).await?;
+                continue;
+            }
+        };
+
+        if existing.is_current_daemon() {
+            write_autosave_owner_marker(&marker_path, notebook_path).await?;
+            return Ok(());
+        }
+
+        if autosave_owner_process_is_live(existing.pid) {
+            error!(
+                "[notebook-sync] Refusing to save {:?}: autosave owner marker {:?} belongs to live daemon pid={} daemon_id={}. Stop that daemon or reconnect through it before saving this path.",
+                notebook_path,
+                marker_path,
+                existing.pid,
+                existing.daemon_id
+            );
+            return Err(SaveError::Unrecoverable(format!(
+                "notebook '{}' is owned by live daemon pid {} (marker '{}')",
+                notebook_path.display(),
+                existing.pid,
+                marker_path.display()
+            )));
+        }
+
+        warn!(
+            "[notebook-sync] Taking over stale autosave owner marker {:?} for {:?} from pid={} daemon_id={}",
+            marker_path, notebook_path, existing.pid, existing.daemon_id
+        );
+        remove_stale_autosave_owner_marker(&marker_path).await?;
+    }
+}
+
+async fn read_autosave_owner_marker(path: &Path) -> std::io::Result<AutosaveOwnerMarker> {
+    let bytes = tokio::fs::read(path).await?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+pub(crate) async fn release_autosave_owner_marker_for_path(notebook_path: &Path) {
+    let marker_path = autosave_owner_marker_path(notebook_path);
+    match read_autosave_owner_marker(&marker_path).await {
+        Ok(marker) if marker.is_current_daemon() => {
+            if let Err(e) = tokio::fs::remove_file(&marker_path).await {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    warn!(
+                        "[notebook-sync] Failed to release autosave owner marker {:?}: {}",
+                        marker_path, e
+                    );
+                }
+            }
+        }
+        Ok(_) | Err(_) => {}
+    }
+}
+
+async fn write_autosave_owner_marker(
+    marker_path: &Path,
+    notebook_path: &Path,
+) -> Result<(), SaveError> {
+    let marker = AutosaveOwnerMarker::current(notebook_path);
+    let mut bytes = serde_json::to_vec_pretty(&marker)
+        .map_err(|e| SaveError::Retryable(format!("failed to serialize autosave owner: {e}")))?;
+    bytes.push(b'\n');
+    write_file_atomic(marker_path, &bytes)
+        .await
+        .map_err(|e| save_error_for_owner_io("refresh autosave owner marker", marker_path, e))
+}
+
+async fn remove_stale_autosave_owner_marker(marker_path: &Path) -> Result<(), SaveError> {
+    match tokio::fs::remove_file(marker_path).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(save_error_for_owner_io(
+            "remove stale autosave owner marker",
+            marker_path,
+            e,
+        )),
+    }
+}
+
+fn save_error_for_owner_io(action: &str, path: &Path, e: std::io::Error) -> SaveError {
+    let msg = format!("{action} '{}': {e}", path.display());
+    match e.kind() {
+        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::IsADirectory => {
+            SaveError::Unrecoverable(msg)
+        }
+        _ => SaveError::Retryable(msg),
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn write_autosave_owner_marker_for_test(
+    notebook_path: &Path,
+    daemon_id: &str,
+    pid: u32,
+) {
+    let marker = AutosaveOwnerMarker {
+        schema_version: AUTOSAVE_OWNER_SCHEMA_VERSION,
+        daemon_id: daemon_id.to_string(),
+        pid,
+        notebook_path: notebook_path.to_path_buf(),
+        claimed_at_unix_ms: unix_now_ms(),
+    };
+    let marker_path = autosave_owner_marker_path(notebook_path);
+    let mut bytes = serde_json::to_vec_pretty(&marker).unwrap();
+    bytes.push(b'\n');
+    tokio::fs::write(marker_path, bytes).await.unwrap();
+}
+
+#[cfg(test)]
+pub(crate) async fn read_autosave_owner_marker_for_test(
+    notebook_path: &Path,
+) -> AutosaveOwnerMarker {
+    read_autosave_owner_marker(&autosave_owner_marker_path(notebook_path))
+        .await
+        .unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn current_autosave_owner_id_for_test() -> String {
+    current_autosave_owner_id().to_string()
+}
+
+#[cfg(test)]
+pub(crate) struct AutosaveOwnerLivenessOverrideGuard {
+    pid: u32,
+}
+
+#[cfg(test)]
+impl Drop for AutosaveOwnerLivenessOverrideGuard {
+    fn drop(&mut self) {
+        if let Some(overrides) = AUTOSAVE_OWNER_LIVENESS_OVERRIDES.get() {
+            if let Ok(mut overrides) = overrides.lock() {
+                overrides.remove(&self.pid);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+static AUTOSAVE_OWNER_LIVENESS_OVERRIDES: std::sync::OnceLock<
+    std::sync::Mutex<HashMap<u32, bool>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+pub(crate) fn override_autosave_owner_liveness_for_test(
+    pid: u32,
+    live: bool,
+) -> AutosaveOwnerLivenessOverrideGuard {
+    let overrides =
+        AUTOSAVE_OWNER_LIVENESS_OVERRIDES.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    overrides.lock().unwrap().insert(pid, live);
+    AutosaveOwnerLivenessOverrideGuard { pid }
+}
+
+fn autosave_owner_process_is_live(pid: u32) -> bool {
+    #[cfg(test)]
+    if let Some(overrides) = AUTOSAVE_OWNER_LIVENESS_OVERRIDES.get() {
+        if let Ok(overrides) = overrides.lock() {
+            if let Some(live) = overrides.get(&pid) {
+                return *live;
+            }
+        }
+    }
+
+    platform_process_exists(pid)
+}
+
+#[cfg(unix)]
+fn platform_process_exists(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
+}
+
+#[cfg(windows)]
+fn platform_process_exists(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle == 0 {
+            return false;
+        }
+        CloseHandle(handle);
+        true
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn platform_process_exists(_pid: u32) -> bool {
+    false
 }
 
 /// Transitions an untitled room to file-backed: claims path in path_index,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5110,6 +5110,76 @@ async fn autosave_refuses_to_overwrite_externally_changed_file() {
     );
 }
 
+/// Cross-daemon ownership guard (#2285): if another live daemon has claimed
+/// this autosave path, this daemon must make the collision loud and leave the
+/// existing file untouched.
+#[tokio::test]
+async fn autosave_refuses_live_foreign_owner_marker() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "live-owner.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    let foreign_pid = 424_242;
+    let _live = override_autosave_owner_liveness_for_test(foreign_pid, true);
+    write_autosave_owner_marker_for_test(&notebook_path, "foreign-daemon", foreign_pid).await;
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "local-cell", "code").unwrap();
+        doc.update_source("local-cell", "local = 1").unwrap();
+    }
+
+    let err = save_notebook_to_disk(&room, None).await.unwrap_err();
+    let SaveError::Unrecoverable(message) = err else {
+        panic!("live foreign owner must be unrecoverable, got {err:?}");
+    };
+    assert!(
+        message.contains("owned by live daemon pid 424242"),
+        "error should name the live owner pid; got {message}"
+    );
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        2,
+        "live owner refusal must not clobber the existing notebook"
+    );
+
+    let marker = read_autosave_owner_marker_for_test(&notebook_path).await;
+    assert_eq!(marker.daemon_id, "foreign-daemon");
+    assert_eq!(marker.pid, foreign_pid);
+}
+
+/// A dead daemon's marker is safe to adopt. This keeps crash recovery working:
+/// a new daemon can autosave the path once the recorded owner process is gone.
+#[tokio::test]
+async fn autosave_takes_over_dead_foreign_owner_marker() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "dead-owner.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    let dead_pid = 515_151;
+    let _dead = override_autosave_owner_liveness_for_test(dead_pid, false);
+    write_autosave_owner_marker_for_test(&notebook_path, "dead-daemon", dead_pid).await;
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "takeover-cell", "code").unwrap();
+        doc.update_source("takeover-cell", "takeover = 1").unwrap();
+    }
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("dead owner marker should be adopted");
+
+    let on_disk = tokio::fs::read_to_string(&notebook_path).await.unwrap();
+    assert!(
+        on_disk.contains("takeover = 1"),
+        "takeover save should write the local room state"
+    );
+    let marker = read_autosave_owner_marker_for_test(&notebook_path).await;
+    assert_eq!(marker.pid, std::process::id());
+    assert_eq!(marker.daemon_id, current_autosave_owner_id_for_test());
+}
+
 /// Saves to a non-primary path (Save As) are not staleness-guarded:
 /// overwriting the chosen target is the user's intent, and the room's disk
 /// baseline belongs to its bound path.

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -8,7 +8,8 @@ use tracing::warn;
 use crate::daemon::Daemon;
 use crate::notebook_sync_server::{
     canonical_target_path, finalize_untitled_promotion, format_notebook_cells,
-    persist_notebook_bytes, save_notebook_to_disk, NotebookFileBinding, NotebookRoom, SaveError,
+    persist_notebook_bytes, release_autosave_owner_marker_for_path, save_notebook_to_disk,
+    NotebookFileBinding, NotebookRoom, SaveError,
 };
 use crate::protocol::NotebookResponse;
 
@@ -150,6 +151,7 @@ pub(crate) async fn handle(
             // Move the persistent binding with the room: the old path is now a
             // different (or absent) file and must not resolve to this id.
             daemon.notebook_registry.forget(old);
+            release_autosave_owner_marker_for_path(old).await;
             daemon
                 .notebook_registry
                 .record(&canonical, room.id, &registry_now);


### PR DESCRIPTION
Fixes #2285. Two daemons autosaving the same notebook path silently overwrote each other's writes - last writer wins, no signal.

Saves to a primary path now maintain a per-path owner marker (daemon id + pid) beside the autosave target. A save that finds a marker belonging to a *live* different daemon refuses loudly with an actionable daemon-log error naming the owning pid; a marker from a dead owner is adopted so crash recovery never blocks. The marker releases when the serving room is reaped or save-as moves the notebook elsewhere. Refusal is deliberately the failure direction - a blocked save is recoverable, a silent overwrite is not.

Gates: full runtimed lib suite (1052 tests, including live-refusal and dead-owner-takeover coverage), tokio mutex lint, cargo xtask lint.
