### PR TITLE
fix(runtimed): resolve queued cells when kernel launch fails

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2425,6 +2425,13 @@ pub(crate) fn publish_environment_launch_error(
         sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, reason, Some(details))?;
         sd.set_kernel_info("python", "python", env_source)?;
         sd.clear_env_progress()?;
+        // This is the coordinator's terminal launch-error publish on the
+        // authoritative room doc. Resolve any cells still queued against the
+        // launch that just failed: with no kernel they can never run, so
+        // "queued" → "cancelled" (and any stray "running" → "error"). Catches
+        // executions the runtime agent's own abort missed because they were
+        // queued room-side during the launch and never synced to the agent.
+        sd.abort_inflight_executions()?;
         Ok(())
     }) {
         error!(

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9503,7 +9503,9 @@ async fn publish_environment_launch_error_writes_kernel_error_and_clears_env_pro
             sd.set_env_progress(
                 "conda",
                 &serde_json::json!({ "phase": "solving", "spec_count": 5 }),
-            )
+            )?;
+            // A cell was queued against the launch that is about to fail.
+            sd.create_execution("exec-queued-1")
         })
         .unwrap();
 
@@ -9528,6 +9530,22 @@ async fn publish_environment_launch_error_writes_kernel_error_and_clears_env_pro
     assert_eq!(state.kernel.language, "python");
     assert_eq!(state.kernel.env_source, "conda:inline");
     assert_eq!(state.env.progress, None);
+
+    // The queued cell can never run now, so it must resolve instead of
+    // spinning on "queued" forever (#3947).
+    assert!(
+        room.state
+            .read(|sd| sd.get_queued_executions())
+            .unwrap()
+            .is_empty(),
+        "no executions should remain queued after a terminal launch error"
+    );
+    let queued_cell = room
+        .state
+        .read(|sd| sd.get_execution("exec-queued-1"))
+        .unwrap()
+        .expect("exec-queued-1 exists");
+    assert_eq!(queued_cell.status, "cancelled");
 }
 
 #[test]

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -351,6 +351,15 @@ fn record_kernel_launching_state(
     })
 }
 
+/// Record a terminal kernel-launch failure into the RuntimeStateDoc.
+///
+/// A launch that fails terminally (see [`kernel_launch_failure::uses_fresh_port_retry`])
+/// leaves the doc's queued executions with no kernel that will ever run them. So
+/// alongside the errored kernel lifecycle, resolve those inflight executions in
+/// the same change: "queued" → "cancelled", any stray "running" → "error". This
+/// mirrors the defensive sweep on restart and is what stops the cells spinning
+/// on "queued" while the kernel banner reports the failure. Without it the launch
+/// error is invisible to the UI and the notebook looks stuck.
 fn record_kernel_launch_failed_state(
     ctx: &RuntimeAgentContext,
     kernel_type: &str,
@@ -361,6 +370,7 @@ fn record_kernel_launch_failed_state(
         sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, None, Some(details))?;
         sd.set_kernel_info(kernel_type, kernel_type, env_source)?;
         sd.set_runtime_agent_id(&ctx.runtime_agent_id)?;
+        sd.abort_inflight_executions()?;
         Ok(())
     })
 }
@@ -3392,6 +3402,53 @@ mod tests {
         assert_eq!(runtime_state.kernel.name, "python");
         assert_eq!(runtime_state.kernel.env_source, "uv:current_python");
         assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+    }
+
+    #[test]
+    fn launch_failure_resolves_queued_executions_so_cells_stop_spinning() {
+        let (ctx, _state, handle) = test_fixtures();
+
+        // Cells were queued against the runtime before the launch was attempted.
+        // This is the launch-on-attach case: executions arrive via CRDT sync
+        // while the kernel is still starting, then the launch fails.
+        handle
+            .with_doc(|sd| {
+                sd.create_execution("exec-queued-1")?;
+                sd.create_execution("exec-queued-2")?;
+                Ok(())
+            })
+            .expect("seed queued executions");
+
+        record_kernel_launching_state(&ctx, "python", "uv:current_python")
+            .expect("record kernel launching");
+        record_kernel_launch_failed_state(
+            &ctx,
+            "python",
+            "uv:current_python",
+            "Failed to launch kernel: missing ipykernel",
+        )
+        .expect("record kernel launch failure");
+
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(runtime_state.kernel.lifecycle, RuntimeLifecycle::Error);
+
+        // The queued cells can never run now, so none may remain "queued":
+        // they must reach a terminal status instead of hanging on the spinner.
+        let still_queued = handle.read(|sd| sd.get_queued_executions()).unwrap();
+        assert!(
+            still_queued.is_empty(),
+            "no executions should remain queued after a terminal launch failure"
+        );
+        let e1 = handle
+            .read(|sd| sd.get_execution("exec-queued-1"))
+            .unwrap()
+            .expect("exec-queued-1 exists");
+        let e2 = handle
+            .read(|sd| sd.get_execution("exec-queued-2"))
+            .unwrap()
+            .expect("exec-queued-2 exists");
+        assert_eq!(e1.status, "cancelled");
+        assert_eq!(e2.status, "cancelled");
     }
 
     #[test]


### PR DESCRIPTION
A terminal kernel-launch failure recorded the errored kernel lifecycle but left the RuntimeStateDoc's queued executions untouched. With no kernel to run them, the cells sat on the "queued" spinner forever while the failure stayed invisible - the "everything queued, nothing running, no logs" symptom. Seen live this week when a workstation's Current Python lacked `ipykernel` and launch-on-attach died: the notebook looked stuck with no error anywhere in the browser, and the truth was only in the host's runtime-peer log (`ModuleNotFoundError: No module named 'ipykernel'`).

## The fix

Resolve the orphaned executions in the same change that records the failure, mirroring the defensive sweep the restart path already performs. `abort_inflight_executions` maps `queued → cancelled` and any stray `running → error`. Two symmetric call sites cover the two authoring models:

- **Runtime agent** (`runtime_agent.rs`, `record_kernel_launch_failed_state`): the hosted runtime peer and the desktop agent both author their own RuntimeStateDoc here. Both the explicit `LaunchKernel` and `RestartKernel` failure arms call this helper, and launch-on-attach routes through the explicit arm.
- **Coordinator** (`notebook_sync_server/metadata.rs`, `publish_environment_launch_error`): the local daemon's terminal launch-error publish on the authoritative room doc. This catches executions the agent's own abort can't see - ones queued room-side during the launch and never synced to the agent before it failed - and covers environment-prepare failures that never reach a kernel launch at all.

`cancelled` is the correct terminal state: a cell queued behind a kernel that never launched never ran (the doc comment and `abort_inflight_executions` both reserve `error`+`success:false` for cells that were actually running when the kernel died).

## Why the failure is now visible

- **Cells**: leave the breathing "queued" dot for a static terminal state (`CompactExecutionButton` renders the spinner only for `state === "queued"`).
- **Toolbar**: already correct - `RuntimeLifecycle::Error` drives a red dot + red "error" text, distinct from Running. Unchanged here; this PR fixes the cells that were the actual stuck surface.

## Scope

Closes the stuck-queue half of #3947. Two things deliberately left out:

1. **Rail "Running" badge**: `src/components/notebook/NotebookWorkstationsPanel.tsx:585`/`:630` reads `workstation.isAttached` (runtime-peer socket presence, hardcoded `status: "ready"` by the room host on connect) rather than `kernel.lifecycle`, so it still reads "Running" after a launch failure. That's the room-host read-side convergence tracked as the #3944 remainder and in `docs/memos/byoc-control-plane.md` (failure mode 2), with its own UX call to make - separate PR.
2. **Pure-hosted concurrent-queue race**: on the Cloudflare-hosted path the runtime agent is the sole author (no local coordinator `publish_environment_launch_error`), so a cell queued room-side during the ~1-2s launch window that then fails is missed by the agent's abort and stays queued until the next relaunch, which sweeps it. Narrow and self-healing; noted rather than closed with hot-sync-path complexity.

Addresses #3947.
