### PR TITLE
feat(cloud): workstation liveness lease in the registry DO

### DIFF
--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -12,7 +12,10 @@ const MAX_NOTEBOOK_IDS_PER_LIST = 500;
 // alarm drops it so DO storage does not accumulate stale records; D1 remains the
 // registry of record, so the workstation still lists (offline) until it is
 // deregistered.
-const WORKSTATION_LEASE_GC_MS = 24 * 60 * 60_000;
+export const WORKSTATION_LEASE_GC_MS = 24 * 60 * 60_000;
+// Hard ceiling on a single went_offline delivery so a slow or dead events DO
+// cannot keep the background notify (and thus the registry DO) alive.
+const WORKSTATION_WENT_OFFLINE_NOTIFY_TIMEOUT_MS = 5_000;
 
 /**
  * A workstation liveness lease held in the owner-scoped registry DO. The
@@ -116,8 +119,11 @@ export class OwnerComputeIndex {
   }
 
   /**
-   * Single-earliest-wins: schedule the alarm for the soonest online lease
-   * expiry, or clear it when no lease is live. Cheap to call on every upsert -
+   * Single-earliest-wins: schedule the alarm for the soonest deadline that
+   * needs the sweep - an online lease's expiry, or an offline lease's GC
+   * deadline - or clear it when nothing is pending. Arming the GC deadline
+   * matters: without it, an all-offline fleet disarms the alarm and its dead
+   * lease rows would never be collected. Cheap to call on every upsert:
    * `setAlarm` is one row write, and we only rewrite when the target moves.
    */
   private async armLeaseAlarm(): Promise<void> {
@@ -127,8 +133,11 @@ export class OwnerComputeIndex {
     const leases = await this.readLeases();
     let earliest: number | null = null;
     for (const lease of leases.values()) {
-      if (lease.online && (earliest === null || lease.lease_expires_at < earliest)) {
-        earliest = lease.lease_expires_at;
+      const deadline = lease.online
+        ? lease.lease_expires_at
+        : lease.lease_expires_at + WORKSTATION_LEASE_GC_MS;
+      if (earliest === null || deadline < earliest) {
+        earliest = deadline;
       }
     }
     const current = (await this.state.storage.getAlarm?.()) ?? null;
@@ -173,8 +182,16 @@ export class OwnerComputeIndex {
     // Push the offline transition to any listeners, so the rail/toolbar learn
     // it went offline instead of inferring absence from a missed poll. The
     // registry reaches the socket-holding DO by fetch, never by holding a
-    // socket itself.
-    await this.notifyWentOffline(wentOffline);
+    // socket itself. Dispatch off the alarm's critical path: a slow or dead
+    // events DO must not keep the handler running, which would pin this DO
+    // resident and break hibernation. waitUntil lets the handler return now
+    // while the bounded-timeout delivery drains in the background.
+    const notify = this.notifyWentOffline(wentOffline);
+    if (this.state.waitUntil) {
+      this.state.waitUntil(notify);
+    } else {
+      void notify;
+    }
     return wentOffline.length;
   }
 
@@ -198,6 +215,7 @@ export class OwnerComputeIndex {
                 workstation_id: lease.workstation_id,
                 reason: lease.offline_reason ?? "went offline",
               }),
+              signal: AbortSignal.timeout(WORKSTATION_WENT_OFFLINE_NOTIFY_TIMEOUT_MS),
             }),
           );
         } catch (error) {

--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -2,11 +2,17 @@ import type { DurableObjectNamespace, DurableObjectState, Env } from "./cloudfla
 import { isNotebookComputeSessionSummary, type NotebookComputeSessionSummary } from "runtimed";
 import { json } from "./http-responses.ts";
 import { cloudLog, errorMessage } from "./observability.ts";
+import { workstationEventsObjectName } from "./workstation-events.ts";
 
 const COMPUTE_SESSION_KEY_PREFIX = "session:";
 const WORKSTATION_LEASE_KEY_PREFIX = "lease:";
 const OWNER_COMPUTE_INDEX_OBJECT_PREFIX = "owner-compute:v1:";
 const MAX_NOTEBOOK_IDS_PER_LIST = 500;
+// A lease that has stayed offline this far past its expiry is dead weight. The
+// alarm drops it so DO storage does not accumulate stale records; D1 remains the
+// registry of record, so the workstation still lists (offline) until it is
+// deregistered.
+const WORKSTATION_LEASE_GC_MS = 24 * 60 * 60_000;
 
 /**
  * A workstation liveness lease held in the owner-scoped registry DO. The
@@ -32,9 +38,7 @@ export class OwnerComputeIndex {
   constructor(
     private readonly state: DurableObjectState,
     private readonly env: Env,
-  ) {
-    void this.env;
-  }
+  ) {}
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -141,8 +145,14 @@ export class OwnerComputeIndex {
 
   private async sweepExpiredLeases(now: number): Promise<number> {
     const leases = await this.readLeases();
-    let expired = 0;
+    const wentOffline: WorkstationLeaseRecord[] = [];
     for (const [key, lease] of leases) {
+      // Drop leases that have stayed offline well past their window so the DO
+      // does not accumulate dead records.
+      if (!lease.online && now - lease.lease_expires_at > WORKSTATION_LEASE_GC_MS) {
+        await this.state.storage.delete(key);
+        continue;
+      }
       if (lease.online && lease.lease_expires_at <= now) {
         const offline: WorkstationLeaseRecord = {
           ...lease,
@@ -150,7 +160,7 @@ export class OwnerComputeIndex {
           offline_reason: "lease expired: no heartbeat within the lease window",
         };
         await this.state.storage.put(key, offline);
-        expired += 1;
+        wentOffline.push(offline);
         cloudLog("info", "fleet_registry.lease_expired", {
           owner_principal: lease.owner_principal,
           workstation_id: lease.workstation_id,
@@ -160,7 +170,47 @@ export class OwnerComputeIndex {
       }
     }
     await this.armLeaseAlarm();
-    return expired;
+    // Push the offline transition to any listeners, so the rail/toolbar learn
+    // it went offline instead of inferring absence from a missed poll. The
+    // registry reaches the socket-holding DO by fetch, never by holding a
+    // socket itself.
+    await this.notifyWentOffline(wentOffline);
+    return wentOffline.length;
+  }
+
+  private async notifyWentOffline(leases: WorkstationLeaseRecord[]): Promise<void> {
+    const namespace = this.env.WORKSTATION_EVENTS;
+    if (!namespace || leases.length === 0) {
+      return;
+    }
+    await Promise.allSettled(
+      leases.map(async (lease) => {
+        try {
+          const id = namespace.idFromName(
+            workstationEventsObjectName(lease.owner_principal, lease.workstation_id),
+          );
+          await namespace.get(id).fetch(
+            new Request("https://workstation-events.internal/notify", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                event: "went_offline",
+                workstation_id: lease.workstation_id,
+                reason: lease.offline_reason ?? "went offline",
+              }),
+            }),
+          );
+        } catch (error) {
+          cloudLog("warn", "fleet_registry.went_offline_notify_failed", {
+            owner_principal: lease.owner_principal,
+            workstation_id: lease.workstation_id,
+            error: errorMessage(error),
+            counter: "fleet_registry_went_offline_notify_failed",
+            counter_delta: 1,
+          });
+        }
+      }),
+    );
   }
 
   private async handleUpsert(request: Request): Promise<Response> {

--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -4,8 +4,29 @@ import { json } from "./http-responses.ts";
 import { cloudLog, errorMessage } from "./observability.ts";
 
 const COMPUTE_SESSION_KEY_PREFIX = "session:";
+const WORKSTATION_LEASE_KEY_PREFIX = "lease:";
 const OWNER_COMPUTE_INDEX_OBJECT_PREFIX = "owner-compute:v1:";
 const MAX_NOTEBOOK_IDS_PER_LIST = 500;
+
+/**
+ * A workstation liveness lease held in the owner-scoped registry DO. The
+ * heartbeat renews it (`lease_expires_at = now + ttl`); the DO's own `alarm()`
+ * sweeps leases past their expiry to `online: false` without waiting on a read.
+ *
+ * The DO holds only lease state plus a self-scheduling alarm - no WebSockets -
+ * so it hibernates between a heartbeat write and the next sweep. Connection
+ * holding stays in WorkstationEvents (hibernatable sockets); the registry
+ * reaches those sockets by an HTTP fetch, never by holding one here. See
+ * docs/memos/byoc-control-plane.md.
+ */
+export interface WorkstationLeaseRecord {
+  workstation_id: string;
+  owner_principal: string;
+  last_seen_at: string;
+  lease_expires_at: number;
+  online: boolean;
+  offline_reason: string | null;
+}
 
 export class OwnerComputeIndex {
   constructor(
@@ -26,7 +47,120 @@ export class OwnerComputeIndex {
     if (request.method === "POST" && url.pathname === "/list") {
       return this.handleList(request);
     }
+    if (request.method === "POST" && url.pathname === "/lease/upsert") {
+      return this.handleLeaseUpsert(request);
+    }
+    if (request.method === "POST" && url.pathname === "/lease/list") {
+      return this.handleLeaseList();
+    }
     return json({ error: "not found" }, 404);
+  }
+
+  /**
+   * Fired by the runtime when the earliest lease reaches its expiry. Sweeps
+   * every lease past its window to offline, then re-arms for the next one. The
+   * DO hibernates again as soon as this returns.
+   */
+  async alarm(): Promise<void> {
+    await this.sweepExpiredLeases(Date.now());
+  }
+
+  private async handleLeaseUpsert(request: Request): Promise<Response> {
+    const payload = await readJsonObject(request);
+    if (payload instanceof Response) {
+      return payload;
+    }
+    const workstationId = boundedString(payload.workstation_id ?? payload.workstationId, 128);
+    const ownerPrincipal = boundedString(payload.owner_principal ?? payload.ownerPrincipal, 320);
+    const ttlMs = positiveInteger(payload.ttl_ms ?? payload.ttlMs);
+    if (!workstationId || !ownerPrincipal || ttlMs === null) {
+      return json({ error: "workstation_id, owner_principal, and ttl_ms are required" }, 400);
+    }
+
+    const now = Date.now();
+    const lease: WorkstationLeaseRecord = {
+      workstation_id: workstationId,
+      owner_principal: ownerPrincipal,
+      last_seen_at: new Date(now).toISOString(),
+      lease_expires_at: now + ttlMs,
+      online: true,
+      offline_reason: null,
+    };
+    await this.state.storage.put(leaseKey(workstationId), lease);
+    await this.armLeaseAlarm();
+    return json({ ok: true, lease_expires_at: lease.lease_expires_at });
+  }
+
+  private async handleLeaseList(): Promise<Response> {
+    const leases = await this.readLeases();
+    return json({ ok: true, leases: Array.from(leases.values()) });
+  }
+
+  private async readLeases(): Promise<Map<string, WorkstationLeaseRecord>> {
+    const all = await this.state.storage.list<unknown>({
+      prefix: WORKSTATION_LEASE_KEY_PREFIX,
+    });
+    const leases = new Map<string, WorkstationLeaseRecord>();
+    for (const [key, value] of all) {
+      // Guard on the key prefix too: fake test storage ignores the list
+      // prefix filter, so a compute-session value must not slip through.
+      if (key.startsWith(WORKSTATION_LEASE_KEY_PREFIX) && isWorkstationLeaseRecord(value)) {
+        leases.set(key, value);
+      }
+    }
+    return leases;
+  }
+
+  /**
+   * Single-earliest-wins: schedule the alarm for the soonest online lease
+   * expiry, or clear it when no lease is live. Cheap to call on every upsert -
+   * `setAlarm` is one row write, and we only rewrite when the target moves.
+   */
+  private async armLeaseAlarm(): Promise<void> {
+    if (!this.state.storage.setAlarm) {
+      return;
+    }
+    const leases = await this.readLeases();
+    let earliest: number | null = null;
+    for (const lease of leases.values()) {
+      if (lease.online && (earliest === null || lease.lease_expires_at < earliest)) {
+        earliest = lease.lease_expires_at;
+      }
+    }
+    const current = (await this.state.storage.getAlarm?.()) ?? null;
+    if (earliest === null) {
+      if (current !== null) {
+        await this.state.storage.deleteAlarm?.();
+      }
+      return;
+    }
+    if (current === null || current > earliest) {
+      await this.state.storage.setAlarm(earliest);
+    }
+  }
+
+  private async sweepExpiredLeases(now: number): Promise<number> {
+    const leases = await this.readLeases();
+    let expired = 0;
+    for (const [key, lease] of leases) {
+      if (lease.online && lease.lease_expires_at <= now) {
+        const offline: WorkstationLeaseRecord = {
+          ...lease,
+          online: false,
+          offline_reason: "lease expired: no heartbeat within the lease window",
+        };
+        await this.state.storage.put(key, offline);
+        expired += 1;
+        cloudLog("info", "fleet_registry.lease_expired", {
+          owner_principal: lease.owner_principal,
+          workstation_id: lease.workstation_id,
+          counter: "fleet_registry_lease_expirations",
+          counter_delta: 1,
+        });
+      }
+    }
+    await this.armLeaseAlarm();
+    return expired;
   }
 
   private async handleUpsert(request: Request): Promise<Response> {
@@ -168,6 +302,102 @@ export async function listOwnerComputeSessions(
   }
 }
 
+/**
+ * Renew a workstation's liveness lease from the heartbeat path. Best-effort:
+ * a registry write failure must not fail workstation registration, so callers
+ * ignore the boolean beyond logging.
+ */
+export async function upsertWorkstationLease(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+  ttlMs: number,
+): Promise<boolean> {
+  const namespace = env.OWNER_COMPUTE_INDEX;
+  if (!namespace) {
+    return false;
+  }
+  try {
+    const response = await ownerComputeIndexStub(namespace, ownerPrincipal).fetch(
+      new Request("https://owner-compute-index.internal/lease/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          workstation_id: workstationId,
+          owner_principal: ownerPrincipal,
+          ttl_ms: ttlMs,
+        }),
+      }),
+    );
+    if (response.ok) {
+      return true;
+    }
+    cloudLog("warn", "fleet_registry.lease_upsert_failed", {
+      owner_principal: ownerPrincipal,
+      workstation_id: workstationId,
+      response_status: response.status,
+      counter: "fleet_registry_lease_upsert_failed",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "fleet_registry.lease_upsert_failed", {
+      owner_principal: ownerPrincipal,
+      workstation_id: workstationId,
+      error: errorMessage(error),
+      counter: "fleet_registry_lease_upsert_failed",
+      counter_delta: 1,
+    });
+  }
+  return false;
+}
+
+/** Read every lease this owner holds, keyed by workstation id. */
+export async function listWorkstationLeases(
+  env: Env,
+  ownerPrincipal: string,
+): Promise<Map<string, WorkstationLeaseRecord>> {
+  const namespace = env.OWNER_COMPUTE_INDEX;
+  if (!namespace) {
+    return new Map();
+  }
+  try {
+    const response = await ownerComputeIndexStub(namespace, ownerPrincipal).fetch(
+      new Request("https://owner-compute-index.internal/lease/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    if (!response.ok) {
+      cloudLog("warn", "fleet_registry.lease_list_failed", {
+        owner_principal: ownerPrincipal,
+        response_status: response.status,
+        counter: "fleet_registry_lease_list_failed",
+        counter_delta: 1,
+      });
+      return new Map();
+    }
+    const body = (await response.json()) as unknown;
+    const leases = new Map<string, WorkstationLeaseRecord>();
+    if (body && typeof body === "object" && Array.isArray((body as { leases?: unknown }).leases)) {
+      for (const entry of (body as { leases: unknown[] }).leases) {
+        if (isWorkstationLeaseRecord(entry)) {
+          leases.set(entry.workstation_id, entry);
+        }
+      }
+    }
+    return leases;
+  } catch (error) {
+    cloudLog("warn", "fleet_registry.lease_list_failed", {
+      owner_principal: ownerPrincipal,
+      error: errorMessage(error),
+      counter: "fleet_registry_lease_list_failed",
+      counter_delta: 1,
+    });
+    return new Map();
+  }
+}
+
 function ownerComputeIndexStub(namespace: DurableObjectNamespace, ownerPrincipal: string) {
   const id = namespace.idFromName(ownerComputeIndexObjectName(ownerPrincipal));
   return namespace.get(id);
@@ -211,6 +441,31 @@ async function fetchOwnerComputeIndex(
 
 function sessionKey(notebookId: string): string {
   return `${COMPUTE_SESSION_KEY_PREFIX}${notebookId}`;
+}
+
+function leaseKey(workstationId: string): string {
+  return `${WORKSTATION_LEASE_KEY_PREFIX}${workstationId}`;
+}
+
+function positiveInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return Math.floor(value);
+}
+
+function isWorkstationLeaseRecord(value: unknown): value is WorkstationLeaseRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.workstation_id === "string" &&
+    typeof record.owner_principal === "string" &&
+    typeof record.last_seen_at === "string" &&
+    typeof record.lease_expires_at === "number" &&
+    typeof record.online === "boolean"
+  );
 }
 
 async function readJsonObject(request: Request): Promise<Record<string, unknown> | Response> {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2816,11 +2816,19 @@ export function workstationStatusForResponse(
   // The registry-DO lease is the proactive liveness signal: its alarm sweeps a
   // workstation offline at expiry instead of waiting for a read to notice.
   // Still check the expiry timestamp directly so a late alarm can't report a
-  // lapsed lease as live. Falls back to the lazy D1 staleness check when no
-  // lease exists (a workstation registered before this shipped, or a dropped
-  // lease write).
+  // lapsed lease as live. Only trust the lease when it is at least as fresh as
+  // the D1 row: a heartbeat writes D1 first and the paired lease write is
+  // best-effort, so if that write lagged or failed, D1 is the newer signal and
+  // a stale offline lease must not override it. Falls back to the lazy D1
+  // staleness check when no (or a stale) lease exists.
   if (lease && (workstation.status === "online" || workstation.status === "offline")) {
-    return lease.online && lease.lease_expires_at > now ? "online" : "offline";
+    const rowSeen = workstation.last_seen_at ? Date.parse(workstation.last_seen_at) : NaN;
+    const leaseSeen = Date.parse(lease.last_seen_at);
+    const leaseIsFreshEnough =
+      !Number.isFinite(rowSeen) || (Number.isFinite(leaseSeen) && leaseSeen >= rowSeen);
+    if (leaseIsFreshEnough) {
+      return lease.online && lease.lease_expires_at > now ? "online" : "offline";
+    }
   }
   if (workstation.status === "online" && workstation.last_seen_at) {
     const lastSeen = Date.parse(workstation.last_seen_at);

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -90,7 +90,11 @@ import {
   workstationEventsObjectName,
   type WorkstationAttachJobNotification,
 } from "./workstation-events.ts";
-import { OwnerComputeIndex, listOwnerComputeSessions } from "./compute-session-index.ts";
+import {
+  OwnerComputeIndex,
+  listOwnerComputeSessions,
+  upsertWorkstationLease,
+} from "./compute-session-index.ts";
 import {
   SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH,
   materializeSnapshotPairRenderWithSummary,
@@ -1675,6 +1679,11 @@ function parseNotebookListLimit(request: Request): number | Response {
 }
 
 const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
+// The lease a heartbeat renews in the registry DO expires after the same
+// window the lazy read-time check uses, so alarm-swept offline and read-time
+// offline agree. The DO's alarm makes the transition proactive instead of
+// only-on-read.
+const WORKSTATION_LEASE_TTL_MS = WORKSTATION_HEARTBEAT_STALE_MS;
 const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
 const MISSING_WORKSTATION_RETRY_AFTER_SECONDS = 15 * 60;
 
@@ -1752,6 +1761,15 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
   if (!workstation) {
     return json({ error: "workstation was not registered" }, 500);
   }
+  // Renew the registry-DO liveness lease alongside the D1 row. Best-effort:
+  // registration already succeeded, and the lazy read-time staleness check
+  // still stands if this write is dropped.
+  await upsertWorkstationLease(
+    env,
+    ownerPrincipal,
+    workstation.workstation_id,
+    WORKSTATION_LEASE_TTL_MS,
+  );
   if (identity.metadata.workstationPairingCodeId) {
     await linkWorkstationToPairing(
       env,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2819,10 +2819,7 @@ export function workstationStatusForResponse(
   // lapsed lease as live. Falls back to the lazy D1 staleness check when no
   // lease exists (a workstation registered before this shipped, or a dropped
   // lease write).
-  if (
-    lease &&
-    (workstation.status === "online" || workstation.status === "offline")
-  ) {
+  if (lease && (workstation.status === "online" || workstation.status === "offline")) {
     return lease.online && lease.lease_expires_at > now ? "online" : "offline";
   }
   if (workstation.status === "online" && workstation.last_seen_at) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -93,7 +93,9 @@ import {
 import {
   OwnerComputeIndex,
   listOwnerComputeSessions,
+  listWorkstationLeases,
   upsertWorkstationLease,
+  type WorkstationLeaseRecord,
 } from "./compute-session-index.ts";
 import {
   SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH,
@@ -1720,9 +1722,10 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
   const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
 
   if (request.method === "GET") {
-    const [workstations, defaultWorkstationId] = await Promise.all([
+    const [workstations, defaultWorkstationId, leases] = await Promise.all([
       listWorkstationsForPrincipal(env, ownerPrincipal),
       getDefaultWorkstationId(env, ownerPrincipal),
+      listWorkstationLeases(env, ownerPrincipal),
     ]);
     const now = Date.now();
     const presenceByWorkstationId = await workstationEventPresenceById(
@@ -1739,6 +1742,7 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
           defaultWorkstationId,
           now,
           eventPresence: presenceByWorkstationId.get(workstation.workstation_id) ?? null,
+          lease: leases.get(workstation.workstation_id) ?? null,
         }),
       ),
     });
@@ -2761,9 +2765,15 @@ function workstationResponseRow(
     defaultWorkstationId: string | null;
     now: number;
     eventPresence?: WorkstationEventPresence | null;
+    lease?: WorkstationLeaseRecord | null;
   },
 ): Record<string, unknown> {
-  const status = workstationStatusForResponse(workstation, options.now, options.eventPresence);
+  const status = workstationStatusForResponse(
+    workstation,
+    options.now,
+    options.eventPresence,
+    options.lease,
+  );
   return {
     workstation_id: workstation.workstation_id,
     display_name: workstation.display_name,
@@ -2791,16 +2801,29 @@ function workstationResponseRow(
   };
 }
 
-function workstationStatusForResponse(
+export function workstationStatusForResponse(
   workstation: WorkstationRow,
   now: number,
   eventPresence: WorkstationEventPresence | null | undefined = null,
+  lease: WorkstationLeaseRecord | null | undefined = null,
 ): WorkstationStatus {
   if (
     eventPresence?.connected === true &&
     (workstation.status === "online" || workstation.status === "offline")
   ) {
     return "online";
+  }
+  // The registry-DO lease is the proactive liveness signal: its alarm sweeps a
+  // workstation offline at expiry instead of waiting for a read to notice.
+  // Still check the expiry timestamp directly so a late alarm can't report a
+  // lapsed lease as live. Falls back to the lazy D1 staleness check when no
+  // lease exists (a workstation registered before this shipped, or a dropped
+  // lease write).
+  if (
+    lease &&
+    (workstation.status === "online" || workstation.status === "offline")
+  ) {
+    return lease.online && lease.lease_expires_at > now ? "online" : "offline";
   }
   if (workstation.status === "online" && workstation.last_seen_at) {
     const lastSeen = Date.parse(workstation.last_seen_at);

--- a/apps/notebook-cloud/src/workstation-events.ts
+++ b/apps/notebook-cloud/src/workstation-events.ts
@@ -21,6 +21,21 @@ export interface WorkstationAttachJobNotification {
   updated_at: string;
 }
 
+/**
+ * Pushed by the registry DO's lease alarm the moment a workstation's lease
+ * lapses, so listeners learn it went offline without waiting to infer absence
+ * from a missed poll.
+ */
+export interface WorkstationWentOfflineNotification {
+  event: "went_offline";
+  workstation_id: string;
+  reason: string;
+}
+
+export type WorkstationEventNotification =
+  | WorkstationAttachJobNotification
+  | WorkstationWentOfflineNotification;
+
 export function workstationEventsObjectName(ownerPrincipal: string, workstationId: string): string {
   return `${ownerPrincipal}\n${workstationId}`;
 }
@@ -227,7 +242,7 @@ function socketAttachment(socket: CloudflareWebSocket): EventSocketAttachment | 
 
 async function readNotification(
   request: Request,
-): Promise<WorkstationAttachJobNotification | Response> {
+): Promise<WorkstationEventNotification | Response> {
   let body: unknown;
   try {
     body = await request.json();
@@ -238,6 +253,19 @@ async function readNotification(
     return Response.json({ error: "notification body must be an object" }, { status: 400 });
   }
   const event = stringField(body.event);
+
+  if (event === "went_offline") {
+    const workstationId = stringField(body.workstation_id);
+    if (!workstationId) {
+      return Response.json({ error: "invalid notification body" }, { status: 400 });
+    }
+    return {
+      event: "went_offline",
+      workstation_id: workstationId,
+      reason: stringField(body.reason) || "went offline",
+    };
+  }
+
   const notification = {
     event,
     workstation_id: stringField(body.workstation_id),
@@ -258,7 +286,7 @@ async function readNotification(
   ) {
     return Response.json({ error: "invalid notification body" }, { status: 400 });
   }
-  return { ...notification, event };
+  return { ...notification, event: "attach_jobs" };
 }
 
 function stringField(value: unknown): string {

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { DurableObjectState, Env } from "../src/cloudflare-types.ts";
-import { OwnerComputeIndex, ownerComputeIndexObjectName } from "../src/compute-session-index.ts";
+import {
+  OwnerComputeIndex,
+  ownerComputeIndexObjectName,
+  WORKSTATION_LEASE_GC_MS,
+} from "../src/compute-session-index.ts";
 import type { NotebookComputeSessionSummary } from "runtimed";
 
 describe("OwnerComputeIndex", () => {
@@ -109,28 +113,31 @@ describe("OwnerComputeIndex workstation leases", () => {
     assert.equal(scheduledAlarm(), sooner.lease_expires_at);
   });
 
-  it("sweeps an expired lease to offline and clears the alarm when none remain", async () => {
-    const { state, values, scheduledAlarm } = fakeStateWithAlarm();
+  it("sweeps an expired lease to offline and arms the GC deadline for the dead row", async () => {
+    const { state, values, scheduledAlarm, deliverAlarm } = fakeStateWithAlarm();
     const object = new OwnerComputeIndex(state, {} as Env);
 
     await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
     // Force the stored lease past its window, then fire the alarm the runtime
     // would have scheduled.
     const stored = values.get("lease:ws-a") as Record<string, unknown>;
-    values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
+    const expiredAt = Date.now() - 1;
+    values.set("lease:ws-a", { ...stored, lease_expires_at: expiredAt });
 
+    deliverAlarm();
     await object.alarm();
 
     const leases = await listLeases(object);
     assert.equal(leases.length, 1);
     assert.equal(leases[0].online, false);
     assert.match(leases[0].offline_reason ?? "", /lease expired/);
-    // No live lease left, so the DO disarms and hibernates.
-    assert.equal(scheduledAlarm(), null);
+    // The row is offline now, so the alarm is armed for its GC deadline, not
+    // cleared - otherwise the dead row would never be collected.
+    assert.equal(scheduledAlarm(), expiredAt + WORKSTATION_LEASE_GC_MS);
   });
 
   it("leaves live leases untouched while sweeping expired ones", async () => {
-    const { state, values } = fakeStateWithAlarm();
+    const { state, values, deliverAlarm } = fakeStateWithAlarm();
     const object = new OwnerComputeIndex(state, {} as Env);
 
     await object.fetch(leaseUpsert("ws-dead", "user:dev:alice", 60_000));
@@ -138,6 +145,7 @@ describe("OwnerComputeIndex workstation leases", () => {
     const dead = values.get("lease:ws-dead") as Record<string, unknown>;
     values.set("lease:ws-dead", { ...dead, lease_expires_at: Date.now() - 1 });
 
+    deliverAlarm();
     await object.alarm();
 
     const byId = new Map(
@@ -150,7 +158,7 @@ describe("OwnerComputeIndex workstation leases", () => {
 
 describe("OwnerComputeIndex lease notifications and GC", () => {
   it("pushes went_offline to WorkstationEvents when a lease lapses", async () => {
-    const { state, values } = fakeStateWithAlarm();
+    const { state, values, settle, deliverAlarm } = fakeStateWithAlarm();
     const events = fakeWorkstationEvents();
     const object = new OwnerComputeIndex(state, events.env);
 
@@ -158,7 +166,10 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
     const stored = values.get("lease:ws-a") as Record<string, unknown>;
     values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
 
+    deliverAlarm();
     await object.alarm();
+    // Delivery is dispatched off the handler via waitUntil; drain it.
+    await settle();
 
     assert.equal(events.notifications.length, 1);
     assert.equal(events.notifications[0].objectName, "user:dev:alice\nws-a");
@@ -168,7 +179,7 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
   });
 
   it("does not push for a lease that is already offline", async () => {
-    const { state, values } = fakeStateWithAlarm();
+    const { state, values, settle, deliverAlarm } = fakeStateWithAlarm();
     const events = fakeWorkstationEvents();
     const object = new OwnerComputeIndex(state, events.env);
 
@@ -176,13 +187,15 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
     const stored = values.get("lease:ws-a") as Record<string, unknown>;
     values.set("lease:ws-a", { ...stored, online: false, lease_expires_at: Date.now() - 1 });
 
+    deliverAlarm();
     await object.alarm();
+    await settle();
 
     assert.equal(events.notifications.length, 0);
   });
 
-  it("garbage-collects leases offline past the GC window", async () => {
-    const { state, values } = fakeStateWithAlarm();
+  it("garbage-collects leases offline past the GC window and disarms", async () => {
+    const { state, values, scheduledAlarm, deliverAlarm } = fakeStateWithAlarm();
     const object = new OwnerComputeIndex(state, {} as Env);
 
     await object.fetch(leaseUpsert("ws-old", "user:dev:alice", 60_000));
@@ -194,10 +207,13 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
       lease_expires_at: Date.now() - 25 * 60 * 60_000,
     });
 
+    deliverAlarm();
     await object.alarm();
 
     assert.equal((await listLeases(object)).length, 0);
     assert.equal(values.has("lease:ws-old"), false);
+    // Nothing left to sweep, so the alarm is cleared and the DO hibernates.
+    assert.equal(scheduledAlarm(), null);
   });
 });
 
@@ -256,9 +272,15 @@ function fakeStateWithAlarm(): {
   state: DurableObjectState;
   values: Map<string, unknown>;
   scheduledAlarm: () => number | null;
+  settle: () => Promise<unknown>;
+  deliverAlarm: () => void;
 } {
   const values = new Map<string, unknown>();
   let alarm: number | null = null;
+  // The alarm dispatches went_offline via waitUntil so the handler returns
+  // without awaiting delivery. Capture those promises so a test can await the
+  // background work it wants to observe.
+  const pending: Promise<unknown>[] = [];
   const state: DurableObjectState = {
     id: { toString: () => "owner-compute" },
     storage: {
@@ -276,9 +298,22 @@ function fakeStateWithAlarm(): {
         alarm = null;
       },
     },
-    waitUntil: () => undefined,
+    waitUntil: (promise: Promise<unknown>) => {
+      pending.push(Promise.resolve(promise));
+    },
   };
-  return { state, values, scheduledAlarm: () => alarm };
+  return {
+    state,
+    values,
+    scheduledAlarm: () => alarm,
+    settle: () => Promise.allSettled(pending),
+    // Model Cloudflare delivering the alarm: the pending alarm is consumed
+    // before the handler runs, so getAlarm() reads null inside alarm() unless
+    // the handler re-arms. Call this right before object.alarm().
+    deliverAlarm: () => {
+      alarm = null;
+    },
+  };
 }
 
 function computeSummary(notebookId: string): NotebookComputeSessionSummary {

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -75,6 +75,136 @@ describe("OwnerComputeIndex", () => {
   });
 });
 
+describe("OwnerComputeIndex workstation leases", () => {
+  it("renews a lease and arms the alarm for its expiry", async () => {
+    const { state, scheduledAlarm } = fakeStateWithAlarm();
+    const object = new OwnerComputeIndex(state, {} as Env);
+
+    const response = await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { ok: boolean; lease_expires_at: number };
+    assert.equal(body.ok, true);
+    // Single-earliest-wins: the alarm is scheduled for exactly this expiry.
+    assert.equal(scheduledAlarm(), body.lease_expires_at);
+
+    const leases = await listLeases(object);
+    assert.equal(leases.length, 1);
+    assert.equal(leases[0].workstation_id, "ws-a");
+    assert.equal(leases[0].online, true);
+    assert.equal(leases[0].offline_reason, null);
+  });
+
+  it("keeps the alarm on the earliest of several leases", async () => {
+    const { state, scheduledAlarm } = fakeStateWithAlarm();
+    const object = new OwnerComputeIndex(state, {} as Env);
+
+    const later = (await (
+      await object.fetch(leaseUpsert("ws-late", "user:dev:alice", 120_000))
+    ).json()) as { lease_expires_at: number };
+    const sooner = (await (
+      await object.fetch(leaseUpsert("ws-soon", "user:dev:alice", 30_000))
+    ).json()) as { lease_expires_at: number };
+
+    assert.ok(sooner.lease_expires_at < later.lease_expires_at);
+    assert.equal(scheduledAlarm(), sooner.lease_expires_at);
+  });
+
+  it("sweeps an expired lease to offline and clears the alarm when none remain", async () => {
+    const { state, values, scheduledAlarm } = fakeStateWithAlarm();
+    const object = new OwnerComputeIndex(state, {} as Env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    // Force the stored lease past its window, then fire the alarm the runtime
+    // would have scheduled.
+    const stored = values.get("lease:ws-a") as Record<string, unknown>;
+    values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
+
+    await object.alarm();
+
+    const leases = await listLeases(object);
+    assert.equal(leases.length, 1);
+    assert.equal(leases[0].online, false);
+    assert.match(leases[0].offline_reason ?? "", /lease expired/);
+    // No live lease left, so the DO disarms and hibernates.
+    assert.equal(scheduledAlarm(), null);
+  });
+
+  it("leaves live leases untouched while sweeping expired ones", async () => {
+    const { state, values } = fakeStateWithAlarm();
+    const object = new OwnerComputeIndex(state, {} as Env);
+
+    await object.fetch(leaseUpsert("ws-dead", "user:dev:alice", 60_000));
+    await object.fetch(leaseUpsert("ws-live", "user:dev:alice", 60_000));
+    const dead = values.get("lease:ws-dead") as Record<string, unknown>;
+    values.set("lease:ws-dead", { ...dead, lease_expires_at: Date.now() - 1 });
+
+    await object.alarm();
+
+    const byId = new Map(
+      (await listLeases(object)).map((lease) => [lease.workstation_id, lease] as const),
+    );
+    assert.equal(byId.get("ws-dead")?.online, false);
+    assert.equal(byId.get("ws-live")?.online, true);
+  });
+});
+
+function leaseUpsert(workstationId: string, ownerPrincipal: string, ttlMs: number): Request {
+  return new Request("https://compute.internal/lease/upsert", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      workstation_id: workstationId,
+      owner_principal: ownerPrincipal,
+      ttl_ms: ttlMs,
+    }),
+  });
+}
+
+async function listLeases(
+  object: OwnerComputeIndex,
+): Promise<Array<{ workstation_id: string; online: boolean; offline_reason: string | null }>> {
+  const response = await object.fetch(
+    new Request("https://compute.internal/lease/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+  const body = (await response.json()) as {
+    leases: Array<{ workstation_id: string; online: boolean; offline_reason: string | null }>;
+  };
+  return body.leases;
+}
+
+function fakeStateWithAlarm(): {
+  state: DurableObjectState;
+  values: Map<string, unknown>;
+  scheduledAlarm: () => number | null;
+} {
+  const values = new Map<string, unknown>();
+  let alarm: number | null = null;
+  const state: DurableObjectState = {
+    id: { toString: () => "owner-compute" },
+    storage: {
+      get: async <T>(key: string) => values.get(key) as T | undefined,
+      put: async <T>(key: string, value: T) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => values.delete(key),
+      list: async <T>() => new Map(values as Map<string, T>),
+      setAlarm: async (time: number | Date) => {
+        alarm = typeof time === "number" ? time : time.getTime();
+      },
+      getAlarm: async () => alarm,
+      deleteAlarm: async () => {
+        alarm = null;
+      },
+    },
+    waitUntil: () => undefined,
+  };
+  return { state, values, scheduledAlarm: () => alarm };
+}
+
 function computeSummary(notebookId: string): NotebookComputeSessionSummary {
   return {
     environment_label: "Current Python",

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -148,6 +148,82 @@ describe("OwnerComputeIndex workstation leases", () => {
   });
 });
 
+describe("OwnerComputeIndex lease notifications and GC", () => {
+  it("pushes went_offline to WorkstationEvents when a lease lapses", async () => {
+    const { state, values } = fakeStateWithAlarm();
+    const events = fakeWorkstationEvents();
+    const object = new OwnerComputeIndex(state, events.env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    const stored = values.get("lease:ws-a") as Record<string, unknown>;
+    values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
+
+    await object.alarm();
+
+    assert.equal(events.notifications.length, 1);
+    assert.equal(events.notifications[0].objectName, "user:dev:alice\nws-a");
+    assert.equal(events.notifications[0].body.event, "went_offline");
+    assert.equal(events.notifications[0].body.workstation_id, "ws-a");
+    assert.match(events.notifications[0].body.reason as string, /lease expired/);
+  });
+
+  it("does not push for a lease that is already offline", async () => {
+    const { state, values } = fakeStateWithAlarm();
+    const events = fakeWorkstationEvents();
+    const object = new OwnerComputeIndex(state, events.env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    const stored = values.get("lease:ws-a") as Record<string, unknown>;
+    values.set("lease:ws-a", { ...stored, online: false, lease_expires_at: Date.now() - 1 });
+
+    await object.alarm();
+
+    assert.equal(events.notifications.length, 0);
+  });
+
+  it("garbage-collects leases offline past the GC window", async () => {
+    const { state, values } = fakeStateWithAlarm();
+    const object = new OwnerComputeIndex(state, {} as Env);
+
+    await object.fetch(leaseUpsert("ws-old", "user:dev:alice", 60_000));
+    // Offline for well over a day past expiry.
+    const stored = values.get("lease:ws-old") as Record<string, unknown>;
+    values.set("lease:ws-old", {
+      ...stored,
+      online: false,
+      lease_expires_at: Date.now() - 25 * 60 * 60_000,
+    });
+
+    await object.alarm();
+
+    assert.equal((await listLeases(object)).length, 0);
+    assert.equal(values.has("lease:ws-old"), false);
+  });
+});
+
+function fakeWorkstationEvents(): {
+  env: Env;
+  notifications: Array<{ objectName: string; body: Record<string, unknown> }>;
+} {
+  const notifications: Array<{ objectName: string; body: Record<string, unknown> }> = [];
+  const namespace = {
+    idFromName: (name: string) => ({ toString: () => name, name }),
+    get: (id: { name: string }) => ({
+      fetch: async (request: Request) => {
+        notifications.push({
+          objectName: id.name,
+          body: (await request.json()) as Record<string, unknown>,
+        });
+        return Response.json({ ok: true, delivered: 1 });
+      },
+    }),
+  };
+  return {
+    env: { WORKSTATION_EVENTS: namespace } as unknown as Env,
+    notifications,
+  };
+}
+
 function leaseUpsert(workstationId: string, ownerPrincipal: string, ttlMs: number): Request {
   return new Request("https://compute.internal/lease/upsert", {
     method: "POST",

--- a/apps/notebook-cloud/test/workstation-events.test.ts
+++ b/apps/notebook-cloud/test/workstation-events.test.ts
@@ -107,6 +107,49 @@ test("workstation events notify sends JSON wakeups to connected sockets", async 
   });
 });
 
+test("workstation events notify delivers went_offline to connected sockets", async () => {
+  const socket = new FakeSocket();
+  const events = new WorkstationEvents(
+    stateWithSockets([socket.asCloudflareWebSocket()]),
+    {} as Env,
+  );
+
+  const response = await events.fetch(
+    new Request("https://workstation-events.internal/notify", {
+      method: "POST",
+      body: JSON.stringify({
+        event: "went_offline",
+        workstation_id: "ws-lab2",
+        reason: "lease expired: no heartbeat within the lease window",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, delivered: 1 });
+  assert.deepEqual(JSON.parse(socket.sent[0]!), {
+    event: "went_offline",
+    data: {
+      event: "went_offline",
+      workstation_id: "ws-lab2",
+      reason: "lease expired: no heartbeat within the lease window",
+    },
+  });
+});
+
+test("workstation events rejects went_offline without a workstation id", async () => {
+  const events = new WorkstationEvents(stateWithSockets([]), {} as Env);
+
+  const response = await events.fetch(
+    new Request("https://workstation-events.internal/notify", {
+      method: "POST",
+      body: JSON.stringify({ event: "went_offline" }),
+    }),
+  );
+
+  assert.equal(response.status, 400);
+});
+
 test("workstation events answers ping in the non-hibernation fallback path", () => {
   const socket = new FakeSocket();
   const events = new WorkstationEvents(stateWithSockets([]), {} as Env);

--- a/apps/notebook-cloud/test/workstation-status.test.ts
+++ b/apps/notebook-cloud/test/workstation-status.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { workstationStatusForResponse } from "../src/index.ts";
+import type { WorkstationRow } from "../src/storage.ts";
+import type { WorkstationLeaseRecord } from "../src/compute-session-index.ts";
+
+const NOW = 1_780_000_000_000;
+
+function row(overrides: Partial<WorkstationRow> = {}): WorkstationRow {
+  return {
+    status: "online",
+    last_seen_at: new Date(NOW).toISOString(),
+    ...overrides,
+  } as WorkstationRow;
+}
+
+function lease(overrides: Partial<WorkstationLeaseRecord> = {}): WorkstationLeaseRecord {
+  return {
+    workstation_id: "ws-a",
+    owner_principal: "user:dev:alice",
+    last_seen_at: new Date(NOW).toISOString(),
+    lease_expires_at: NOW + 60_000,
+    online: true,
+    offline_reason: null,
+    ...overrides,
+  };
+}
+
+describe("workstationStatusForResponse", () => {
+  it("reports online from a live lease", () => {
+    assert.equal(workstationStatusForResponse(row(), NOW, null, lease()), "online");
+  });
+
+  it("reports offline from a lease the alarm swept", () => {
+    const swept = lease({ online: false, offline_reason: "lease expired" });
+    assert.equal(workstationStatusForResponse(row(), NOW, null, swept), "offline");
+  });
+
+  it("reports offline from a lapsed lease even if the alarm was late to flip online", () => {
+    // online === true but the window already passed: a late alarm must not
+    // read as live.
+    const lapsed = lease({ online: true, lease_expires_at: NOW - 1 });
+    assert.equal(workstationStatusForResponse(row(), NOW, null, lapsed), "offline");
+  });
+
+  it("falls back to lazy D1 staleness when no lease exists", () => {
+    const fresh = row({ last_seen_at: new Date(NOW).toISOString() });
+    assert.equal(workstationStatusForResponse(fresh, NOW, null, null), "online");
+
+    const stale = row({ last_seen_at: new Date(NOW - 4 * 60_000).toISOString() });
+    assert.equal(workstationStatusForResponse(stale, NOW, null, null), "offline");
+  });
+
+  it("lets a live event socket override a swept lease", () => {
+    const swept = lease({ online: false });
+    assert.equal(
+      workstationStatusForResponse(row(), NOW, { connected: true, connections: 1 }, swept),
+      "online",
+    );
+  });
+});

--- a/apps/notebook-cloud/test/workstation-status.test.ts
+++ b/apps/notebook-cloud/test/workstation-status.test.ts
@@ -58,4 +58,16 @@ describe("workstationStatusForResponse", () => {
       "online",
     );
   });
+
+  it("ignores a stale offline lease when the D1 row is fresher", () => {
+    // Heartbeat landed in D1 but the paired lease write lagged or failed, so the
+    // lease still reads the pre-heartbeat swept-offline verdict. D1 is the newer
+    // signal; a fresh row must not be regressed to offline.
+    const freshRow = row({ last_seen_at: new Date(NOW).toISOString() });
+    const staleSwept = lease({
+      online: false,
+      last_seen_at: new Date(NOW - 5 * 60_000).toISOString(),
+    });
+    assert.equal(workstationStatusForResponse(freshRow, NOW, null, staleSwept), "online");
+  });
 });


### PR DESCRIPTION
Consolidates workstation liveness into the owner-scoped registry Durable Object. Each heartbeat renews a lease with an expiry, and a single DO alarm sweeps a workstation offline the moment its lease lapses, then pushes the transition to any listeners. Today offline is only inferred lazily, at read time, from a stale D1 `last_seen_at`, so the rail and toolbar can keep showing a workstation online well after it went quiet. This makes the offline edge proactive and cheap, without standing up a separate ingress/egress service to register and track nodes.

## Design decision: the hibernation boundary is load-bearing

The registry DO (`OwnerComputeIndex`) holds only lease state and one alarm. It never holds a WebSocket. That is what lets it hibernate between a heartbeat write and the next sweep, so an idle fleet costs nothing while it waits. A DO that parks an open connection stays resident and bills wall-clock, which is the failure mode to avoid here.

The socket-holding DO (`WorkstationEvents`) already hibernates: it uses `setWebSocketAutoResponse` for ping/pong, so it answers keepalives without waking. On expiry the registry reaches it by `fetch` to deliver the `went_offline` push. It never grabs a socket of its own. Keeping the lease DO connection-less and the events DO socket-only is the boundary that keeps both hibernatable.

The alarm is single-earliest-wins: it arms for the soonest live lease expiry and rewrites only when that target moves, so N workstations share one alarm, not N.

## What ships (three commits)

1. **Lease store + alarm.** `OwnerComputeIndex` gains `/lease/upsert` and `/lease/list`; the heartbeat POST dual-writes a lease next to the D1 row (best-effort, never blocks registration). `alarm()` sweeps expired leases to offline and re-arms, or disarms when none are live.
2. **Read path consults the lease.** `GET /api/workstations` reads the lease so an alarm-swept lease reports offline proactively. It also checks the expiry timestamp directly, so a late alarm can't report a lapsed lease as live. A live event socket still overrides to online; a missing lease falls back to the old D1 staleness check.
3. **went_offline push + GC.** The sweep `fetch`es `WorkstationEvents /notify` with a new `went_offline` event so listeners learn a drop instead of inferring it from a missed poll. The same sweep garbage-collects leases that have stayed offline past a day, so DO storage doesn't accumulate dead records. D1 stays the registry of record, so a GC'd workstation still lists (offline) via the fallback.

## Behavioral coverage

| Situation | Reported status | Path |
|---|---|---|
| Heartbeat within the window | online | lease `online` + not expired |
| No heartbeat within the window | offline | alarm sweeps + pushes `went_offline` |
| Alarm late, lease already lapsed | offline | read checks `lease_expires_at` directly |
| Live event socket present | online | socket presence overrides the lease |
| No lease (pre-feature / dropped write) | D1 lazy staleness | backward-compatible fallback |
| Offline past the GC window | dropped from DO, still lists offline | alarm GC + D1 fallback |

## Cost

Liveness stays on DO-SQLite row writes. At ~200 nodes on a 20s heartbeat that's roughly 26M writes/month, under the 50M included row-writes, so ~$0 marginal. A Redis control plane would add a managed dependency plus separate ingress/egress and can't hold the persistent `SUBSCRIBE`/keyspace-notification connections a Worker needs anyway. The design rationale and the options considered are in the memo (#3946).

## Scope

Explicit user-initiated deregistration (a D1 cascade-delete plus a remove-workstation control) is a separate follow-up. It's registration lifecycle, not liveness, and the motivating never-connected workstation has no lease to sweep. The rail "Running" badge convergence (the room host reflecting `kernel.lifecycle` into attachment status) also stays out; that's the read-side remainder tracked on #3947.

Tests: DO lease upsert/list, alarm arm/disarm, sweep-to-offline, GC, and the `went_offline` push (fake `WorkstationEvents` namespace); the read-path derivation (live/swept/lapsed/fallback/socket-override); and `WorkstationEvents` accepting the new event. Full notebook-cloud node suite and the cloud viewer vitest suite are green.

Design doc: #3946. Part of the workstation reliability work alongside #3948 (which resolved the stuck-queue on launch failure); tracked with #3947.
