### PR TITLE
feat(local-oidc): multiple dev users selectable by login_hint

### DIFF
--- a/apps/notebook-cloud/src/dev-oidc.ts
+++ b/apps/notebook-cloud/src/dev-oidc.ts
@@ -29,11 +29,16 @@ export const NOTEBOOK_CLOUD_LOCAL_OIDC_MOUNT_PATH = "/dev/oidc";
 export const NOTEBOOK_CLOUD_LOCAL_OIDC_CLIENT_ID = "local-oidc-client";
 export const NOTEBOOK_CLOUD_LOCAL_OIDC_DEFAULT_TTL_SECONDS = 300;
 
-const DEV_USER = {
-  email: "dev@localhost",
-  givenName: "Local",
-  familyName: "Developer",
-} as const;
+// Multiple dev identities so local multi-user flows (sharing, presence,
+// cross-user gating) are drivable against one issuer. The first is the default
+// when the authorize request carries no login_hint; reach the others with
+// `?login_hint=<email>` on the sign-in URL (the viewer forwards it only for this
+// local issuer).
+const DEV_USERS = [
+  { email: "dev@localhost", givenName: "Local", familyName: "Developer" },
+  { email: "alice@localhost", givenName: "Alice", familyName: "Example" },
+  { email: "bob@localhost", givenName: "Bob", familyName: "Example" },
+] as const;
 
 // One issuer instance per resolved issuer URL, held for the worker's boot. Every
 // restart starts with an empty cache and a fresh signing key.
@@ -83,7 +88,7 @@ function localOidcIssuer(env: Env, issuerUrl: string): LocalOidcIssuer {
     issuerUrl,
     clientId: env.NOTEBOOK_CLOUD_OIDC_CLIENT_ID?.trim() || NOTEBOOK_CLOUD_LOCAL_OIDC_CLIENT_ID,
     defaultTokenTtlSeconds: localOidcTtlSeconds(env),
-    users: [DEV_USER],
+    users: [...DEV_USERS],
   });
   issuersByUrl.set(issuerUrl, issuer);
   return issuer;

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -5934,6 +5934,10 @@ function oidcAuthConfigForRequest(request: Request, env: Env): Record<string, st
     clientId,
     redirectUri: env.NOTEBOOK_CLOUD_OIDC_REDIRECT_URI?.trim() || new URL("/oidc", request.url).href,
     ...(providerLabel ? { providerLabel } : {}),
+    // Server-derived: only the dev issuer mount sets this, and the viewer keys
+    // its login_hint forwarding on it. Deriving it here (not from the issuer
+    // string) keeps production sign-in unable to forward a URL login_hint.
+    ...(localOidcEnabled(env) ? { localOidc: "true" } : {}),
   };
 }
 

--- a/apps/notebook-cloud/test/dev-oidc.test.ts
+++ b/apps/notebook-cloud/test/dev-oidc.test.ts
@@ -252,3 +252,48 @@ describe("dev OIDC token delay", () => {
     }
   });
 });
+
+describe("dev OIDC multi-user selection", () => {
+  const env = gateEnv({ NOTEBOOK_CLOUD_LOCAL_OIDC: "true" });
+
+  async function signInEmail(loginHint?: string): Promise<string> {
+    const authorizeUrl = new URL(`${ISSUER_URL}/authorize`);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("client_id", CLIENT_ID);
+    authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    if (loginHint) {
+      authorizeUrl.searchParams.set("login_hint", loginHint);
+    }
+    const authorizeResponse = await handleLocalOidcRequest(new Request(authorizeUrl), env);
+    assert.ok(authorizeResponse, "authorize handled by the mount");
+    const code = new URL(authorizeResponse.headers.get("location") ?? "").searchParams.get("code");
+    assert.ok(code, "authorize returns a code");
+
+    const tokenResponse = await handleLocalOidcRequest(
+      new Request(`${ISSUER_URL}/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          client_id: CLIENT_ID,
+          redirect_uri: REDIRECT_URI,
+        }).toString(),
+      }),
+      env,
+    );
+    assert.ok(tokenResponse, "token handled by the mount");
+    const { id_token } = JSON.parse(await tokenResponse.text()) as { id_token: string };
+    const claims = JSON.parse(Buffer.from(id_token.split(".")[1] ?? "", "base64url").toString());
+    return claims.email as string;
+  }
+
+  it("defaults to the first dev user when no login_hint is sent", async () => {
+    assert.equal(await signInEmail(), "dev@localhost");
+  });
+
+  it("selects the additional dev users by login_hint", async () => {
+    assert.equal(await signInEmail("alice@localhost"), "alice@localhost");
+    assert.equal(await signInEmail("bob@localhost"), "bob@localhost");
+  });
+});

--- a/apps/notebook-cloud/test/oidc-auth.test.ts
+++ b/apps/notebook-cloud/test/oidc-auth.test.ts
@@ -76,6 +76,75 @@ describe("cloud OIDC browser auth", () => {
     assert.equal(url.searchParams.get("response_type"), "code");
     assert.equal(url.searchParams.get("state"), "state-123");
     assert.equal(url.searchParams.get("scope"), "openid email profile offline_access");
+    assert.equal(url.searchParams.get("login_hint"), null);
+  });
+
+  it("adds login_hint to the authorize URL only when one is provided", () => {
+    const requestState: CloudOidcRequestState = {
+      challenge: "challenge",
+      verifier: "verifier",
+      state: "state-123",
+      returnUrl: "https://preview.runt.run/n/demo",
+    };
+    const endpoints = {
+      authorizationEndpoint: "https://auth.stage.anaconda.com/api/auth/authorize",
+      tokenEndpoint: "https://auth.stage.anaconda.com/api/auth/token",
+    };
+    assert.equal(
+      buildOidcAuthorizationUrl(
+        authConfig,
+        endpoints,
+        requestState,
+        "bob@localhost",
+      ).searchParams.get("login_hint"),
+      "bob@localhost",
+    );
+    assert.equal(
+      buildOidcAuthorizationUrl(authConfig, endpoints, requestState).searchParams.get("login_hint"),
+      null,
+    );
+  });
+
+  it("forwards a URL login_hint to authorize only for the local dev issuer", async () => {
+    const discovery = (issuerOrigin: string): typeof fetch =>
+      (async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/.well-known/openid-configuration")) {
+          return new Response(
+            JSON.stringify({
+              authorization_endpoint: `${issuerOrigin}/authorize`,
+              token_endpoint: `${issuerOrigin}/token`,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }) as typeof fetch;
+
+    // Local dev issuer (mounted at /dev/oidc): the hint is forwarded so a
+    // non-default dev identity can be selected.
+    const devUrl = await beginOidcLogin(
+      {
+        issuer: "http://127.0.0.1:45626/dev/oidc",
+        clientId: "local-oidc-client",
+        redirectUri: "http://127.0.0.1:45626/oidc",
+        scope: "openid profile email",
+      },
+      {
+        currentUrl: "http://127.0.0.1:45626/n?login_hint=alice@localhost",
+        storage: new MemoryStorage(),
+        fetchImpl: discovery("http://127.0.0.1:45626/dev/oidc"),
+      },
+    );
+    assert.equal(devUrl.searchParams.get("login_hint"), "alice@localhost");
+
+    // Production issuer: the same URL param must NOT reach the real IdP.
+    const prodUrl = await beginOidcLogin(authConfig, {
+      currentUrl: "https://preview.runt.run/n?login_hint=alice@localhost",
+      storage: new MemoryStorage(),
+      fetchImpl: discovery("https://auth.stage.anaconda.com/api/auth"),
+    });
+    assert.equal(prodUrl.searchParams.get("login_hint"), null);
   });
 
   it("exchanges a valid callback for stored tokens and a same-origin return URL", async () => {

--- a/apps/notebook-cloud/test/oidc-auth.test.ts
+++ b/apps/notebook-cloud/test/oidc-auth.test.ts
@@ -121,7 +121,7 @@ describe("cloud OIDC browser auth", () => {
         throw new Error(`unexpected fetch ${url}`);
       }) as typeof fetch;
 
-    // Local dev issuer (mounted at /dev/oidc): the hint is forwarded so a
+    // Local dev issuer: the worker set localOidc, so the hint is forwarded and a
     // non-default dev identity can be selected.
     const devUrl = await beginOidcLogin(
       {
@@ -129,6 +129,7 @@ describe("cloud OIDC browser auth", () => {
         clientId: "local-oidc-client",
         redirectUri: "http://127.0.0.1:45626/oidc",
         scope: "openid profile email",
+        localOidc: true,
       },
       {
         currentUrl: "http://127.0.0.1:45626/n?login_hint=alice@localhost",
@@ -138,13 +139,46 @@ describe("cloud OIDC browser auth", () => {
     );
     assert.equal(devUrl.searchParams.get("login_hint"), "alice@localhost");
 
-    // Production issuer: the same URL param must NOT reach the real IdP.
+    // Production issuer (no localOidc marker): the URL param must NOT reach the
+    // real IdP.
     const prodUrl = await beginOidcLogin(authConfig, {
       currentUrl: "https://preview.runt.run/n?login_hint=alice@localhost",
       storage: new MemoryStorage(),
       fetchImpl: discovery("https://auth.stage.anaconda.com/api/auth"),
     });
     assert.equal(prodUrl.searchParams.get("login_hint"), null);
+
+    // A production issuer whose URL merely CONTAINS "/dev/oidc" as a path
+    // substring must still not forward: forwarding keys on the server-set
+    // localOidc flag, not on parsing the issuer string.
+    const lookalikeUrl = await beginOidcLogin(
+      {
+        issuer: "https://auth.anaconda.com/tenants/dev/oidc/api/auth",
+        clientId: "client-id",
+        redirectUri: "https://preview.runt.run/oidc",
+        scope: "openid profile email",
+      },
+      {
+        currentUrl: "https://preview.runt.run/n?login_hint=alice@localhost",
+        storage: new MemoryStorage(),
+        fetchImpl: discovery("https://auth.anaconda.com/tenants/dev/oidc/api/auth"),
+      },
+    );
+    assert.equal(lookalikeUrl.searchParams.get("login_hint"), null);
+  });
+
+  it("carries the server-set localOidc dev flag through normalization", () => {
+    const base = {
+      issuer: authConfig.issuer,
+      clientId: "client-id",
+      redirectUri: "https://x/oidc",
+    };
+    assert.equal(
+      normalizeOidcAuthConfig({ ...base, localOidc: "true" } as unknown as CloudOidcAuthConfig)
+        ?.localOidc,
+      true,
+    );
+    assert.equal(normalizeOidcAuthConfig(base)?.localOidc, undefined);
   });
 
   it("exchanges a valid callback for stored tokens and a same-origin return URL", async () => {

--- a/apps/notebook-cloud/viewer/oidc-auth.ts
+++ b/apps/notebook-cloud/viewer/oidc-auth.ts
@@ -285,7 +285,30 @@ export async function beginOidcLogin(
   const requestState = await createOidcRequestState(input.currentUrl);
   const endpoints = await discoverOidcEndpoints(config, input.fetchImpl, input);
   input.storage.setItem(NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY, JSON.stringify(requestState));
-  return buildOidcAuthorizationUrl(config, endpoints, requestState);
+  return buildOidcAuthorizationUrl(
+    config,
+    endpoints,
+    requestState,
+    devLoginHint(config, input.currentUrl),
+  );
+}
+
+// The dev issuer is mounted at `/dev/oidc` and can grant more than one identity.
+// Forward a `login_hint` query param to the authorize request so local
+// multi-user flows can select a non-default user - but only for that local
+// issuer, so production sign-in behavior is unchanged.
+const LOCAL_DEV_OIDC_ISSUER_MARKER = "/dev/oidc";
+
+function devLoginHint(config: CloudOidcAuthConfig, currentUrl: string): string | undefined {
+  if (!config.issuer.includes(LOCAL_DEV_OIDC_ISSUER_MARKER)) {
+    return undefined;
+  }
+  try {
+    const hint = new URL(currentUrl).searchParams.get("login_hint")?.trim();
+    return hint ? hint : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function completeOidcRedirect(
@@ -337,6 +360,7 @@ export function buildOidcAuthorizationUrl(
   config: CloudOidcAuthConfig,
   endpoints: CloudOidcEndpoints,
   requestState: CloudOidcRequestState,
+  loginHint?: string,
 ): URL {
   const url = new URL(endpoints.authorizationEndpoint);
   url.searchParams.set("client_id", config.clientId);
@@ -346,6 +370,9 @@ export function buildOidcAuthorizationUrl(
   url.searchParams.set("response_type", "code");
   url.searchParams.set("scope", config.scope ?? DEFAULT_OIDC_SCOPE);
   url.searchParams.set("state", requestState.state);
+  if (loginHint) {
+    url.searchParams.set("login_hint", loginHint);
+  }
   return url;
 }
 

--- a/apps/notebook-cloud/viewer/oidc-auth.ts
+++ b/apps/notebook-cloud/viewer/oidc-auth.ts
@@ -34,6 +34,11 @@ export interface CloudOidcAuthConfig {
   redirectUri: string;
   providerLabel?: string;
   scope?: string;
+  /**
+   * Set by the worker only under the NOTEBOOK_CLOUD_LOCAL_OIDC dev gate. Gates
+   * login_hint forwarding so production sign-in can never forward a URL hint.
+   */
+  localOidc?: boolean;
 }
 
 export interface CloudOidcRequestState {
@@ -90,11 +95,15 @@ export function normalizeOidcAuthConfig(
   if (!issuer || !clientId || !redirectUri) {
     return null;
   }
+  // The worker serializes this flag as a string; accept either shape.
+  const rawLocalOidc = (input as { localOidc?: unknown } | null | undefined)?.localOidc;
+  const localOidc = rawLocalOidc === true || rawLocalOidc === "true";
   return {
     issuer,
     clientId,
     redirectUri,
     ...(providerLabel ? { providerLabel } : {}),
+    ...(localOidc ? { localOidc: true } : {}),
     scope: input?.scope?.trim() || DEFAULT_OIDC_SCOPE,
   };
 }
@@ -293,14 +302,13 @@ export async function beginOidcLogin(
   );
 }
 
-// The dev issuer is mounted at `/dev/oidc` and can grant more than one identity.
-// Forward a `login_hint` query param to the authorize request so local
-// multi-user flows can select a non-default user - but only for that local
-// issuer, so production sign-in behavior is unchanged.
-const LOCAL_DEV_OIDC_ISSUER_MARKER = "/dev/oidc";
-
+// The local dev issuer can grant more than one identity. Forward a `login_hint`
+// query param to the authorize request so local multi-user flows can select a
+// non-default user - but only when the worker marked this as the dev issuer
+// (`localOidc`), never by inferring dev-ness from the issuer URL, so production
+// sign-in can never forward an attacker-supplied URL hint.
 function devLoginHint(config: CloudOidcAuthConfig, currentUrl: string): string | undefined {
-  if (!config.issuer.includes(LOCAL_DEV_OIDC_ISSUER_MARKER)) {
+  if (config.localOidc !== true) {
     return undefined;
   }
   try {


### PR DESCRIPTION
Unblocks local multi-user QA. Driving the cloud viewer against local wrangler, the entire multi-user matrix (cross-user sign-in, request/grant edit access, public/private visibility, presence) was unreachable: the dev OIDC issuer mounted a single `dev@localhost` identity and the viewer never sent a `login_hint`, so there was no way to reach a second user. The `feat/local-oidc-issuer` goal doc anticipated exactly this gap.

## Change

- `dev-oidc.ts` mounts three dev identities: `dev@localhost` (default), `alice@localhost`, `bob@localhost`. The issuer already supported a `users` list selected by `login_hint`; it was only ever handed one user.
- `beginOidcLogin` forwards a `login_hint` query param to the authorize request, sourced from the current URL, **only for the local dev issuer** (detected by its fixed `/dev/oidc` mount in the issuer URL). Sign in as a non-default user from `/n?login_hint=alice@localhost`.

## Dev-only by construction

The extra identities exist only behind the `NOTEBOOK_CLOUD_LOCAL_OIDC` gate, and the hint is forwarded only when the configured issuer is the local `/dev/oidc` mount. Production sign-in is provably unchanged: a test asserts the prod issuer drops a `login_hint` present in the URL. `login_hint` is a standard OIDC parameter regardless, so the shape is conventional even where it is sent.

## Tests

- Viewer: `beginOidcLogin` forwards the URL `login_hint` for the dev issuer and drops it for the prod issuer; `buildOidcAuthorizationUrl` sets the param only when given one.
- Mount: authorize + token through `handleLocalOidcRequest` selects `alice@localhost` and `bob@localhost` by `login_hint`, and defaults to `dev@localhost` with none. Issuer-level `selectUser` is already covered in `packages/local-oidc`.

Part of the cloud-viewer QA arc (`.context/goal-cloud-viewer-qa.md`); this is the enabler for the multi-user rows in `.context/cloud-qa-findings.md`.
