### PR TITLE
fix(notebook-cloud): don't show "Request sent" for an edit request that was never sent

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -435,7 +435,7 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   );
   assert.match(
     editModeButtonSourceText,
-    /<NotebookEditModeButton[\s\S]*state=\{accessPending \? "viewing" : interaction\.state\}/,
+    /<NotebookEditModeButton[\s\S]*state=\{\s*accessPending \|\| \(!hasSentEditRequest && interaction\.state === "requested"\)\s*\? "viewing"\s*: interaction\.state\s*\}/,
   );
   assert.match(editModeButtonSourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
   assert.match(authControlsSourceText, /authConfig\.localDev\?\.label\?\.trim\(\)/);
@@ -464,6 +464,10 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   );
   assert.match(editModeButtonSourceText, /onModeChange=\{\(mode\) => \{/);
   assert.match(sourceText, /accessLevel=\{shellCapabilities\.access\.level\}/);
+  assert.match(
+    sourceText,
+    /hasSentEditRequest=\{\s*accessRequestFacts\.requestedByUser \|\| Boolean\(cloudAccessFacts\.effectiveAccessRequest\)\s*\}/,
+  );
   assert.doesNotMatch(sourceText, /projectCloudNotebookEditAccess/);
   assert.doesNotMatch(sourceText, /cloudNotebookShellCapabilities/);
   assert.match(shellHookSourceText, /projectCloudNotebookEditAccess/);
@@ -487,7 +491,7 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /accessPending=\{editAccessPending\}/);
   assert.match(
     editModeButtonSourceText,
-    /state=\{accessPending \? "viewing" : interaction\.state\}/,
+    /state=\{\s*accessPending \|\| \(!hasSentEditRequest && interaction\.state === "requested"\)\s*\? "viewing"\s*: interaction\.state\s*\}/,
   );
   assert.match(editModeButtonSourceText, /disabled=\{accessPending\}/);
   assert.match(

--- a/apps/notebook-cloud/viewer/cloud-edit-mode-button.tsx
+++ b/apps/notebook-cloud/viewer/cloud-edit-mode-button.tsx
@@ -11,6 +11,7 @@ export function CloudNotebookEditModeButton({
   hasAppSession,
   accessLevel,
   accessPending,
+  hasSentEditRequest,
   interaction,
   reconnecting = false,
   onModeChange,
@@ -20,6 +21,7 @@ export function CloudNotebookEditModeButton({
   hasAppSession: boolean;
   accessLevel: NotebookShellCapabilities["access"]["level"];
   accessPending: boolean;
+  hasSentEditRequest: boolean;
   interaction: NotebookInteractionModeProjection | null;
   reconnecting?: boolean;
   onModeChange: (mode: NotebookInteractionMode) => void;
@@ -46,7 +48,11 @@ export function CloudNotebookEditModeButton({
         reconnecting ? "Offline while the room reconnects" : "Edit access requested"
       }
       mode={accessPending ? "view" : interaction.selectedMode}
-      state={accessPending ? "viewing" : interaction.state}
+      state={
+        accessPending || (!hasSentEditRequest && interaction.state === "requested")
+          ? "viewing"
+          : interaction.state
+      }
       variant="segmented"
       disabled={accessPending}
       onModeChange={(mode) => {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1650,6 +1650,9 @@ export function NotebookViewer({
           interaction={shellCapabilities.interaction ?? null}
           accessLevel={shellCapabilities.access.level}
           accessPending={editAccessPending}
+          hasSentEditRequest={
+            accessRequestFacts.requestedByUser || Boolean(cloudAccessFacts.effectiveAccessRequest)
+          }
           reconnecting={sustainedReconnecting}
           onModeChange={handleSelectInteractionMode}
           onRequestEditAccess={requestCloudEditAccess}


### PR DESCRIPTION
Surfaced while driving the cloud-viewer QA matrix: a signed-in user with no access to a private notebook who opens its room via a `?mode=edit` URL sees the edit-access button read **"Request sent"** even though no request was ever created (only `GET /access-requests` returning 403, zero POST). The label implies a pending request that does not exist.

The "Request sent" label was derived from `selectedMode === "edit"` plus no-write-authority alone, with no input for whether an edit request actually exists. `?mode=edit` seeds `selectedMode="edit"`; for a no-access notebook the catalog and live room both fail so the interaction mode stays `edit`, and `projectNotebookEditAccess` computes `state="requested"` from `wantsEdit && !canActivateEdit`. `CloudNotebookEditModeButton` then rendered the `requestedEditLabel`.

The fix plumbs the real "was a request actually sent" fact into the cloud button and clamps the display: `state="requested"` only passes through when `hasSentEditRequest` is true (the user requested this session, or a request record exists), otherwise it clamps to `"viewing"` so the segment shows the ordinary "Request edit" label. The clamp extends the existing `accessPending` guard in the same expression, so the two live side by side. The shared `projectNotebookEditAccess` projection is untouched: its generic `"requested"` state is shared with the desktop app, and the "was a request sent" fact only exists in the cloud viewer layer, so the correction belongs at the cloud host-adapter boundary.

Behavioral coverage:

| Case | Before | After |
|------|--------|-------|
| No-access stranger opens `?mode=edit` (no request) | "Request sent" | "Request edit" |
| Viewer clicks Request edit (`requestedByUser`) | "Request sent" | "Request sent" |
| Pending request record exists (`effectiveAccessRequest`) | "Request sent" | "Request sent" |

The source-text assertions that pin the button's `state={...}` expression and the new prop wiring are updated. `pnpm --dir apps/notebook-cloud run typecheck`, the `viewer-shared-cell-surface` suite (36 tests), and `cargo xtask lint` all pass. Verified in the browser against local wrangler: the repro case rendered "Request sent" pre-fix; the label derivation confirms `state="viewing"` yields "Request edit".

Cross-model: implemented by Codex against a code-traced spec, reviewed here (label derivation confirmed through the shared `NotebookEditModeButton`).
