### PR TITLE
fix(notebook-cloud): hide the edit-mode toggle when notebook body access is blocked

### DIFF
--- a/apps/notebook-cloud/test/notebook-view-loading.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-loading.test.ts
@@ -129,6 +129,7 @@ describe("cloud notebook header chrome projection", () => {
       }),
       {
         showConnectionIdentity: false,
+        showEditModeControl: false,
         showPresenceStatus: false,
       },
     );
@@ -142,6 +143,7 @@ describe("cloud notebook header chrome projection", () => {
       }),
       {
         showConnectionIdentity: false,
+        showEditModeControl: false,
         showPresenceStatus: false,
       },
     );
@@ -155,6 +157,7 @@ describe("cloud notebook header chrome projection", () => {
       }),
       {
         showConnectionIdentity: true,
+        showEditModeControl: true,
         showPresenceStatus: true,
       },
     );

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -221,6 +221,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     /buildCloudShareAccessRows\(\{ acl, invites, accessRequests \}\)/,
   );
   assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /editControls=\{[\s\S]*notebookHeaderChrome\.showEditModeControl \? \(/);
   assert.match(
     sourceText,
     /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*hasAppSession,[\s\S]*\}\) \? \(/,

--- a/apps/notebook-cloud/viewer/notebook-view-loading.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-loading.ts
@@ -25,6 +25,7 @@ export interface CloudNotebookHeaderChromeProjectionInput {
 
 export interface CloudNotebookHeaderChromeProjection {
   showConnectionIdentity: boolean;
+  showEditModeControl: boolean;
   showPresenceStatus: boolean;
 }
 
@@ -64,6 +65,7 @@ export function projectCloudNotebookHeaderChrome({
   const showCollaborationChrome = !bodyAccessBlocked && !liveRoomAccessPending;
   return {
     showConnectionIdentity: showCollaborationChrome,
+    showEditModeControl: showCollaborationChrome,
     showPresenceStatus: showCollaborationChrome,
   };
 }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1644,19 +1644,21 @@ export function NotebookViewer({
         />
       }
       editControls={
-        <CloudNotebookEditModeButton
-          authState={authState}
-          hasAppSession={hasAppSession}
-          interaction={shellCapabilities.interaction ?? null}
-          accessLevel={shellCapabilities.access.level}
-          accessPending={editAccessPending}
-          hasSentEditRequest={
-            accessRequestFacts.requestedByUser || Boolean(cloudAccessFacts.effectiveAccessRequest)
-          }
-          reconnecting={sustainedReconnecting}
-          onModeChange={handleSelectInteractionMode}
-          onRequestEditAccess={requestCloudEditAccess}
-        />
+        notebookHeaderChrome.showEditModeControl ? (
+          <CloudNotebookEditModeButton
+            authState={authState}
+            hasAppSession={hasAppSession}
+            interaction={shellCapabilities.interaction ?? null}
+            accessLevel={shellCapabilities.access.level}
+            accessPending={editAccessPending}
+            hasSentEditRequest={
+              accessRequestFacts.requestedByUser || Boolean(cloudAccessFacts.effectiveAccessRequest)
+            }
+            reconnecting={sustainedReconnecting}
+            onModeChange={handleSelectInteractionMode}
+            onRequestEditAccess={requestCloudEditAccess}
+          />
+        ) : null
       }
       identityControls={
         // Connection/identity slot: self-identity avatar + connectivity dot


### PR DESCRIPTION
Follow-up to #3952, closing out the same QA finding's second half: when a signed-in user has no access to a private notebook, the room blocks the body and shows the "Notebook access needed" notice - but the edit-mode toggle still rendered in the header, floating over a body that doesn't exist.

The header already answers this question for its sibling slots: `projectCloudNotebookHeaderChrome` hides presence status and connection identity when `bodyAccessBlocked || liveRoomAccessPending`. The edit toggle was the one chrome slot not routed through that projection. This adds `showEditModeControl` to the projection (same `showCollaborationChrome` value as its siblings) and gates the `editControls` slot on it with the same ternary pattern `utilityControls` and `identityControls` use. The access-needed notice is now the whole page.

Why the gate lives at the viewer render site and not inside the button: in the zero-access case `connectionScope` is null, so `accessLevel` falls back to the intentionally optimistic `"viewer"` and `canRequestEdit` is a pure auth-identity check - the button's inputs are structurally identical to a legitimate viewer's. The only reliable zero-access signal is the confirmed connection diagnostic (`cloudConnectionDiagnosticBlocksNotebookBody`), which already lives in the viewer layer. The shared `notebookRoomAccessLevelFromConnectionScope` fallback is untouched; it serves the not-yet-resolved case for desktop too.

A real viewer is unaffected: once connected with viewer scope, `connectionError` is null, the projection stays true, and the button renders "Request edit" as before. The gate also covers the sign-in-required diagnostic, which hides the body the same way.

Typecheck, the three touched test suites (57 tests), and lint pass. Cross-model: implemented by Codex against a code-traced spec, reviewed here.
