### PR TITLE
fix(notebook-cloud): correct misleading unhappy-path copy (404 vs 403, never-signed-in, hero drift)

### DIFF
--- a/apps/notebook-cloud/test/connection-diagnostics.test.ts
+++ b/apps/notebook-cloud/test/connection-diagnostics.test.ts
@@ -5,6 +5,7 @@ import {
   CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+  CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   cloudConnectionDiagnosticBlocksNotebookBody,
   cloudConnectionErrorWithAccessDiagnostic,
@@ -41,7 +42,17 @@ describe("cloud connection diagnostics", () => {
       },
     });
 
-    assert.match(diagnostic ?? "", /does not have access/);
+    assert.equal(diagnostic, CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC);
+  });
+
+  it("reports missing notebooks separately from account access problems", async () => {
+    const diagnostic = await diagnoseCloudConnectionAccess({
+      accessRequestsEndpoint: "/api/n/missing/access-requests",
+      authState: authState("dev"),
+      fetchImpl: async () => Response.json({ error: "not found" }, { status: 404 }),
+    });
+
+    assert.equal(diagnostic, CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC);
   });
 
   it("probes access with same-origin cookies for app-session browsers", async () => {
@@ -58,7 +69,7 @@ describe("cloud connection diagnostics", () => {
       },
     });
 
-    assert.match(diagnostic ?? "", /does not have access/);
+    assert.equal(diagnostic, CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC);
   });
 
   it("keeps successful authenticated access silent", async () => {
@@ -158,6 +169,7 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
 
   it("identifies access diagnostics that should survive reconnect noise", () => {
     assert.equal(isCloudConnectionAccessDiagnostic(CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC), true);
+    assert.equal(isCloudConnectionAccessDiagnostic(CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC), true);
     assert.equal(isCloudConnectionAccessDiagnostic(CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC), true);
     assert.equal(isCloudConnectionAccessDiagnostic("cloud sync socket failed"), false);
     assert.equal(isCloudConnectionAccessDiagnostic(null), false);
@@ -166,6 +178,10 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
   it("identifies diagnostics that should block notebook body rendering", () => {
     assert.equal(
       cloudConnectionDiagnosticBlocksNotebookBody(CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC),
+      true,
+    );
+    assert.equal(
+      cloudConnectionDiagnosticBlocksNotebookBody(CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC),
       true,
     );
     assert.equal(

--- a/apps/notebook-cloud/test/notebook-view-loading.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-loading.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+  CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
 } from "../viewer/connection-diagnostics.ts";
 import {
   projectCloudNotebookHeaderChrome,
@@ -78,24 +79,29 @@ describe("cloud notebook body loading projection", () => {
   });
 
   it("does not render the notebook view when content access is blocked", () => {
-    assert.deepEqual(
-      projectCloudNotebookViewSurface({
-        bodyAccessBlocked: true,
-        cellCount: 0,
-        canEditStructure: false,
-        connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
-        editAccessPending: false,
-        emptyRoomGraceElapsed: true,
-        hasAccessDiagnostic: true,
-        hasReadableSnapshot: false,
-        liveMaterialized: false,
-        status: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
-      }),
-      {
-        isLoading: false,
-        shouldRenderNotebookView: false,
-      },
-    );
+    for (const connectionError of [
+      CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+      CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
+    ]) {
+      assert.deepEqual(
+        projectCloudNotebookViewSurface({
+          bodyAccessBlocked: true,
+          cellCount: 0,
+          canEditStructure: false,
+          connectionError,
+          editAccessPending: false,
+          emptyRoomGraceElapsed: true,
+          hasAccessDiagnostic: true,
+          hasReadableSnapshot: false,
+          liveMaterialized: false,
+          status: { kind: "error", message: connectionError },
+        }),
+        {
+          isLoading: false,
+          shouldRenderNotebookView: false,
+        },
+      );
+    }
   });
 
   it("keeps non-blocking access diagnostics on the normal notebook surface", () => {

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -4,8 +4,10 @@ import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import {
+  CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+  CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   cloudConnectionErrorAcceptsAccessDiagnostic,
 } from "../viewer/connection-diagnostics";
@@ -186,8 +188,29 @@ test("cloud notebook notices distinguish sign-in and access diagnostics from soc
   );
 
   assert.match(noAccessHtml, /Notebook access needed/);
-  assert.match(noAccessHtml, /does not have access to this notebook yet/);
+  assert.match(
+    noAccessHtml,
+    /This account does not have access to this notebook\. Ask the owner to share it, or refresh sign-in if an invite was just accepted\./,
+  );
+  assert.doesNotMatch(noAccessHtml, /does not have access to this notebook yet/);
   assert.doesNotMatch(noAccessHtml, /Live room unavailable/);
+
+  const notFoundHtml = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onRetryConnection: () => {},
+    }),
+  );
+
+  assert.match(notFoundHtml, /Notebook not found/);
+  assert.match(notFoundHtml, /This notebook doesn&#x27;t exist, or the link may be wrong/);
+  assert.doesNotMatch(notFoundHtml, /Retry/);
+  assert.doesNotMatch(notFoundHtml, /Ask the owner to share it/);
+  assert.doesNotMatch(notFoundHtml, /Live room unavailable/);
 });
 
 test("cloud notebook notices replace signed-out local room retries with sign-in required", () => {
@@ -215,11 +238,27 @@ test("cloud notebook notices replace signed-out local room retries with sign-in 
   );
 
   assert.match(html, /Sign in required/);
-  assert.match(html, /Sign in again to open the live notebook room/);
-  assert.match(html, /Sign in again/);
+  assert.match(html, /Sign in to open the live notebook room\./);
+  assert.match(html, /Sign in/);
+  assert.doesNotMatch(html, /Sign in again/);
   assert.doesNotMatch(html, /Loading notebook/);
   assert.doesNotMatch(html, /Connecting to live notebook room/);
   assert.doesNotMatch(html, /cloud sync socket failed/);
+});
+
+test("cloud notebook notices render approved edit access as success", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /data-tone="success"/);
+  assert.match(html, /Edit access approved/);
 });
 
 test("cloud notebook notices let access diagnostics own private-route loading", () => {

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -81,8 +81,13 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
   assert.match(homeSource, /aria-label="Notebook sign-in"/);
   assert.match(homeSource, /className="cloud-home-copy"/);
   assert.match(homeSource, /className="cloud-home-kicker"/);
-  assert.match(homeSource, /NTERACT/);
-  assert.match(homeSource, /<h1>Bring computation to life\.<\/h1>/);
+  assert.match(homeSource, /const localMode = Boolean\(localDevAuth\)/);
+  assert.match(homeSource, /localMode \? "LOCAL MODE" : "NTERACT"/);
+  assert.match(homeSource, /localMode \? "Open local notebooks\." : "Bring computation to life\."/);
+  assert.match(
+    homeSource,
+    /Use local auth to create notebooks and test the live room on this machine\./,
+  );
   assert.match(
     homeSource,
     /Sign in to create live notebooks, share work with colleagues, and attach compute\./,
@@ -240,6 +245,9 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     sourceText,
     /const requestCloudEditAccess = useCallback\(\(\) => \{[\s\S]*accessRequest\.requestEditAccess\(\);/,
   );
+  assert.match(sourceText, /projection\.kind === "dismissed"/);
+  assert.match(sourceText, /icon=\{<Info className="h-4 w-4" \/>\}/);
+  assert.doesNotMatch(sourceText, /projection\.kind === "dismissed"[\s\S]{0,240}AlertCircle/);
   // The connection/identity slot is filled by the shared quiet component:
   // avatar + connectivity dot, driven by the stable status bridge. It must
   // never regress into a text pill or a second status label surface. The
@@ -459,7 +467,12 @@ test("cloud viewer presents live-room failures as one host notice", () => {
   assert.match(noticesText, /function cloudConnectionNoticeDisplay/);
   assert.match(noticesText, /hasReadableSnapshot: boolean/);
   assert.match(noticesText, /Sign in required\./);
+  assert.match(noticesText, /Sign in to open the live notebook room\./);
   assert.match(noticesText, /Notebook access needed\./);
+  assert.match(noticesText, /message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC/);
+  assert.match(noticesText, /Notebook not found\./);
+  assert.match(noticesText, /CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC/);
+  assert.match(noticesText, /tone: "success"/);
   assert.match(noticesText, /Live room unavailable\./);
   assert.match(noticesText, /The notebook will load once the account or connection is refreshed\./);
   assert.match(noticesText, /tone=\{connectionNotice\.tone\}/);

--- a/apps/notebook-cloud/viewer/connection-diagnostics.ts
+++ b/apps/notebook-cloud/viewer/connection-diagnostics.ts
@@ -5,6 +5,8 @@ import type { CloudNotebookAccessRequest } from "./sharing-client";
 export const CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC = "Sign in again to open this notebook.";
 export const CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC =
   "This account does not have access to this notebook. Ask the owner to share it, or refresh sign-in if an invite was just accepted.";
+export const CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC =
+  "This notebook doesn't exist, or the link may be wrong.";
 export const CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC =
   "Edit access is waiting for owner approval.";
 export const CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC =
@@ -13,6 +15,7 @@ export const CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC =
 const ACCESS_DIAGNOSTICS = new Set<string>([
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+  CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
 ]);
@@ -24,7 +27,8 @@ export function isCloudConnectionAccessDiagnostic(message: string | null): boole
 export function cloudConnectionDiagnosticBlocksNotebookBody(message: string | null): boolean {
   return (
     message === CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC ||
-    message === CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC
+    message === CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC ||
+    message === CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC
   );
 }
 
@@ -96,8 +100,11 @@ export async function diagnoseCloudConnectionAccess({
     if (response.status === 401) {
       return CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC;
     }
-    if (response.status === 403 || response.status === 404) {
+    if (response.status === 403) {
       return CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC;
+    }
+    if (response.status === 404) {
+      return CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC;
     }
   } catch {
     return null;

--- a/apps/notebook-cloud/viewer/home-view.tsx
+++ b/apps/notebook-cloud/viewer/home-view.tsx
@@ -27,6 +27,7 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [formError, setFormError] = useState<string | null>(null);
   const localDevAuth = authConfig.localDev;
+  const localMode = Boolean(localDevAuth);
   const signInConfigured = Boolean(localDevAuth || authConfig.oidc);
 
   useEffect(() => {
@@ -96,10 +97,14 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
         <div className="cloud-home-copy">
           <div className="cloud-home-kicker">
             <Sparkles aria-hidden="true" />
-            NTERACT
+            {localMode ? "LOCAL MODE" : "NTERACT"}
           </div>
-          <h1>Bring computation to life.</h1>
-          <p>Sign in to create live notebooks, share work with colleagues, and attach compute.</p>
+          <h1>{localMode ? "Open local notebooks." : "Bring computation to life."}</h1>
+          <p>
+            {localMode
+              ? "Use local auth to create notebooks and test the live room on this machine."
+              : "Sign in to create live notebooks, share work with colleagues, and attach compute."}
+          </p>
         </div>
 
         <section

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { AlertCircle, Check, Loader2, PanelLeftOpen, X } from "lucide-react";
+import { AlertCircle, Check, Info, Loader2, PanelLeftOpen, X } from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import {
   useHasIsolatedOutputs,
@@ -1947,6 +1947,18 @@ function cloudAccessRequestNotice(
       <NotebookNotice
         tone={projection.tone}
         icon={<X className="h-4 w-4" />}
+        title={projection.title}
+      >
+        {projection.message}
+      </NotebookNotice>
+    );
+  }
+
+  if (projection.kind === "dismissed") {
+    return (
+      <NotebookNotice
+        tone={projection.tone}
+        icon={<Info className="h-4 w-4" />}
         title={projection.title}
       >
         {projection.message}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -10,6 +10,7 @@ import {
   CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+  CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   isCloudConnectionAccessDiagnostic,
 } from "./connection-diagnostics";
@@ -267,11 +268,11 @@ export function CloudNotebookNotices({
           title="Sign in required."
           actions={
             onSignInAgain ? (
-              <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in again</SignInNoticeAction>
+              <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in</SignInNoticeAction>
             ) : null
           }
         >
-          Sign in again to open the live notebook room.
+          Sign in to open the live notebook room.
         </NotebookNotice>
       ) : null}
 
@@ -469,6 +470,10 @@ function ConnectionNoticeAction({
     return <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in again</SignInNoticeAction>;
   }
 
+  if (connectionError === CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC) {
+    return null;
+  }
+
   if (onRetryConnection) {
     return (
       <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw className="h-3 w-3" />}>
@@ -532,7 +537,7 @@ function cloudConnectionNoticeDisplay(
 ): {
   title: string;
   message: string;
-  tone: "warning";
+  tone: "warning" | "success";
 } | null {
   if (isTransportReconnectError(error)) {
     // The transport retries forever on its own; the debounced sustained-
@@ -552,8 +557,15 @@ function cloudConnectionNoticeDisplay(
   if (error === CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC) {
     return {
       title: "Notebook access needed.",
-      message:
-        "This account does not have access to this notebook yet. Ask the owner to share it, or refresh sign-in if an invite was just accepted.",
+      message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+      tone: "warning",
+    };
+  }
+
+  if (error === CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC) {
+    return {
+      title: "Notebook not found.",
+      message: CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC,
       tone: "warning",
     };
   }
@@ -570,7 +582,7 @@ function cloudConnectionNoticeDisplay(
     return {
       title: "Edit access approved.",
       message: "Refresh or reconnect to open the live notebook room with editor access.",
-      tone: "warning",
+      tone: "success",
     };
   }
 


### PR DESCRIPTION
Copy-correctness pass over the unhappy-path states catalogued in this week's cloud-viewer QA sweep. Five fixes, no layout changes.

**404 vs 403 in the room's access diagnostic.** A nonexistent notebook and a permission denial both produced "Ask the owner to share it" - actively wrong when there is no notebook to share. `diagnoseCloudConnectionAccess` now maps 404 to a new `CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC` ("This notebook doesn't exist, or the link may be wrong."), which blocks the body like the other access diagnostics and renders with no Retry action (retrying a nonexistent notebook is meaningless). Known remaining gap, deferred to the access-gate design slice: the probe still doesn't run for anonymous visitors, and anonymous 404 deliberately means "not found or private."

**Rendered copy and diagnostic constant no longer drift.** The no-access notice hand-copied the diagnostic string (and had already drifted by one word); it now renders the constant.

**"Sign in again" implied a session that never existed.** The sign-in-required room notice fires for never-signed-in visitors; message and action now read "Sign in." The renewal-failure copy keeps "again" - there a session did exist.

**Home's signed-out hero now matches the List's local-dev branching.** Local builds get "LOCAL MODE / Open local notebooks." on both landings instead of only on `/n`.

**Edit-request notice nits.** Dismissed requests use an Info icon instead of AlertCircle (it's an info-tone notice, not an error), and the "Edit access approved" room-block notice renders success-toned instead of warning.

Typecheck, the full notebook-cloud suite (1360 tests, including a new 404-diagnostic case and a not-found render test), and lint pass. Cross-model: implemented by Codex against the QA inventory spec, reviewed here.
