### PR TITLE
feat(design): mint severity tokens, codify design law, add chroma ratchet

### DIFF
--- a/apps/notebook/src/components/__tests__/component-chroma-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/component-chroma-boundary.test.ts
@@ -1,0 +1,130 @@
+// Convention 3: chroma carries meaning. This ratchets raw Tailwind palette
+// classes in src/components/** per the fix train in
+// .context/elements-audit-2026-07-07.md.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const componentsDir = join(process.cwd(), "src/components");
+
+const RAW_TAILWIND_PALETTE_CLASS =
+  /(?:^|[\s"'`:[])(?:bg|text|border|ring|fill|stroke|from|via|to|decoration|outline|shadow)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d{2,3}\b/;
+
+// SANCTIONED: raw palette that is permanently allowed by an external contract.
+const SANCTIONED_RAW_PALETTE_FILES = ["src/components/outputs/ansi-output.tsx"];
+
+// RATCHET: current raw-palette debt. Remove entries as slices 3-4 tokenize them.
+const RATCHET_RAW_PALETTE_FILES = [
+  "src/components/cell/CellInsertionRibbon.tsx",
+  "src/components/cell/CodeCellCurrentLine.tsx",
+  "src/components/cell/CompactExecutionButton.tsx",
+  "src/components/cell/gutter-colors.ts",
+  "src/components/environment/CondaDependencyPanel.tsx",
+  "src/components/environment/DenoDependencyPanel.tsx",
+  "src/components/environment/PackageSpecList.tsx",
+  "src/components/environment/PixiDependencyPanel.tsx",
+  "src/components/environment/UvDependencyPanel.tsx",
+  "src/components/isolated/IsolationTest.tsx",
+  "src/components/markdown/markdown-typography.ts",
+  "src/components/notebook/DebugBanner.tsx",
+  "src/components/notebook/EnvBuildDecisionDialog.tsx",
+  "src/components/notebook/KernelLaunchErrorBanner.tsx",
+  "src/components/notebook/NotebookCommandToolbar.tsx",
+  "src/components/notebook/NotebookConnectionIdentity.tsx",
+  "src/components/notebook/NotebookEditModeButton.tsx",
+  "src/components/notebook/NotebookIdentity.tsx",
+  "src/components/notebook/NotebookNotice.tsx",
+  "src/components/notebook/NotebookWorkstationsPanel.tsx",
+  "src/components/notebook/PoolErrorBanner.tsx",
+  "src/components/notebook/TrustDialog.tsx",
+  "src/components/outputs/json-output.tsx",
+  "src/components/outputs/media-router.tsx",
+  "src/components/outputs/traceback-output.tsx",
+  "src/components/widgets/controls/box-widget.tsx",
+  "src/components/widgets/controls/button-style-utils.ts",
+  "src/components/widgets/controls/controller-widget.tsx",
+  "src/components/widgets/controls/float-progress.tsx",
+  "src/components/widgets/controls/gridbox-widget.tsx",
+  "src/components/widgets/controls/hbox-widget.tsx",
+  "src/components/widgets/controls/int-progress.tsx",
+  "src/components/widgets/controls/valid-widget.tsx",
+  "src/components/widgets/controls/vbox-widget.tsx",
+  "src/components/workstations/WorkstationsManagementPage.tsx",
+];
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const fullPath = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return entry.name === "__tests__" ? [] : sourceFiles(fullPath);
+      }
+
+      if (!/\.(ts|tsx)$/.test(entry.name)) return [];
+      if (/\.test\./.test(entry.name)) return [];
+
+      return [fullPath];
+    })
+    .sort();
+}
+
+function rawPaletteMatches(): Map<string, string[]> {
+  const matches = new Map<string, string[]>();
+
+  for (const filePath of sourceFiles(componentsDir)) {
+    const relativePath = filePath.slice(`${process.cwd()}/`.length);
+    const lines = readFileSync(filePath, "utf8").split("\n");
+
+    lines.forEach((line, index) => {
+      if (RAW_TAILWIND_PALETTE_CLASS.test(line)) {
+        const fileMatches = matches.get(relativePath) ?? [];
+        fileMatches.push(`${index + 1}: ${line.trim()}`);
+        matches.set(relativePath, fileMatches);
+      }
+    });
+  }
+
+  return matches;
+}
+
+function duplicateEntries(entries: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+
+  entries.forEach((entry) => {
+    if (seen.has(entry)) duplicates.add(entry);
+    seen.add(entry);
+  });
+
+  return [...duplicates].sort();
+}
+
+describe("component chroma boundary", () => {
+  it("keeps raw Tailwind palette classes inside sanctioned files and ratchet debt", () => {
+    const matchesByFile = rawPaletteMatches();
+    const matchedFiles = [...matchesByFile.keys()].sort();
+    const ratchetFiles = new Set(RATCHET_RAW_PALETTE_FILES);
+    const allowedFiles = new Set([...SANCTIONED_RAW_PALETTE_FILES, ...RATCHET_RAW_PALETTE_FILES]);
+
+    expect(
+      duplicateEntries([...SANCTIONED_RAW_PALETTE_FILES, ...RATCHET_RAW_PALETTE_FILES]),
+    ).toEqual([]);
+    expect(SANCTIONED_RAW_PALETTE_FILES.filter((filePath) => ratchetFiles.has(filePath))).toEqual(
+      [],
+    );
+
+    expect(
+      matchedFiles.flatMap((filePath) => {
+        if (allowedFiles.has(filePath)) return [];
+        return (matchesByFile.get(filePath) ?? []).map((line) => `${filePath}:${line}`);
+      }),
+    ).toEqual([]);
+
+    expect(RATCHET_RAW_PALETTE_FILES.filter((filePath) => !matchesByFile.has(filePath))).toEqual(
+      [],
+    );
+    expect([...allowedFiles].filter((filePath) => !matchesByFile.has(filePath)).sort()).toEqual([]);
+  });
+});

--- a/src/components/ui/AGENTS.md
+++ b/src/components/ui/AGENTS.md
@@ -65,3 +65,28 @@ return import(/* @vite-ignore */ esm);
 **Build errors after shadcn update:** Run `tsc -b` to catch TypeScript errors. Common: missing imports, path mismatches, type mismatches from prop changes.
 
 Use `pnpm` as the package manager for shadcn operations.
+
+## Design law (ratified 2026-07-07)
+
+1. Radius: controls and menus use `rounded-md`; dialogs use `rounded-lg`; full circles are only for dots, avatars, and thumbs. Banners are not pills, and `rounded-xl`/`rounded-2xl` do not belong in shared UI.
+2. Focus: use `focus-visible:ring-1 ring-ring` with no offset everywhere.
+3. Chroma carries meaning: component chroma comes from `--ct-*`, `--k-*`, `--live`, `--live-ink`, `--destructive`, `--sev-*`, and uv identity. Raw Tailwind palette color classes in component code are lint failures.
+4. Left rules mark code lines, never notices. The traceback failing-line rule is the sanctioned left-border pattern; banner/card left accents are not.
+5. Banners: use a 1px full border tinted from a meaning token, a background tint of 8% or less, small radius, and severity in the icon. Do not use full-color panels.
+6. Loading: use skeleton shimmer where content will appear; use a spinner only where a skeleton has no room.
+
+Sanctioned exceptions:
+
+1. Traceback may use a left rule for the failing code line.
+2. Cell insertion ribbons may use directional gradients.
+3. Presence green and comment author colors may carry identity.
+4. Cell toolbar `backdrop-blur-sm` is the only blur.
+
+Severity aliases:
+
+| Alias | Target |
+| --- | --- |
+| `--sev-info` | `var(--k-start)` |
+| `--sev-warn` | `var(--k-exec)` |
+| `--sev-ok` | `var(--live-ink)` |
+| `--sev-error` | `var(--destructive)` |

--- a/src/styles/dashboard-atoms.css
+++ b/src/styles/dashboard-atoms.css
@@ -19,6 +19,12 @@
   --k-start: #3b82f6;
   --k-stale: #9ca3af;
   --k-error: var(--destructive, #dc2626);
+  /* Severity aliases runtime meaning tokens so banners/notices have named inputs
+     and never reach for raw palette. */
+  --sev-info: var(--k-start);
+  --sev-warn: var(--k-exec);
+  --sev-ok: var(--live-ink);
+  --sev-error: var(--destructive);
 }
 
 .dark,


### PR DESCRIPTION
Slice 1 of the Elements audit fix train (working notes: `.context/elements-audit-2026-07-07.md`; source: the Claude Design audit board).

- `--sev-info/warn/ok/error` alias the runtime meaning tokens in `dashboard-atoms.css`, giving banners and notices named severity inputs. Aliases follow the dark-mode redefinitions of their targets.
- The six ratified design conventions land in `src/components/ui/AGENTS.md` as enumerated law (radius, focus ring, chroma-carries-meaning, left-rule scope, banner recipe, skeleton-over-spinner) plus the four sanctioned exceptions.
- A chroma ratchet test (`component-chroma-boundary.test.ts`, in the style-boundary pattern) makes convention 3 enforceable: raw Tailwind palette classes in `src/components/**` fail CI unless the file is sanctioned (ANSI terminal contract) or on the shrinking ratchet list. The scan surfaced 34 files of palette debt - wider than the audit board sampled (notebook chrome, environment panels, widget controls) - each pinned so a fix must remove its entry and a new violation fails immediately.

Cross-model: Codex implemented, reviewed here. All three verify commands green.
