### PR TITLE
fix(cloud): stop labeling an attached-but-kernel-less runtime as running, surface launch errors

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -30,7 +30,9 @@ import {
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
   NotebookWorkstationsPanel,
+  KernelLaunchErrorBanner,
   projectNotebookCommandRuntimeStatusFromRuntimeState,
+  shouldShowKernelLaunchErrorBanner,
   shouldShowNotebookDocumentCommandToolbar,
   useActiveOutlineItemId,
   useOutlineSelection,
@@ -309,6 +311,7 @@ export function NotebookViewer({
   const [commentFocus, setCommentFocus] = useState<{ threadId: string; nonce: number } | null>(
     null,
   );
+  const [dismissedLaunchError, setDismissedLaunchError] = useState<string | null>(null);
   const handledHeadingHashRef = useRef<string | null>(null);
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
   const browserApiAuthState = useBrowserApiAuthState();
@@ -555,6 +558,17 @@ export function NotebookViewer({
     [profilesSnapshot, user],
   );
   const runtimeState = useRuntimeState();
+  const cloudKernelLifecycle = runtimeState.kernel.lifecycle;
+  const cloudKernelErrorDetails =
+    runtimeState.kernel.error_details && runtimeState.kernel.error_details.length > 0
+      ? runtimeState.kernel.error_details
+      : null;
+  const cloudKernelErrorReason = runtimeState.kernel.error_reason;
+  useEffect(() => {
+    if (cloudKernelLifecycle.lifecycle !== "Error") {
+      setDismissedLaunchError(null);
+    }
+  }, [cloudKernelLifecycle.lifecycle]);
   // Deduplicated shared projection — re-renders only when attachment facts
   // change, not on every runtime tick (was per-host shadow state).
   const workstationAttachment = useWorkstationAttachment();
@@ -1742,11 +1756,40 @@ export function NotebookViewer({
   const rendererAssetError = hasIsolatedOutputs
     ? (isolatedRenderer.error ?? isolatedRenderer.lastError)
     : null;
+  const cloudKernelRuntime =
+    runtimeState.kernel.language === "deno" || notebookLanguageRef.current === "deno"
+      ? "deno"
+      : "python";
+  const shouldRenderKernelLaunchError =
+    shouldShowKernelLaunchErrorBanner({
+      lifecycle: cloudKernelLifecycle,
+      errorDetails: cloudKernelErrorDetails,
+      errorReason: cloudKernelErrorReason,
+      runtime: cloudKernelRuntime,
+    }) && dismissedLaunchError !== cloudKernelErrorDetails;
+  const kernelLaunchNotice =
+    shouldRenderKernelLaunchError && cloudKernelErrorDetails ? (
+      <KernelLaunchErrorBanner
+        errorDetails={cloudKernelErrorDetails}
+        onRetry={() => {
+          setDismissedLaunchError(null);
+          handleCloudRestartRuntime();
+        }}
+        onDismiss={() => setDismissedLaunchError(cloudKernelErrorDetails)}
+      />
+    ) : null;
+  const diagnostics =
+    kernelLaunchNotice || accessRequestNotice ? (
+      <>
+        {kernelLaunchNotice}
+        {accessRequestNotice}
+      </>
+    ) : null;
   const hasNotices = cloudNotebookHasNotices({
     authState,
     authRenewal,
     connectionError,
-    diagnostics: accessRequestNotice,
+    diagnostics,
     hasAppSession,
     isPublicViewer,
     hasReadableSnapshot: notebookHasReadableSnapshot,
@@ -1762,7 +1805,7 @@ export function NotebookViewer({
       authState={authState}
       authRenewal={authRenewal}
       connectionError={connectionError}
-      diagnostics={accessRequestNotice}
+      diagnostics={diagnostics}
       hasAppSession={hasAppSession}
       isPublicViewer={isPublicViewer}
       hasReadableSnapshot={notebookHasReadableSnapshot}

--- a/packages/runtimed/src/notebook-command-runtime.ts
+++ b/packages/runtimed/src/notebook-command-runtime.ts
@@ -99,7 +99,7 @@ export const RUNTIME_STATUS_LABELS: Record<RuntimeStatusKey, string> = {
   [RUNTIME_STATUS.CONNECTING]: "connecting to kernel",
   [RUNTIME_STATUS.RUNNING_IDLE]: "idle",
   [RUNTIME_STATUS.RUNNING_BUSY]: "busy",
-  [RUNTIME_STATUS.RUNNING_UNKNOWN]: "running",
+  [RUNTIME_STATUS.RUNNING_UNKNOWN]: "available",
   [RUNTIME_STATUS.ERROR]: "error",
   [RUNTIME_STATUS.SHUTDOWN]: "shutdown",
 };

--- a/packages/runtimed/tests/notebook-command-runtime.test.ts
+++ b/packages/runtimed/tests/notebook-command-runtime.test.ts
@@ -38,7 +38,9 @@ describe("notebook command runtime projection", () => {
 
   it("projects lifecycle labels through the same status-key table", () => {
     expect(getLifecycleLabel({ lifecycle: "Launching" }, null)).toBe("launching kernel");
-    expect(getLifecycleLabel({ lifecycle: "Running", activity: "Unknown" }, null)).toBe("running");
+    expect(getLifecycleLabel({ lifecycle: "Running", activity: "Unknown" }, null)).toBe(
+      "available",
+    );
   });
 
   it("maps expanded status keys to toolbar states", () => {
@@ -103,7 +105,7 @@ describe("notebook command runtime projection", () => {
     });
   });
 
-  it("treats scaffolded not-started state as running when host execution is already available", () => {
+  it("keeps scaffolded not-started state honest when host execution is available", () => {
     const projection = projectNotebookCommandRuntimeStatusFromRuntimeState(
       {
         kernel: {
@@ -115,10 +117,11 @@ describe("notebook command runtime projection", () => {
     );
 
     expect(projection).toMatchObject({
-      label: "running",
+      label: "available",
       state: "idle",
       statusKey: RUNTIME_STATUS.RUNNING_UNKNOWN,
     });
+    expect(projection.label).not.toBe("running");
   });
 
   it("projects stable runtime command affordances from capabilities and host actions", () => {


### PR DESCRIPTION
A workstation that attaches but whose kernel dies at launch presented in the cloud viewer as "Kernel running" with cells stuck queued (#3947). Two independent gaps produced that lie, and this fixes both.

## The optimistic label

`projectNotebookCommandRuntimeStatusFromRuntimeState` promotes `NotStarted + executionAvailable` to `RUNNING_UNKNOWN`, and that key's label read "running". Cloud sets `executionAvailable` from runtime-peer presence, so a peer that attached successfully but never brought up a live kernel satisfied the promotion — present peer, absent authoritative `Running` state, labeled "running". An attached peer with no authoritative running kernel is *available*, not running, so `RUNNING_UNKNOWN` now labels "available".

The change is in shared `packages/runtimed`, so it reaches desktop too. Blast radius is contained: the primary toolbar marker (`RuntimeStatusDot`) carries its own label map and collapses `RUNNING_UNKNOWN` to "Kernel ready", untouched here. The changed word only surfaces in the command-runtime projection's `label`/`title`/`ariaLabel`. For a genuinely-running kernel in the transient `activity: Unknown` window, "available" is still accurate.

## No error surfacing in cloud

Desktop renders `KernelLaunchErrorBanner` for `RuntimeLifecycle::Error`; the cloud viewer had no equivalent, so even when the Error state arrived the user saw at most a status dot with no explanation. This wires the same banner into the cloud viewer through the shared gate `shouldShowKernelLaunchErrorBanner` (which defers the targeted remediation cases — missing ipykernel, Deno auto-install, conda env) so it only catches the generic launch failures that have no better home. Retry restarts the runtime; dismiss is keyed to the specific `error_details` string, and a `lifecycle`-leaves-`Error` effect clears the dismissal so the same failure after a successful run re-shows. This mirrors the desktop gating at `App.tsx` exactly.

Closes #3947.
