### PR TITLE
feat(ui): add generic Skeleton primitive with ratified shimmer

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -15,6 +15,7 @@ import {
   Palette,
   PanelLeft,
   PanelTop,
+  Rows3,
   Search,
   Server,
   ShieldCheck,
@@ -72,6 +73,12 @@ const catalogGroups = [
         description: "Empty, blocked, notice, and rail status states for cloud viewer paths.",
         href: "/docs/unhappy-states",
         icon: TriangleAlert,
+      },
+      {
+        title: "Skeleton",
+        description: "Theme-aware shimmer placeholders for known loading shapes.",
+        href: "/docs/skeleton",
+        icon: Rows3,
       },
       {
         title: "Compute placement",

--- a/apps/elements/components/skeleton-example.tsx
+++ b/apps/elements/components/skeleton-example.tsx
@@ -1,0 +1,98 @@
+import { CircleDashed, FileCode2, Rows3 } from "lucide-react";
+import type { ReactNode } from "react";
+import { CellSkeleton } from "@/components/cell/CellSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const textLines = ["w-full", "w-11/12", "w-3/4", "w-5/6"] as const;
+
+export function SkeletonExample() {
+  return (
+    <div className="not-prose space-y-6" data-testid="skeleton-example">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
+        <div className="flex items-start gap-3">
+          <CircleDashed className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Skeleton primitive</h2>
+            <p className="mt-1 text-xs leading-5">
+              Deterministic loading geometry for surfaces that already know the shape of the content
+              they are waiting on.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <SkeletonFixture title="Single bar">
+          <Skeleton className="h-3 w-72 max-w-full" />
+        </SkeletonFixture>
+
+        <SkeletonFixture title="Text-line stack">
+          <div className="space-y-2">
+            {textLines.map((width, index) => (
+              <Skeleton
+                key={width}
+                className={cnForLine(width)}
+                style={{ animationDelay: `${index * 75}ms` }}
+              />
+            ))}
+          </div>
+        </SkeletonFixture>
+
+        <SkeletonFixture title="Avatar row">
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-10 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-3 w-40 max-w-full" />
+              <Skeleton className="h-3 w-56 max-w-full" style={{ animationDelay: "75ms" }} />
+            </div>
+          </div>
+        </SkeletonFixture>
+
+        <SkeletonFixture title="Card block">
+          <div className="space-y-3">
+            <Skeleton className="h-28 w-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-5/6" style={{ animationDelay: "75ms" }} />
+              <Skeleton className="h-3 w-2/3" style={{ animationDelay: "150ms" }} />
+            </div>
+          </div>
+        </SkeletonFixture>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <Rows3 className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold">CellSkeleton composition</h2>
+              <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                src/components/cell/CellSkeleton.tsx
+              </div>
+            </div>
+          </div>
+          <FileCode2 className="size-4 shrink-0 text-fd-muted-foreground" aria-hidden="true" />
+        </div>
+        <div className="bg-background p-4">
+          <div className="rounded-lg border border-fd-border bg-fd-background">
+            <CellSkeleton />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SkeletonFixture({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-fd-border bg-fd-card">
+      <div className="border-b border-fd-border px-4 py-3">
+        <h3 className="text-sm font-semibold">{title}</h3>
+      </div>
+      <div className="bg-background p-4">{children}</div>
+    </section>
+  );
+}
+
+function cnForLine(width: (typeof textLines)[number]) {
+  return `h-3 ${width}`;
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -44,6 +44,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Full shell composition](/docs/full-shell-composition)
 - [Cloud dashboard](/docs/cloud-dashboard)
 - [Unhappy states](/docs/unhappy-states)
+- [Skeleton](/docs/skeleton)
 - [Compute placement](/docs/compute-placement)
 - [Workstation management](/docs/workstation-management)
 - [Context controls](/docs/context-controls)

--- a/apps/elements/content/docs/skeleton.mdx
+++ b/apps/elements/content/docs/skeleton.mdx
@@ -1,0 +1,22 @@
+---
+title: Skeleton
+description: Theme-aware loading placeholders with the ratified shimmer motion.
+---
+
+import { SkeletonExample } from "@/components/skeleton-example";
+
+Skeleton is the generic loading primitive for known content shapes. It uses the
+ratified shimmer convention: a moving gradient sweep, not a pulse. The gradient
+is theme-aware through `color-mix()` against notebook tokens, so the same
+primitive works in light and dark themes without separate palette classes.
+
+Use Skeleton when the pending content shape is known: text lines, avatars,
+cards, table rows, and notebook cells. Use a spinner only where the shape is not
+known or where the surface has no room for a skeleton, such as a compact inline
+status banner.
+
+This primitive is the shared convergence target for the cloud startup shimmer
+and Sift loading shimmer. Those local shimmers remain in place until their
+surfaces migrate to the shared primitive.
+
+<SkeletonExample />

--- a/src/components/cell/CellSkeleton.tsx
+++ b/src/components/cell/CellSkeleton.tsx
@@ -1,4 +1,5 @@
 import { cellContentColumnInset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 const skeletonCells = [
@@ -13,10 +14,7 @@ function SkeletonCell({ height, delay }: { height: string; delay: string }) {
       <div className="w-1 self-stretch rounded-sm bg-muted/40" />
 
       <div className={cn("min-w-0 flex-1 py-3 pr-3", cellContentColumnInset)}>
-        <div
-          className="rounded bg-muted/30 animate-pulse"
-          style={{ minHeight: height, animationDelay: delay }}
-        />
+        <Skeleton style={{ minHeight: height, animationDelay: delay }} />
       </div>
     </div>
   );

--- a/src/components/cell/__tests__/CellSkeleton.test.tsx
+++ b/src/components/cell/__tests__/CellSkeleton.test.tsx
@@ -6,8 +6,12 @@ describe("CellSkeleton", () => {
   it("renders loading placeholders using the shared cell layout", () => {
     const { container } = render(<CellSkeleton />);
 
-    const placeholders = container.querySelectorAll(".animate-pulse");
+    const placeholders = container.querySelectorAll('[data-slot="skeleton"]');
     expect(placeholders).toHaveLength(3);
+    for (const placeholder of placeholders) {
+      expect(placeholder).toHaveClass("nb-skeleton", "animate-skeleton-shimmer");
+      expect(placeholder).not.toHaveClass("animate-pulse");
+    }
     expect(placeholders[0]).toHaveStyle({ minHeight: "2.5rem", animationDelay: "0ms" });
     expect(placeholders[1]).toHaveStyle({ minHeight: "5rem", animationDelay: "75ms" });
     expect(placeholders[2]).toHaveStyle({ minHeight: "2rem", animationDelay: "150ms" });

--- a/src/components/ui/AGENTS.md
+++ b/src/components/ui/AGENTS.md
@@ -79,8 +79,9 @@ Sanctioned exceptions:
 
 1. Traceback may use a left rule for the failing code line.
 2. Cell insertion ribbons may use directional gradients.
-3. Presence green and comment author colors may carry identity.
-4. Cell toolbar `backdrop-blur-sm` is the only blur.
+3. Skeleton loading uses a horizontal shimmer gradient over a muted, chroma-free tint (`Skeleton` / `.nb-skeleton`); this is the mechanism convention 6 asks for.
+4. Presence green and comment author colors may carry identity.
+5. Cell toolbar `backdrop-blur-sm` is the only blur.
 
 Severity aliases:
 

--- a/src/components/ui/__tests__/skeleton.test.tsx
+++ b/src/components/ui/__tests__/skeleton.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Skeleton } from "../skeleton";
+
+describe("Skeleton", () => {
+  it("renders the ratified shimmer skeleton without pulse animation", () => {
+    const { container } = render(<Skeleton />);
+
+    const skeleton = container.querySelector<HTMLElement>('[data-slot="skeleton"]');
+    expect(skeleton).not.toBeNull();
+    expect(skeleton).toHaveAttribute("aria-hidden", "true");
+    expect(skeleton).toHaveClass("nb-skeleton", "animate-skeleton-shimmer", "rounded-md");
+    expect(skeleton).not.toHaveClass("animate-pulse");
+  });
+
+  it("passes through className and style", () => {
+    const { container } = render(
+      <Skeleton className="h-4 w-32" style={{ animationDelay: "120ms", minHeight: "1rem" }} />,
+    );
+
+    const skeleton = container.querySelector<HTMLElement>('[data-slot="skeleton"]');
+    expect(skeleton).not.toBeNull();
+    expect(skeleton).toHaveClass("h-4", "w-32");
+    expect(skeleton).toHaveStyle({ animationDelay: "120ms", minHeight: "1rem" });
+  });
+});

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,20 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Ratified loading skeleton: shimmer, not pulse, theme-aware via color-mix,
+ * and the shared convergence target for the cloud and Sift shimmers.
+ */
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="skeleton"
+      aria-hidden="true"
+      className={cn("nb-skeleton animate-skeleton-shimmer rounded-md", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/index.css
+++ b/src/index.css
@@ -45,8 +45,18 @@
   --color-ansi-magenta-bg: var(--ansi-magenta-bg);
   --color-ansi-cyan-bg: var(--ansi-cyan-bg);
   --color-ansi-white-bg: var(--ansi-white-bg);
+  --animate-skeleton-shimmer: skeleton-shimmer 1.5s ease-in-out infinite;
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+
+  @keyframes skeleton-shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
 
   @keyframes accordion-down {
     from {
@@ -64,5 +74,17 @@
     to {
       height: 0;
     }
+  }
+}
+
+@layer components {
+  .nb-skeleton {
+    background: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--muted-foreground) 13%, transparent) 25%,
+      color-mix(in srgb, var(--muted-foreground) 22%, transparent) 50%,
+      color-mix(in srgb, var(--muted-foreground) 13%, transparent) 75%
+    );
+    background-size: 200% 100%;
   }
 }


### PR DESCRIPTION
Adds a generic `Skeleton` to `src/components/ui`. The design audit's convention 6 ratified shimmer over pulse for loading states, but the only skeletons in the tree were one-offs: `CellSkeleton` on Tailwind's `animate-pulse`, plus separate shimmer keyframes hand-rolled in the cloud viewer and Sift. This gives them one primitive to share.

The shimmer is a moving gradient sweep, theme-aware through `color-mix()` against `--muted-foreground` so a single definition works in light and dark with no palette classes (the chroma ratchet forbids raw palette anyway). The animation registers as `--animate-skeleton-shimmer` in the `@theme` block next to the accordion keyframes; the gradient lives in a `.nb-skeleton` component layer. The primitive is `aria-hidden` — a loading announcement belongs on the region that owns the pending content, not on decorative geometry.

Gradient opacity is tuned for legibility on light surfaces: at the stock 8/14% the bars vanished against the warm `#f5f2ec` page background, so the base/peak sit at 13/22% — clearly readable on cards and bare backgrounds alike, still calm.

`CellSkeleton` now composes `Skeleton` (closing the audit's separate pulse→shimmer item). The cloud and Sift shimmers stay put until their surfaces migrate to the shared primitive. Ships with an Elements catalog page.

Follows #3961 (design law + tokens) and #3963 (mechanics) in the Elements audit fix train.
