### PR TITLE
feat(ui): add Separator and Spinner primitives

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -8,6 +8,8 @@ import {
   Frame,
   IdCard,
   LayoutDashboard,
+  Loader2,
+  Minus,
   ListPlus,
   MessageSquareText,
   MousePointer2,
@@ -79,6 +81,18 @@ const catalogGroups = [
         description: "Theme-aware shimmer placeholders for known loading shapes.",
         href: "/docs/skeleton",
         icon: Rows3,
+      },
+      {
+        title: "Separator",
+        description: "Token-native horizontal and vertical rules.",
+        href: "/docs/separator",
+        icon: Minus,
+      },
+      {
+        title: "Spinner",
+        description: "Colorless compact loading motion.",
+        href: "/docs/spinner",
+        icon: Loader2,
       },
       {
         title: "Compute placement",

--- a/apps/elements/components/separator-example.tsx
+++ b/apps/elements/components/separator-example.tsx
@@ -1,0 +1,70 @@
+import { FileText, GitBranch, Rows3 } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+
+const notebookSections = [
+  { label: "Input", value: "8 cells" },
+  { label: "Output", value: "12 frames" },
+  { label: "Comments", value: "3 open" },
+] as const;
+
+export function SeparatorExample() {
+  return (
+    <div className="not-prose space-y-6" data-testid="separator-example">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
+        <div className="flex items-start gap-3">
+          <Rows3 className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Separator primitive</h2>
+            <p className="mt-1 text-xs leading-5">
+              Token-native rules for dividing nearby notebook content without inventing local border
+              colors.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card">
+        <div className="flex items-start gap-3 p-4">
+          <FileText
+            className="mt-0.5 size-4 flex-none text-fd-muted-foreground"
+            aria-hidden="true"
+          />
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold">Notebook summary</h3>
+            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+              Horizontal separators split stacked regions while staying on the shared border token.
+            </p>
+          </div>
+        </div>
+        <Separator />
+        <div className="grid gap-4 p-4 sm:grid-cols-3">
+          {notebookSections.map((section) => (
+            <div key={section.label}>
+              <div className="text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+                {section.label}
+              </div>
+              <div className="mt-1 text-sm font-semibold">{section.value}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card p-4">
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <span className="inline-flex items-center gap-2 font-medium">
+            <GitBranch className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            main
+          </span>
+          <div className="h-5">
+            <Separator orientation="vertical" />
+          </div>
+          <span className="text-fd-muted-foreground">runtime attached</span>
+          <div className="h-5">
+            <Separator orientation="vertical" />
+          </div>
+          <span className="text-fd-muted-foreground">autosaved just now</span>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/components/spinner-example.tsx
+++ b/apps/elements/components/spinner-example.tsx
@@ -1,0 +1,54 @@
+import { CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+const sizes = [
+  { label: "Small", size: "sm" },
+  { label: "Default", size: "default" },
+  { label: "Large", size: "lg" },
+] as const;
+
+export function SpinnerExample() {
+  return (
+    <div className="not-prose space-y-6" data-testid="spinner-example">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
+        <div className="flex items-start gap-3">
+          <CheckCircle2 className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Spinner primitive</h2>
+            <p className="mt-1 text-xs leading-5">
+              Colorless currentColor motion for compact status slots where a skeleton has no room.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        {sizes.map((item) => (
+          <div key={item.size} className="rounded-lg border border-fd-border bg-fd-card p-4">
+            <div className="flex h-16 items-center justify-center text-fd-foreground">
+              <Spinner size={item.size} label={`${item.label} loading`} />
+            </div>
+            <div className="border-t border-fd-border pt-3">
+              <h3 className="text-sm font-semibold">{item.label}</h3>
+              <p className="mt-1 text-xs text-fd-muted-foreground">size={item.size}</p>
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card p-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button disabled>
+            <Spinner size="default" label="Saving notebook" />
+            Saving
+          </Button>
+          <p className="text-xs leading-5 text-fd-muted-foreground">
+            Use this pattern for inline action progress. Use Skeleton when the pending content shape
+            is known.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -45,6 +45,8 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Cloud dashboard](/docs/cloud-dashboard)
 - [Unhappy states](/docs/unhappy-states)
 - [Skeleton](/docs/skeleton)
+- [Separator](/docs/separator)
+- [Spinner](/docs/spinner)
 - [Compute placement](/docs/compute-placement)
 - [Workstation management](/docs/workstation-management)
 - [Context controls](/docs/context-controls)

--- a/apps/elements/content/docs/separator.mdx
+++ b/apps/elements/content/docs/separator.mdx
@@ -1,0 +1,16 @@
+---
+title: Separator
+description: Token-native horizontal and vertical rules for nearby notebook content.
+---
+
+import { SeparatorExample } from "@/components/separator-example";
+
+Separator is the shared divider primitive for local content grouping. It wraps
+Radix Separator, defaults to decorative horizontal rules, and uses the shared
+`border` token through `bg-border` instead of local palette colors.
+
+Use horizontal separators to divide stacked sections and vertical separators to
+split compact inline metadata. Migrations from existing hand-rolled dividers
+should happen in follow-up convergence sweeps.
+
+<SeparatorExample />

--- a/apps/elements/content/docs/spinner.mdx
+++ b/apps/elements/content/docs/spinner.mdx
@@ -1,0 +1,16 @@
+---
+title: Spinner
+description: Colorless currentColor loading motion for compact status slots.
+---
+
+import { SpinnerExample } from "@/components/spinner-example";
+
+Spinner is the tight-space fallback for loading state. It inherits the current
+text color, exposes a small/default/large size variant, and carries an
+accessible status label.
+
+Prefer Skeleton wherever the pending content shape is known. Spinner is for
+inline buttons, narrow status slots, and other places where a skeleton has no
+room.
+
+<SpinnerExample />

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.11",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slider':
         specifier: ^1.3.6
         version: 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3935,6 +3938,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context-menu@2.2.16':
     resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
     peerDependencies:
@@ -4240,6 +4252,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: 19.2.7
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.7':
     resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
     peerDependencies:
@@ -4318,6 +4343,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.11':
+    resolution: {integrity: sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: 19.2.7
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.7':
     resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
     peerDependencies:
@@ -4355,6 +4393,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
       '@types/react': '*'
       react: 19.2.7
@@ -13986,6 +14033,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -14322,6 +14375,15 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
@@ -14423,6 +14485,15 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-separator@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -14461,6 +14532,13 @@ snapshots:
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17

--- a/src/components/ui/__tests__/separator.test.tsx
+++ b/src/components/ui/__tests__/separator.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Separator } from "../separator";
+
+const RAW_PALETTE_CLASS =
+  /^(?:bg|text|border|ring|fill|stroke|from|via|to|decoration|outline|shadow)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d{2,3}\b/;
+
+function rawPaletteClasses(element: HTMLElement): string[] {
+  return [...element.classList].filter((className) => RAW_PALETTE_CLASS.test(className));
+}
+
+describe("Separator", () => {
+  it("renders an accessible separator with orientation data", () => {
+    const { getByRole } = render(<Separator decorative={false} orientation="vertical" />);
+
+    const separator = getByRole("separator");
+    expect(separator).toHaveAttribute("data-slot", "separator");
+    expect(separator).toHaveAttribute("data-orientation", "vertical");
+    expect(separator).toHaveClass("h-full", "w-px");
+  });
+
+  it("uses the border token without raw palette classes", () => {
+    const { container } = render(<Separator />);
+
+    const separator = container.querySelector<HTMLElement>('[data-slot="separator"]');
+    expect(separator).not.toBeNull();
+    expect(separator).toHaveClass("bg-border", "h-px", "w-full");
+    expect(rawPaletteClasses(separator!)).toEqual([]);
+  });
+
+  it("passes through className", () => {
+    const { container } = render(<Separator className="my-4 opacity-50" />);
+
+    const separator = container.querySelector<HTMLElement>('[data-slot="separator"]');
+    expect(separator).not.toBeNull();
+    expect(separator).toHaveClass("my-4", "opacity-50");
+  });
+});

--- a/src/components/ui/__tests__/spinner.test.tsx
+++ b/src/components/ui/__tests__/spinner.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Spinner } from "../spinner";
+
+const CONTEXTUAL_COLOR_CLASS =
+  /^(?:bg|border|ring|fill|stroke|from|via|to|decoration|outline|shadow)-/;
+
+function colorClasses(element: HTMLElement): string[] {
+  return [...element.classList].filter(
+    (className) =>
+      CONTEXTUAL_COLOR_CLASS.test(className) ||
+      (className.startsWith("text-") && className !== "text-current"),
+  );
+}
+
+describe("Spinner", () => {
+  it("renders a labelled status with the default size", () => {
+    const { getByRole, getByText } = render(<Spinner />);
+
+    const spinner = getByRole("status", { name: "Loading" });
+    expect(spinner).toHaveAttribute("data-slot", "spinner");
+    expect(spinner).toHaveClass("animate-spin", "size-4", "text-current");
+    expect(getByText("Loading")).toHaveClass("sr-only");
+  });
+
+  it("applies size variants", () => {
+    const { getByRole, rerender } = render(<Spinner size="sm" />);
+
+    expect(getByRole("status")).toHaveClass("size-3");
+
+    rerender(<Spinner size="lg" />);
+
+    expect(getByRole("status")).toHaveClass("size-6");
+  });
+
+  it("keeps color inherited from the current context", () => {
+    const { getByRole } = render(<Spinner />);
+
+    const spinner = getByRole("status");
+    expect(colorClasses(spinner)).toEqual([]);
+  });
+
+  it("allows the accessible label to be overridden", () => {
+    const { getByRole, getByText } = render(<Spinner label="Connecting runtime" />);
+
+    expect(getByRole("status", { name: "Connecting runtime" })).toBeTruthy();
+    expect(getByText("Connecting runtime")).toHaveClass("sr-only");
+  });
+});

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    data-slot="separator"
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border",
+      orientation === "vertical" ? "h-full w-px" : "h-px w-full",
+      className,
+    )}
+    {...props}
+  />
+));
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,49 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const spinnerVariants = cva(
+  "inline-flex shrink-0 animate-spin items-center justify-center text-current",
+  {
+    variants: {
+      size: {
+        sm: "size-3",
+        default: "size-4",
+        lg: "size-6",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+export interface SpinnerProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof spinnerVariants> {
+  label?: string;
+}
+
+/**
+ * Tight-space loading fallback. Prefer Skeleton where the pending content shape
+ * is known, per loading convention 6.
+ */
+const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
+  ({ className, size, label = "Loading", ...props }, ref) => (
+    <span
+      ref={ref}
+      data-slot="spinner"
+      role="status"
+      aria-label={label}
+      className={cn(spinnerVariants({ size }), className)}
+      {...props}
+    >
+      <Loader2 className="size-full" aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+    </span>
+  ),
+);
+Spinner.displayName = "Spinner";
+
+export { Spinner, spinnerVariants };


### PR DESCRIPTION
Two canonical shadcn primitives the design audit flagged as missing (slice 5). Both have real in-app demand, but this PR only adds the primitives and their Elements pages; migrating the existing hand-rolled sites is a follow-up sweep so this stays reviewable and touches no rendered surface.

**Separator** is the canonical Radix separator, token-native on `--border` (`bg-border`), horizontal or vertical. It replaces the pattern behind ~16 hand-rolled `border-t border-border` dividers and `<hr>` elements scattered across the app.

**Spinner** wraps `Loader2` with a `cva` size variant (`sm`/`default`/`lg`) and is colorless by design (`text-current`), so it inherits context color and passes the chroma ratchet trivially. It carries a labeled `role="status"` with an `sr-only` label and an `aria-hidden` icon. The doc comment states its place: this is the tight-space fallback; `Skeleton` shimmer is the default where the pending content shape is known (loading convention 6). There are ~12 ad-hoc `Loader2 animate-spin` spinners today (environment panels, notebook chrome, workstations) for the follow-up sweep to converge.

Adds `@radix-ui/react-separator` (`^1.1.11`, matching the sibling Radix pins). Both ship Elements catalog pages. Follows #3964 (Skeleton) in the slice-5 primitive track.
