### PR TITLE
feat(settings): add font picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +2481,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -4736,6 +4768,7 @@ dependencies = [
  "cocoa",
  "dirs",
  "flate2",
+ "fontdb",
  "log",
  "nbformat",
  "nix 0.31.2",
@@ -7317,6 +7350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8510,6 +8549,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -10146,6 +10194,15 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "termcolor",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
 ]
 
 [[package]]

--- a/apps/elements/components/fixture-notebook-host.ts
+++ b/apps/elements/components/fixture-notebook-host.ts
@@ -1,5 +1,5 @@
 import { EMPTY } from "rxjs";
-import type { NotebookHost } from "@nteract/notebook-host";
+import { DEFAULT_FONT_FAMILIES, type NotebookHost } from "@nteract/notebook-host";
 
 export const noop = () => {};
 export const asyncNoop = async () => {};
@@ -79,7 +79,7 @@ export function createFixtureNotebookHost({
     system: {
       getGitInfo: async () => null,
       getUsername: async () => "kyle",
-      getFontFamilies: async () => ["Arial", "Georgia", "Menlo", "SF Mono", "Times New Roman"],
+      getFontFamilies: async () => [...DEFAULT_FONT_FAMILIES],
     },
     dialog: {
       openFile: async () => null,

--- a/apps/elements/components/fixture-notebook-host.ts
+++ b/apps/elements/components/fixture-notebook-host.ts
@@ -9,11 +9,13 @@ const unlisten = () => {};
 
 interface FixtureNotebookHostOptions {
   name?: string;
+  fontFamilies?: string[];
   transport?: Partial<NotebookHost["transport"]>;
 }
 
 export function createFixtureNotebookHost({
   name = "elements-fixture",
+  fontFamilies = [...DEFAULT_FONT_FAMILIES],
   transport: transportOverrides = {},
 }: FixtureNotebookHostOptions = {}): NotebookHost {
   const transport: NotebookHost["transport"] = {
@@ -79,7 +81,7 @@ export function createFixtureNotebookHost({
     system: {
       getGitInfo: async () => null,
       getUsername: async () => "kyle",
-      getFontFamilies: async () => [...DEFAULT_FONT_FAMILIES],
+      getFontFamilies: async () => [...fontFamilies],
     },
     dialog: {
       openFile: async () => null,

--- a/apps/elements/components/fixture-notebook-host.ts
+++ b/apps/elements/components/fixture-notebook-host.ts
@@ -79,6 +79,7 @@ export function createFixtureNotebookHost({
     system: {
       getGitInfo: async () => null,
       getUsername: async () => "kyle",
+      getFontFamilies: async () => ["Arial", "Georgia", "Menlo", "SF Mono", "Times New Roman"],
     },
     dialog: {
       openFile: async () => null,

--- a/apps/notebook-cloud/viewer/cloud-notebook-host.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-host.ts
@@ -1,4 +1,9 @@
-import { createCommandRegistry, type NotebookHost, type Unlisten } from "@nteract/notebook-host";
+import {
+  DEFAULT_FONT_FAMILIES,
+  createCommandRegistry,
+  type NotebookHost,
+  type Unlisten,
+} from "@nteract/notebook-host";
 import { EMPTY, type Observable } from "rxjs";
 import type {
   BlobResolver,
@@ -225,7 +230,7 @@ export function createCloudNotebookHost({
     system: {
       getGitInfo: async () => null,
       getUsername: async () => "notebook-cloud",
-      getFontFamilies: async () => ["Arial", "Georgia", "Menlo", "SF Mono", "Times New Roman"],
+      getFontFamilies: async () => [...DEFAULT_FONT_FAMILIES],
     },
     dialog: {
       openFile: async () => null,

--- a/apps/notebook-cloud/viewer/cloud-notebook-host.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-host.ts
@@ -225,6 +225,7 @@ export function createCloudNotebookHost({
     system: {
       getGitInfo: async () => null,
       getUsername: async () => "notebook-cloud",
+      getFontFamilies: async () => ["Arial", "Georgia", "Menlo", "SF Mono", "Times New Roman"],
     },
     dialog: {
       openFile: async () => null,

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -1,7 +1,25 @@
-import { AlertCircle, ChevronDown, Monitor, Moon, Sun, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronsUpDown,
+  Monitor,
+  Moon,
+  Sun,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNotebookHost } from "@nteract/notebook-host";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Input } from "@/components/ui/input";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { useNotebookEditorSettings } from "@/components/editor/editor-settings-store";
@@ -37,35 +55,165 @@ function formatDuration(secs: number): string {
   return `${secs}s`;
 }
 
-function FontFamilyInput({
+const FONT_FAMILY_FALLBACKS = [
+  "Arial",
+  "Courier New",
+  "Georgia",
+  "Helvetica",
+  "Inter",
+  "Menlo",
+  "Monaco",
+  "SF Mono",
+  "Times New Roman",
+  "Trebuchet MS",
+  "Verdana",
+];
+
+const GENERIC_FONT_FAMILIES = new Set([
+  "cursive",
+  "emoji",
+  "fantasy",
+  "fangsong",
+  "math",
+  "monospace",
+  "sans-serif",
+  "serif",
+  "system-ui",
+  "ui-monospace",
+  "ui-rounded",
+  "ui-sans-serif",
+  "ui-serif",
+]);
+
+function uniqueSortedFontFamilies(fontFamilies: readonly string[]): string[] {
+  const byKey = new Map<string, string>();
+  for (const fontFamily of fontFamilies) {
+    const trimmed = fontFamily.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLocaleLowerCase();
+    if (!byKey.has(key)) byKey.set(key, trimmed);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: "base" }),
+  );
+}
+
+function stripCssFamilyQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const quote = trimmed[0];
+  if ((quote !== '"' && quote !== "'") || trimmed[trimmed.length - 1] !== quote) return trimmed;
+  return trimmed
+    .slice(1, -1)
+    .replace(/\\(["'\\])/g, "$1")
+    .trim();
+}
+
+function singleFontFamilyFromCssValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes(",")) return null;
+  return stripCssFamilyQuotes(trimmed);
+}
+
+export function fontFamilyNameToCssValue(fontFamily: string): string {
+  const trimmed = fontFamily.trim();
+  if (!trimmed) return "";
+  if (GENERIC_FONT_FAMILIES.has(trimmed.toLocaleLowerCase())) return trimmed;
+  if (/^-?[_a-zA-Z][_a-zA-Z0-9-]*$/.test(trimmed)) return trimmed;
+  return `"${trimmed.replace(/["\\]/g, "\\$&")}"`;
+}
+
+function useAvailableFontFamilies() {
+  const host = useNotebookHost();
+  const [fontFamilies, setFontFamilies] = useState(() =>
+    uniqueSortedFontFamilies(FONT_FAMILY_FALLBACKS),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    host.system
+      .getFontFamilies()
+      .then((families) => {
+        if (cancelled) return;
+        setFontFamilies(uniqueSortedFontFamilies([...FONT_FAMILY_FALLBACKS, ...families]));
+      })
+      .catch((error) => {
+        host.log.warn(
+          `[settings] Failed to load system font families: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [host]);
+
+  return fontFamilies;
+}
+
+export function FontFamilyPicker({
   label,
   value,
   onChange,
   placeholder,
   description,
+  fontFamilies,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
   placeholder: string;
   description: string;
+  fontFamilies: readonly string[];
 }) {
-  const [draft, setDraft] = useState(value);
+  const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
   const inputId = `editor-${label.toLowerCase().replace(/\s+/g, "-")}`;
+  const listId = `${inputId}-list`;
 
-  useEffect(() => {
-    setDraft(value);
-  }, [value]);
+  const options = useMemo(() => {
+    const currentSingleFamily = singleFontFamilyFromCssValue(value);
+    return uniqueSortedFontFamilies([
+      ...fontFamilies,
+      ...(currentSingleFamily ? [currentSingleFamily] : []),
+    ]);
+  }, [fontFamilies, value]);
 
-  const commit = useCallback(() => {
-    const next = draft.trim();
-    if (next !== value) onChange(next);
-  }, [draft, onChange, value]);
+  const normalizedSearchValue = searchValue.trim().toLocaleLowerCase();
+  const visibleOptions = useMemo(() => {
+    if (!normalizedSearchValue) return options.slice(0, 200);
+    return options
+      .filter((fontFamily) => fontFamily.toLocaleLowerCase().includes(normalizedSearchValue))
+      .slice(0, 200);
+  }, [normalizedSearchValue, options]);
+
+  const currentSingleFamily = singleFontFamilyFromCssValue(value);
+  const exactSearchMatch = options.some(
+    (fontFamily) => fontFamily.toLocaleLowerCase() === normalizedSearchValue,
+  );
+  const customCandidate = searchValue.trim();
+  const showCustomCandidate = customCandidate.length > 0 && !exactSearchMatch;
 
   const clear = useCallback(() => {
-    setDraft("");
     if (value !== "") onChange("");
   }, [onChange, value]);
+
+  const selectValue = useCallback(
+    (next: string) => {
+      onChange(next);
+      setSearchValue("");
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  const selectFontFamily = useCallback(
+    (fontFamily: string) => {
+      selectValue(fontFamilyNameToCssValue(fontFamily));
+    },
+    [selectValue],
+  );
 
   return (
     <div className="space-y-1.5">
@@ -73,29 +221,109 @@ function FontFamilyInput({
         <label className="text-sm text-muted-foreground" htmlFor={inputId}>
           {label}
         </label>
-        <div className="relative min-w-0 flex-1">
-          <Input
-            id={inputId}
-            value={draft}
-            placeholder={placeholder}
-            autoComplete="off"
-            spellCheck={false}
-            onChange={(event) => setDraft(event.target.value)}
-            onBlur={commit}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.currentTarget.blur();
-              }
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <Popover
+            open={open}
+            onOpenChange={(nextOpen) => {
+              setOpen(nextOpen);
+              if (nextOpen) setSearchValue("");
             }}
-            className="h-8 pr-8 font-mono text-xs"
-          />
-          {draft ? (
+          >
+            <PopoverTrigger asChild>
+              <button
+                id={inputId}
+                type="button"
+                role="combobox"
+                aria-controls={listId}
+                aria-expanded={open}
+                className={cn(
+                  "flex h-8 min-w-0 flex-1 items-center justify-between rounded-md border border-input bg-background px-3 py-1 text-left text-xs shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                  value ? "text-foreground" : "text-muted-foreground",
+                )}
+              >
+                <span className="min-w-0 truncate font-mono">{value || placeholder}</span>
+                <ChevronsUpDown className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent id={listId} align="end" className="w-[min(29rem,calc(100vw-2rem))] p-0">
+              <Command shouldFilter={false}>
+                <CommandInput
+                  value={searchValue}
+                  onValueChange={setSearchValue}
+                  placeholder="Search fonts or enter a CSS stack"
+                />
+                <CommandList className="max-h-72">
+                  <CommandGroup heading="Fonts">
+                    <CommandItem value="__default__" onSelect={() => selectValue("")}>
+                      <Check
+                        className={cn("size-3.5", value === "" ? "opacity-100" : "opacity-0")}
+                      />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm">Theme default</div>
+                        <div className="truncate font-mono text-[10px] text-muted-foreground">
+                          {placeholder}
+                        </div>
+                      </div>
+                    </CommandItem>
+                    {visibleOptions.map((fontFamily) => {
+                      const selected = currentSingleFamily === fontFamily;
+                      const cssValue = fontFamilyNameToCssValue(fontFamily);
+                      return (
+                        <CommandItem
+                          key={fontFamily}
+                          value={fontFamily}
+                          onSelect={() => selectFontFamily(fontFamily)}
+                          className="items-start"
+                        >
+                          <Check
+                            className={cn(
+                              "mt-0.5 size-3.5",
+                              selected ? "opacity-100" : "opacity-0",
+                            )}
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm" style={{ fontFamily: cssValue }}>
+                              {fontFamily}
+                            </div>
+                            <div
+                              className="truncate text-[11px] text-muted-foreground"
+                              style={{ fontFamily: cssValue }}
+                            >
+                              Aa The quick brown fox 0123
+                            </div>
+                          </div>
+                        </CommandItem>
+                      );
+                    })}
+                    {showCustomCandidate ? (
+                      <CommandItem
+                        value={customCandidate}
+                        onSelect={() => selectValue(customCandidate)}
+                      >
+                        <Check className="size-3.5 opacity-0" />
+                        <div className="min-w-0">
+                          <div className="truncate text-sm">Use custom value</div>
+                          <div className="truncate font-mono text-[10px] text-muted-foreground">
+                            {customCandidate}
+                          </div>
+                        </div>
+                      </CommandItem>
+                    ) : null}
+                  </CommandGroup>
+                  {visibleOptions.length === 0 && !showCustomCandidate ? (
+                    <CommandEmpty>No fonts found.</CommandEmpty>
+                  ) : null}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+          {value ? (
             <button
               type="button"
               aria-label={`Clear ${label.toLowerCase()}`}
               title="Clear"
               onClick={clear}
-              className="absolute right-1.5 top-1/2 inline-flex size-5 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+              className="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-input text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <X className="size-3" />
             </button>
@@ -237,6 +465,8 @@ function EditorSection({
   onMarkdownFontFamilyChange: (value: string) => void;
   onLineNumbersChange: (value: boolean) => void;
 }) {
+  const fontFamilies = useAvailableFontFamilies();
+
   return (
     <div className="space-y-4 pt-4 border-t border-border/50">
       <div>
@@ -246,19 +476,21 @@ function EditorSection({
       </div>
 
       <div className="space-y-3">
-        <FontFamilyInput
+        <FontFamilyPicker
           label="Code font"
           value={codeFontFamily}
           onChange={onCodeFontFamilyChange}
           placeholder='ui-monospace, "SF Mono", monospace'
           description="Code cells, raw cells, inline code, and code blocks"
+          fontFamilies={fontFamilies}
         />
-        <FontFamilyInput
+        <FontFamilyPicker
           label="Markdown font"
           value={markdownFontFamily}
           onChange={onMarkdownFontFamilyChange}
           placeholder="system-ui, sans-serif"
           description="Rendered Markdown and Markdown input"
+          fontFamilies={fontFamilies}
         />
         <div className="flex items-center justify-between gap-3">
           <div className="space-y-0.5">

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -132,6 +132,7 @@ export function FontFamilyPicker({
   );
   const customCandidate = searchValue.trim();
   const showCustomCandidate = customCandidate.length > 0 && !exactSearchMatch;
+  const displayValue = currentSingleFamily || value || placeholder;
 
   const clear = useCallback(() => {
     if (value !== "") onChange("");
@@ -179,7 +180,7 @@ export function FontFamilyPicker({
                   value ? "text-foreground" : "text-muted-foreground",
                 )}
               >
-                <span className="min-w-0 truncate font-mono">{value || placeholder}</span>
+                <span className="min-w-0 truncate font-mono">{displayValue}</span>
                 <ChevronsUpDown className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
               </button>
             </PopoverTrigger>

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -9,7 +9,13 @@ import {
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNotebookHost } from "@nteract/notebook-host";
+import {
+  DEFAULT_FONT_FAMILIES,
+  fontFamilyNameToCssValue,
+  singleFontFamilyFromCssValue,
+  uniqueSortedFontFamilies,
+  useNotebookHost,
+} from "@nteract/notebook-host";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
   Command,
@@ -55,78 +61,10 @@ function formatDuration(secs: number): string {
   return `${secs}s`;
 }
 
-const FONT_FAMILY_FALLBACKS = [
-  "Arial",
-  "Courier New",
-  "Georgia",
-  "Helvetica",
-  "Inter",
-  "Menlo",
-  "Monaco",
-  "SF Mono",
-  "Times New Roman",
-  "Trebuchet MS",
-  "Verdana",
-];
-
-const GENERIC_FONT_FAMILIES = new Set([
-  "cursive",
-  "emoji",
-  "fantasy",
-  "fangsong",
-  "math",
-  "monospace",
-  "sans-serif",
-  "serif",
-  "system-ui",
-  "ui-monospace",
-  "ui-rounded",
-  "ui-sans-serif",
-  "ui-serif",
-]);
-
-function uniqueSortedFontFamilies(fontFamilies: readonly string[]): string[] {
-  const byKey = new Map<string, string>();
-  for (const fontFamily of fontFamilies) {
-    const trimmed = fontFamily.trim();
-    if (!trimmed) continue;
-    const key = trimmed.toLocaleLowerCase();
-    if (!byKey.has(key)) byKey.set(key, trimmed);
-  }
-  return Array.from(byKey.values()).sort((a, b) =>
-    a.localeCompare(b, undefined, { sensitivity: "base" }),
-  );
-}
-
-function stripCssFamilyQuotes(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.length < 2) return trimmed;
-  const quote = trimmed[0];
-  if ((quote !== '"' && quote !== "'") || trimmed[trimmed.length - 1] !== quote) return trimmed;
-  return trimmed
-    .slice(1, -1)
-    .replace(/\\(["'\\])/g, "$1")
-    .trim();
-}
-
-function singleFontFamilyFromCssValue(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.includes(",")) return null;
-  return stripCssFamilyQuotes(trimmed);
-}
-
-export function fontFamilyNameToCssValue(fontFamily: string): string {
-  const trimmed = fontFamily.trim();
-  if (!trimmed) return "";
-  if (GENERIC_FONT_FAMILIES.has(trimmed.toLocaleLowerCase())) return trimmed;
-  if (/^-?[_a-zA-Z][_a-zA-Z0-9-]*$/.test(trimmed)) return trimmed;
-  return `"${trimmed.replace(/["\\]/g, "\\$&")}"`;
-}
-
 function useAvailableFontFamilies() {
   const host = useNotebookHost();
   const [fontFamilies, setFontFamilies] = useState(() =>
-    uniqueSortedFontFamilies(FONT_FAMILY_FALLBACKS),
+    uniqueSortedFontFamilies(DEFAULT_FONT_FAMILIES),
   );
 
   useEffect(() => {
@@ -135,7 +73,7 @@ function useAvailableFontFamilies() {
       .getFontFamilies()
       .then((families) => {
         if (cancelled) return;
-        setFontFamilies(uniqueSortedFontFamilies([...FONT_FAMILY_FALLBACKS, ...families]));
+        setFontFamilies(uniqueSortedFontFamilies([...DEFAULT_FONT_FAMILIES, ...families]));
       })
       .catch((error) => {
         host.log.warn(

--- a/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
+++ b/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { fontFamilyNameToCssValue } from "@nteract/notebook-host";
+import { fontFamilyNameToCssValue, uniqueSortedFontFamilies } from "@nteract/notebook-host";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { FontFamilyPicker } from "../../settings/App";
 
@@ -85,5 +85,12 @@ describe("FontFamilyPicker", () => {
     expect(fontFamilyNameToCssValue("Fraunces")).toBe("Fraunces");
     expect(fontFamilyNameToCssValue("SF Mono")).toBe('"SF Mono"');
     expect(fontFamilyNameToCssValue("serif")).toBe("serif");
+  });
+
+  it("deduplicates unicode font names case-insensitively", () => {
+    expect(uniqueSortedFontFamilies(["  Ümlaut  ", "ümlaut", "Naïve", "naïve"])).toEqual([
+      "Naïve",
+      "Ümlaut",
+    ]);
   });
 });

--- a/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
+++ b/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { fontFamilyNameToCssValue } from "@nteract/notebook-host";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
-import { FontFamilyPicker, fontFamilyNameToCssValue } from "../../settings/App";
+import { FontFamilyPicker } from "../../settings/App";
 
 const fontFamilies = ["Fraunces", "Georgia", "SF Mono", "Times New Roman"];
 

--- a/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
+++ b/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
@@ -67,9 +67,17 @@ describe("FontFamilyPicker", () => {
     );
     const option = screen.getByText("Use custom value").closest("[cmdk-item]");
     expect(option).not.toBeNull();
-    await user.click(within(option as HTMLElement).getByText("Use custom value"));
+    await user.click(within(option!).getByText("Use custom value"));
 
     expect(onChange).toHaveBeenCalledWith("Fraunces, Georgia, serif");
+  });
+
+  it("displays selected multi-word font names without CSS quotes", () => {
+    renderPicker('"SF Mono"');
+
+    const combobox = screen.getByRole("combobox", { name: "Markdown font" });
+    expect(combobox.textContent).toContain("SF Mono");
+    expect(combobox.textContent).not.toContain('"SF Mono"');
   });
 
   it("clears back to the theme default", async () => {

--- a/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
+++ b/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { FontFamilyPicker, fontFamilyNameToCssValue } from "../../settings/App";
+
+const fontFamilies = ["Fraunces", "Georgia", "SF Mono", "Times New Roman"];
+
+beforeAll(() => {
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  }
+});
+
+function renderPicker(value = "", onChange = vi.fn()) {
+  render(
+    <FontFamilyPicker
+      label="Markdown font"
+      value={value}
+      onChange={onChange}
+      placeholder="system-ui, sans-serif"
+      description="Rendered Markdown and Markdown input"
+      fontFamilies={fontFamilies}
+    />,
+  );
+  return { onChange };
+}
+
+describe("FontFamilyPicker", () => {
+  it("filters font families and commits the selected font", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker();
+
+    await user.click(screen.getByRole("combobox", { name: "Markdown font" }));
+    await user.type(screen.getByPlaceholderText("Search fonts or enter a CSS stack"), "frau");
+    await user.click(screen.getByText("Fraunces"));
+
+    expect(onChange).toHaveBeenCalledWith("Fraunces");
+  });
+
+  it("quotes multi-word font names when selecting from the list", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker();
+
+    await user.click(screen.getByRole("combobox", { name: "Markdown font" }));
+    await user.type(screen.getByPlaceholderText("Search fonts or enter a CSS stack"), "sf mono");
+    await user.click(screen.getByText("SF Mono"));
+
+    expect(onChange).toHaveBeenCalledWith('"SF Mono"');
+  });
+
+  it("allows a custom CSS font stack", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker();
+
+    await user.click(screen.getByRole("combobox", { name: "Markdown font" }));
+    await user.type(
+      screen.getByPlaceholderText("Search fonts or enter a CSS stack"),
+      "Fraunces, Georgia, serif",
+    );
+    const option = screen.getByText("Use custom value").closest("[cmdk-item]");
+    expect(option).not.toBeNull();
+    await user.click(within(option as HTMLElement).getByText("Use custom value"));
+
+    expect(onChange).toHaveBeenCalledWith("Fraunces, Georgia, serif");
+  });
+
+  it("clears back to the theme default", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker("Fraunces");
+
+    await user.click(screen.getByRole("button", { name: "Clear markdown font" }));
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("formats CSS family values for installed font names", () => {
+    expect(fontFamilyNameToCssValue("Fraunces")).toBe("Fraunces");
+    expect(fontFamilyNameToCssValue("SF Mono")).toBe('"SF Mono"');
+    expect(fontFamilyNameToCssValue("serif")).toBe("serif");
+  });
+});

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -58,6 +58,7 @@ rfd = "0.17"  # Native dialogs for pre-window error display
 flate2 = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 tar = { workspace = true }
+fontdb = "0.23.0"
 
 # WebDriver plugin for E2E testing
 tauri-plugin-webdriver = { version = "0.2", optional = true }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1049,8 +1049,9 @@ async fn setup_sync_receivers(
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_commit_hash, next_available_sample_path, pathless_file_open_policy, reopen_action,
-        PathlessFileOpenPolicy, ReopenAction, SyncReadyState,
+        extract_commit_hash, next_available_sample_path, normalize_font_families,
+        pathless_file_open_policy, reopen_action, PathlessFileOpenPolicy, ReopenAction,
+        SyncReadyState,
     };
     use tempfile::TempDir;
 
@@ -1063,6 +1064,28 @@ mod tests {
             "dirty suffix is informational; SHA equality is what drives upgrade decisions"
         );
         assert_eq!(extract_commit_hash("1.4.1"), None);
+    }
+
+    #[test]
+    fn normalize_font_families_returns_empty_for_empty_input() {
+        let families: Vec<&str> = Vec::new();
+        assert!(normalize_font_families(families).is_empty());
+    }
+
+    #[test]
+    fn normalize_font_families_trims_and_dedupes_case_insensitively() {
+        assert_eq!(
+            normalize_font_families(["  Fraunces  ", "fraunces", "", "Georgia"]),
+            vec!["Fraunces", "Georgia"]
+        );
+    }
+
+    #[test]
+    fn normalize_font_families_sorts_case_insensitively() {
+        assert_eq!(
+            normalize_font_families(["zeta", "Alpha", "beta"]),
+            vec!["Alpha", "beta", "zeta"]
+        );
     }
 
     #[test]
@@ -3144,19 +3167,30 @@ fn list_font_families() -> Vec<String> {
     let mut database = fontdb::Database::new();
     database.load_system_fonts();
 
-    let mut families = std::collections::BTreeSet::new();
-    for face in database.faces() {
-        for (family, _language) in &face.families {
-            let family = family.trim();
-            if !family.is_empty() {
-                families.insert(family.to_string());
-            }
+    normalize_font_families(
+        database
+            .faces()
+            .flat_map(|face| face.families.iter().map(|(family, _language)| family)),
+    )
+}
+
+fn normalize_font_families<I, S>(font_families: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut by_key = std::collections::BTreeMap::new();
+    for font_family in font_families {
+        let font_family = font_family.as_ref().trim();
+        if font_family.is_empty() {
+            continue;
         }
+        by_key
+            .entry(font_family.to_lowercase())
+            .or_insert_with(|| font_family.to_string());
     }
 
-    let mut families: Vec<String> = families.into_iter().collect();
-    families.sort_by_key(|family| family.to_lowercase());
-    families
+    by_key.into_values().collect()
 }
 
 /// Get synced settings from the Automerge settings document via runtimed.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1089,6 +1089,14 @@ mod tests {
     }
 
     #[test]
+    fn normalize_font_families_dedupes_unicode_names_case_insensitively() {
+        assert_eq!(
+            normalize_font_families(["  Ümlaut  ", "ümlaut", "Naïve", "naïve"]),
+            vec!["Naïve", "Ümlaut"]
+        );
+    }
+
+    #[test]
     fn next_available_sample_path_reuses_original_name_when_available() {
         let temp_dir = TempDir::new().expect("temp dir");
         let path = next_available_sample_path(temp_dir.path(), "example.ipynb");

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3138,6 +3138,27 @@ async fn check_typosquats(packages: Vec<String>) -> Vec<typosquat::TyposquatWarn
     typosquat::check_packages(&packages)
 }
 
+/// List installed system font families for settings font pickers.
+#[tauri::command]
+fn list_font_families() -> Vec<String> {
+    let mut database = fontdb::Database::new();
+    database.load_system_fonts();
+
+    let mut families = std::collections::BTreeSet::new();
+    for face in database.faces() {
+        for (family, _language) in &face.families {
+            let family = family.trim();
+            if !family.is_empty() {
+                families.insert(family.to_string());
+            }
+        }
+    }
+
+    let mut families: Vec<String> = families.into_iter().collect();
+    families.sort_by_key(|family| family.to_lowercase());
+    families
+}
+
 /// Get synced settings from the Automerge settings document via runtimed.
 /// Falls back to reading settings.json when the daemon is unavailable,
 /// so the frontend always gets real settings instead of hardcoded defaults.
@@ -4127,6 +4148,7 @@ pub fn run(
             get_daemon_info,
             get_blob_port,
             get_username,
+            list_font_families,
             // Feedback
             open_feedback_window,
             get_feedback_system_info,

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -37,6 +37,19 @@ import type {
 const DEFAULT_CONFIG_URL = "/__nteract_dev_relay/config";
 const FRAME_TYPE_REQUEST = 0x01;
 const FRAME_TYPE_RESPONSE = 0x02;
+const BROWSER_FONT_FAMILY_FALLBACKS = [
+  "Arial",
+  "Courier New",
+  "Georgia",
+  "Helvetica",
+  "Inter",
+  "Menlo",
+  "Monaco",
+  "SF Mono",
+  "Times New Roman",
+  "Trebuchet MS",
+  "Verdana",
+];
 
 interface BrowserRelayConfig {
   websocket_url: string;
@@ -574,6 +587,9 @@ export async function createBrowserHost(
       },
       async getUsername() {
         return "browser";
+      },
+      async getFontFamilies() {
+        return BROWSER_FONT_FAMILY_FALLBACKS;
       },
     },
     dialog: {

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -33,24 +33,11 @@ import type {
   TyposquatWarning,
   Unlisten,
 } from "../types";
+import { DEFAULT_FONT_FAMILIES, uniqueSortedFontFamilies } from "../font-families";
 
 const DEFAULT_CONFIG_URL = "/__nteract_dev_relay/config";
 const FRAME_TYPE_REQUEST = 0x01;
 const FRAME_TYPE_RESPONSE = 0x02;
-const BROWSER_FONT_FAMILY_FALLBACKS = [
-  "Arial",
-  "Courier New",
-  "Georgia",
-  "Helvetica",
-  "Inter",
-  "Menlo",
-  "Monaco",
-  "SF Mono",
-  "Times New Roman",
-  "Trebuchet MS",
-  "Verdana",
-];
-
 interface BrowserRelayConfig {
   websocket_url: string;
   token: string;
@@ -76,6 +63,38 @@ export interface CreateBrowserHostOptions {
   fetchImpl?: typeof fetch;
   /** Test seam. */
   WebSocketImpl?: typeof WebSocket;
+}
+
+type BrowserFontAccess = {
+  query?: () => Promise<Iterable<{ family?: string }>>;
+};
+
+async function getBrowserFontFamilies(): Promise<string[]> {
+  const fontFamilies: string[] = [...DEFAULT_FONT_FAMILIES];
+  const fontAccess =
+    typeof navigator !== "undefined"
+      ? (navigator as Navigator & { fonts?: BrowserFontAccess }).fonts
+      : undefined;
+
+  if (typeof fontAccess?.query === "function") {
+    try {
+      const availableFonts = await fontAccess.query();
+      for (const font of availableFonts) {
+        if (font.family) fontFamilies.push(font.family);
+      }
+    } catch {
+      // The Font Access API is optional and permission-gated; loaded CSS fonts
+      // and the curated defaults still give the picker useful options.
+    }
+  }
+
+  if (typeof document !== "undefined" && "fonts" in document) {
+    document.fonts.forEach((fontFace) => {
+      if (fontFace.family) fontFamilies.push(fontFace.family);
+    });
+  }
+
+  return uniqueSortedFontFamilies(fontFamilies);
 }
 
 interface PendingEntry {
@@ -588,9 +607,7 @@ export async function createBrowserHost(
       async getUsername() {
         return "browser";
       },
-      async getFontFamilies() {
-        return BROWSER_FONT_FAMILY_FALLBACKS;
-      },
+      getFontFamilies: getBrowserFontFamilies,
     },
     dialog: {
       async openFile() {

--- a/packages/notebook-host/src/font-families.ts
+++ b/packages/notebook-host/src/font-families.ts
@@ -1,0 +1,67 @@
+export const DEFAULT_FONT_FAMILIES = [
+  "Arial",
+  "Courier New",
+  "Georgia",
+  "Helvetica",
+  "Inter",
+  "Menlo",
+  "Monaco",
+  "SF Mono",
+  "Times New Roman",
+  "Trebuchet MS",
+  "Verdana",
+] as const;
+
+const GENERIC_FONT_FAMILIES = new Set([
+  "cursive",
+  "emoji",
+  "fantasy",
+  "fangsong",
+  "math",
+  "monospace",
+  "sans-serif",
+  "serif",
+  "system-ui",
+  "ui-monospace",
+  "ui-rounded",
+  "ui-sans-serif",
+  "ui-serif",
+]);
+
+export function uniqueSortedFontFamilies(fontFamilies: readonly string[]): string[] {
+  const byKey = new Map<string, string>();
+  for (const fontFamily of fontFamilies) {
+    const trimmed = fontFamily.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLocaleLowerCase();
+    if (!byKey.has(key)) byKey.set(key, trimmed);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: "base" }),
+  );
+}
+
+export function stripCssFamilyQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const quote = trimmed[0];
+  if ((quote !== '"' && quote !== "'") || trimmed[trimmed.length - 1] !== quote) return trimmed;
+  return trimmed
+    .slice(1, -1)
+    .replace(/\\(["'\\])/g, "$1")
+    .trim();
+}
+
+export function singleFontFamilyFromCssValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes(",")) return null;
+  return stripCssFamilyQuotes(trimmed);
+}
+
+export function fontFamilyNameToCssValue(fontFamily: string): string {
+  const trimmed = fontFamily.trim();
+  if (!trimmed) return "";
+  if (GENERIC_FONT_FAMILIES.has(trimmed.toLocaleLowerCase())) return trimmed;
+  if (/^-?[_a-zA-Z][_a-zA-Z0-9-]*$/.test(trimmed)) return trimmed;
+  return `"${trimmed.replace(/["\\]/g, "\\$&")}"`;
+}

--- a/packages/notebook-host/src/index.ts
+++ b/packages/notebook-host/src/index.ts
@@ -45,6 +45,14 @@ export {
 export { NotebookHostProvider, type NotebookHostProviderProps, useNotebookHost } from "./react";
 
 export {
+  DEFAULT_FONT_FAMILIES,
+  fontFamilyNameToCssValue,
+  singleFontFamilyFromCssValue,
+  stripCssFamilyQuotes,
+  uniqueSortedFontFamilies,
+} from "./font-families";
+
+export {
   startRelayBootstrapCoordinator,
   type RelayBootstrapCoordinator,
   type RelayBootstrapCoordinatorOptions,

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -304,6 +304,9 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     async getUsername() {
       return invoke<string>("get_username");
     },
+    async getFontFamilies() {
+      return invoke<string[]>("list_font_families");
+    },
   };
 
   const dialog: HostDialog = {

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -259,6 +259,7 @@ export interface HostWindow {
 export interface HostSystem {
   getGitInfo(): Promise<GitInfo | null>;
   getUsername(): Promise<string>;
+  getFontFamilies(): Promise<string[]>;
 }
 
 /** File picker. Returned paths are platform-native strings, or null if cancelled. */

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -36,6 +36,8 @@ vi.mock("@tauri-apps/api/core", () => ({
         return Promise.resolve([]);
       case "get_username":
         return Promise.resolve("kyle");
+      case "list_font_families":
+        return Promise.resolve(["Fraunces", "Georgia"]);
       case "get_daemon_ready_info":
         return Promise.resolve({
           notebook_id: "nb-1",
@@ -328,7 +330,7 @@ describe("createTauriHost()", () => {
     expect(capturedInvokes[2].args).toEqual({ path: "/tmp/notebooks/a.ipynb" });
   });
 
-  it("system.getGitInfo and getUsername route to the correct commands", async () => {
+  it("system methods route to the correct commands", async () => {
     const host = createTauriHost({ transport: stubTransport });
     await expect(host.system.getGitInfo()).resolves.toEqual({
       branch: "main",
@@ -336,6 +338,12 @@ describe("createTauriHost()", () => {
       description: null,
     });
     await expect(host.system.getUsername()).resolves.toBe("kyle");
+    await expect(host.system.getFontFamilies()).resolves.toEqual(["Fraunces", "Georgia"]);
+    expect(capturedInvokes.map((x) => x.cmd)).toEqual([
+      "get_git_info",
+      "get_username",
+      "list_font_families",
+    ]);
   });
 
   it("daemonEvents.onReady subscribes to 'daemon:ready' and returns a working unlisten", async () => {


### PR DESCRIPTION
## Summary

- add a searchable font picker with per-row font previews for editor font settings
- enumerate installed system font families from the Tauri host with browser fallbacks for web/dev settings
- share fallback font families and CSS font-family helpers through `@nteract/notebook-host`
- keep theme-default clearing and custom CSS font stack entry for advanced values

## Verification

- `pnpm test:run packages/notebook-host/tests/tauri-host.test.ts apps/notebook/src/__tests__/settings-font-family-picker.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook build`
- `cargo check -p notebook`
- `cargo test -p notebook`
- `cargo clippy -p notebook --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- settings visual smoke at desktop and narrow widths via Playwright against `pnpm --dir apps/notebook dev --host 127.0.0.1 --port 5190`
