### PR TITLE
fix(cloud): workstation control plane correctness for multiple workstations

### DIFF
--- a/apps/notebook-cloud/migrations/0008_workstation_attach_active_owner_unique.sql
+++ b/apps/notebook-cloud/migrations/0008_workstation_attach_active_owner_unique.sql
@@ -40,6 +40,6 @@ UPDATE workstation_attach_jobs
 
 DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx;
 
-CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
+CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_owner_unique_idx
   ON workstation_attach_jobs(notebook_id, owner_principal)
   WHERE status IN ('pending', 'accepted', 'running');

--- a/apps/notebook-cloud/migrations/0008_workstation_attach_active_owner_unique.sql
+++ b/apps/notebook-cloud/migrations/0008_workstation_attach_active_owner_unique.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS workstation_attach_jobs (
+  id TEXT PRIMARY KEY,
+  notebook_id TEXT NOT NULL,
+  owner_principal TEXT NOT NULL,
+  workstation_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'accepted', 'running', 'failed', 'completed', 'cancelled')
+  ),
+  requested_by_actor_label TEXT NOT NULL,
+  requested_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  accepted_at TEXT,
+  finished_at TEXT,
+  error_message TEXT,
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE INDEX IF NOT EXISTS workstation_attach_jobs_poll_idx
+  ON workstation_attach_jobs(owner_principal, workstation_id, status, requested_at);
+
+UPDATE workstation_attach_jobs
+   SET status = 'cancelled',
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+       finished_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+       error_message = 'cancelled by active workstation attach job uniqueness migration'
+ WHERE status IN ('pending', 'accepted', 'running')
+   AND id IN (
+     SELECT id
+       FROM (
+         SELECT id,
+                ROW_NUMBER() OVER (
+                  PARTITION BY notebook_id, owner_principal
+                  ORDER BY requested_at DESC, updated_at DESC, id DESC
+                ) AS active_rank
+           FROM workstation_attach_jobs
+          WHERE status IN ('pending', 'accepted', 'running')
+       )
+      WHERE active_rank > 1
+   );
+
+DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
+  ON workstation_attach_jobs(notebook_id, owner_principal)
+  WHERE status IN ('pending', 'accepted', 'running');

--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -37,6 +37,12 @@ export interface WorkstationLeaseRecord {
   offline_reason: string | null;
 }
 
+export interface WorkstationLeaseDeleteResult {
+  deleted: boolean;
+  went_offline: boolean;
+  reason: string | null;
+}
+
 export class OwnerComputeIndex {
   constructor(
     private readonly state: DurableObjectState,
@@ -56,6 +62,9 @@ export class OwnerComputeIndex {
     }
     if (request.method === "POST" && url.pathname === "/lease/upsert") {
       return this.handleLeaseUpsert(request);
+    }
+    if (request.method === "POST" && url.pathname === "/lease/delete") {
+      return this.handleLeaseDelete(request);
     }
     if (request.method === "POST" && url.pathname === "/lease/list") {
       return this.handleLeaseList();
@@ -96,6 +105,38 @@ export class OwnerComputeIndex {
     await this.state.storage.put(leaseKey(workstationId), lease);
     await this.armLeaseAlarm();
     return json({ ok: true, lease_expires_at: lease.lease_expires_at });
+  }
+
+  private async handleLeaseDelete(request: Request): Promise<Response> {
+    const payload = await readJsonObject(request);
+    if (payload instanceof Response) {
+      return payload;
+    }
+    const workstationId = boundedString(payload.workstation_id ?? payload.workstationId, 128);
+    const ownerPrincipal = boundedString(payload.owner_principal ?? payload.ownerPrincipal, 320);
+    if (!workstationId || !ownerPrincipal) {
+      return json({ error: "workstation_id and owner_principal are required" }, 400);
+    }
+
+    const key = leaseKey(workstationId);
+    const lease = await this.state.storage.get<unknown>(key);
+    if (!isWorkstationLeaseRecord(lease) || lease.owner_principal !== ownerPrincipal) {
+      return json({
+        ok: true,
+        deleted: false,
+        went_offline: false,
+        reason: null,
+      });
+    }
+
+    await this.state.storage.delete(key);
+    await this.armLeaseAlarm();
+    return json({
+      ok: true,
+      deleted: true,
+      went_offline: lease.online,
+      reason: lease.offline_reason,
+    });
   }
 
   private async handleLeaseList(): Promise<Response> {
@@ -417,6 +458,68 @@ export async function upsertWorkstationLease(
     });
   }
   return false;
+}
+
+/**
+ * Delete a workstation liveness lease from the owner registry. Returns whether
+ * the delete consumed an online lease so callers can send exactly one
+ * went_offline notification and avoid racing the alarm sweep's own transition.
+ */
+export async function deleteWorkstationLease(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+): Promise<WorkstationLeaseDeleteResult> {
+  const namespace = env.OWNER_COMPUTE_INDEX;
+  const fallback: WorkstationLeaseDeleteResult = {
+    deleted: false,
+    went_offline: false,
+    reason: null,
+  };
+  if (!namespace) {
+    return fallback;
+  }
+  try {
+    const response = await ownerComputeIndexStub(namespace, ownerPrincipal).fetch(
+      new Request("https://owner-compute-index.internal/lease/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          workstation_id: workstationId,
+          owner_principal: ownerPrincipal,
+        }),
+      }),
+    );
+    if (!response.ok) {
+      cloudLog("warn", "fleet_registry.lease_delete_failed", {
+        owner_principal: ownerPrincipal,
+        workstation_id: workstationId,
+        response_status: response.status,
+        counter: "fleet_registry_lease_delete_failed",
+        counter_delta: 1,
+      });
+      return fallback;
+    }
+    const body = (await response.json()) as unknown;
+    if (!body || typeof body !== "object") {
+      return fallback;
+    }
+    const result = body as Partial<WorkstationLeaseDeleteResult>;
+    return {
+      deleted: result.deleted === true,
+      went_offline: result.went_offline === true,
+      reason: typeof result.reason === "string" ? result.reason : null,
+    };
+  } catch (error) {
+    cloudLog("warn", "fleet_registry.lease_delete_failed", {
+      owner_principal: ownerPrincipal,
+      workstation_id: workstationId,
+      error: errorMessage(error),
+      counter: "fleet_registry_lease_delete_failed",
+      counter_delta: 1,
+    });
+    return fallback;
+  }
 }
 
 /** Read every lease this owner holds, keyed by workstation id. */

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2400,11 +2400,17 @@ async function routeWorkstationAttachJobs(
       }),
     ),
   );
+  const [defaultWorkstationId, leases] = await Promise.all([
+    getDefaultWorkstationId(env, ownerPrincipal),
+    listWorkstationLeases(env, ownerPrincipal),
+  ]);
+  const lease = leases.get(workstationId) ?? null;
   return json({
     ok: true,
     workstation: workstationResponseRow(workstation, {
-      defaultWorkstationId: await getDefaultWorkstationId(env, ownerPrincipal),
+      defaultWorkstationId,
       now: Date.now(),
+      lease,
     }),
     jobs: jobs.map((job) => workstationAttachJobResponseRow(request, job)),
   });
@@ -2594,7 +2600,7 @@ function workstationListNeedsEventPresence(
   if (workstation.status !== "online" || !workstation.last_seen_at) {
     return false;
   }
-  if (lease && !lease.online && workstationLeaseIsFreshEnough(workstation, lease)) {
+  if (lease && workstationLeaseIsFreshEnough(workstation, lease)) {
     return false;
   }
   const lastSeen = Date.parse(workstation.last_seen_at);

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2134,19 +2134,27 @@ async function routeNotebookWorkstationAttachment(
     scope: "runtime_peer",
     actorLabel: identity.actorLabel,
   });
-  const job = await createWorkstationAttachJob(env, {
+  const attachJob = await createWorkstationAttachJob(env, {
     notebookId,
     ownerPrincipal,
     replaceActive: replaceExisting,
     workstationId,
     actorLabel: identity.actorLabel,
   });
-  if (!job) {
+  if (!attachJob) {
     return json({ error: "workstation attach job was not created" }, 500);
   }
+  const { job } = attachJob;
+  const switchedWorkstations =
+    attachJob.cancelledActiveJob !== null &&
+    attachJob.cancelledActiveJob.workstation_id !== workstationId;
   await publishWorkstationAttachJobRuntimeState(env, job, workstation, {
-    closeRuntimePeers: replaceExisting,
-    closeReason: replaceExisting ? "workstation restart requested" : undefined,
+    closeRuntimePeers: replaceExisting || switchedWorkstations,
+    closeReason: replaceExisting
+      ? "workstation restart requested"
+      : switchedWorkstations
+        ? "workstation attachment switched"
+        : undefined,
   });
   await notifyWorkstationAttachJob(env, ownerPrincipal, job);
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2396,6 +2396,7 @@ async function routeWorkstationAttachJobs(
         reason:
           job.error_message ?? "pending workstation attach job expired before host accepted it",
         operation: "workstation_attach_job_pending_expired",
+        expectedRuntimeSessionId: job.id,
       }),
     ),
   );
@@ -2725,6 +2726,7 @@ async function routeWorkstationAttachJob(
       reason:
         job.error_message ?? `workstation attach job ${job.status} before a runtime peer attached`,
       operation: `workstation_attach_job_${job.status}`,
+      expectedRuntimeSessionId: job.id,
     });
   }
   return json({
@@ -3125,6 +3127,7 @@ async function repairNotebookRuntimeStateIfNoRuntimePeer(
   env: Env,
   notebookId: string,
   options: {
+    expectedRuntimeSessionId?: string | null;
     operation: string;
     reason: string;
   },
@@ -3140,7 +3143,12 @@ async function repairNotebookRuntimeStateIfNoRuntimePeer(
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ reason: options.reason }),
+          body: JSON.stringify({
+            reason: options.reason,
+            ...(options.expectedRuntimeSessionId
+              ? { expected_runtime_session_id: options.expectedRuntimeSessionId }
+              : {}),
+          }),
         },
       ),
     );

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -92,6 +92,7 @@ import {
 } from "./workstation-events.ts";
 import {
   OwnerComputeIndex,
+  deleteWorkstationLease,
   listOwnerComputeSessions,
   listWorkstationLeases,
   upsertWorkstationLease,
@@ -375,6 +376,14 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     methods: ["POST"],
     handler: ({ params }, request, env) =>
       routeWorkstationCredentialRevoke(request, env, params.credentialId),
+  },
+  {
+    match: routePath("/api/workstations/:workstationId", {
+      trailingSlash: "optional",
+    }),
+    methods: ["DELETE"],
+    handler: ({ params }, request, env) =>
+      routeWorkstationDeregister(request, env, params.workstationId),
   },
   {
     match: routePath("/api/workstations/:workstationId/events", {
@@ -1806,6 +1815,68 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
   );
 }
 
+async function routeWorkstationDeregister(
+  request: Request,
+  env: Env,
+  workstationIdParam: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const workstationId = boundedStringField(workstationIdParam, "workstation_id", 128);
+  if (workstationId instanceof Response) {
+    return workstationId;
+  }
+
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner", {
+    allowWorkstationCredential: true,
+  });
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to deregister a workstation" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
+  if (!workstation) {
+    return missingWorkstationResponse();
+  }
+
+  const leaseDelete = await deleteWorkstationLease(env, ownerPrincipal, workstationId);
+  const deleted = await deleteRegisteredWorkstation(env, ownerPrincipal, workstationId);
+  if (!deleted) {
+    return missingWorkstationResponse();
+  }
+  if (leaseDelete.went_offline) {
+    await notifyWorkstationWentOffline(
+      env,
+      ownerPrincipal,
+      workstationId,
+      leaseDelete.reason ?? "workstation deregistered",
+    );
+  }
+
+  cloudLog("info", "workstation.deregistered", {
+    principal: ownerPrincipal,
+    workstation_id: workstationId,
+    counter: "workstation_deregistrations",
+    counter_delta: 1,
+  });
+  return json({
+    ok: true,
+    workstation_id: workstationId,
+    deregistered: true,
+  });
+}
+
 async function routeDefaultWorkstation(request: Request, env: Env): Promise<Response> {
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
@@ -2384,6 +2455,78 @@ async function notifyWorkstationAttachJob(
       counter_delta: 1,
     });
   }
+}
+
+async function notifyWorkstationWentOffline(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+  reason: string,
+): Promise<void> {
+  if (!env.WORKSTATION_EVENTS) {
+    return;
+  }
+  try {
+    const response = await workstationEventsStub(env, ownerPrincipal, workstationId).fetch(
+      new Request("https://workstation-events.internal/notify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          event: "went_offline",
+          workstation_id: workstationId,
+          reason,
+        }),
+      }),
+    );
+    if (response.ok) {
+      return;
+    }
+    cloudLog("warn", "workstation.events.went_offline_notify_failed", {
+      principal: ownerPrincipal,
+      workstation_id: workstationId,
+      response_status: response.status,
+      counter: "workstation_events_went_offline_notify_failed",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "workstation.events.went_offline_notify_failed", {
+      principal: ownerPrincipal,
+      workstation_id: workstationId,
+      error: error instanceof Error ? error.message : String(error),
+      counter: "workstation_events_went_offline_notify_failed",
+      counter_delta: 1,
+    });
+  }
+}
+
+async function deleteRegisteredWorkstation(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+): Promise<boolean> {
+  if (!env.DB) {
+    return false;
+  }
+  await env.DB.prepare(
+    `DELETE FROM workstation_defaults
+      WHERE owner_principal = ?
+        AND workstation_id = ?`,
+  )
+    .bind(ownerPrincipal, workstationId)
+    .run();
+  const result = await env.DB.prepare(
+    `DELETE FROM workstations
+      WHERE owner_principal = ?
+        AND workstation_id = ?`,
+  )
+    .bind(ownerPrincipal, workstationId)
+    .run();
+  return d1MutationChanges(result) > 0;
+}
+
+function d1MutationChanges(result: { meta?: Record<string, unknown> }): number {
+  const changes = result.meta?.changes;
+  return typeof changes === "number" ? changes : 0;
 }
 
 function workstationEventsStub(

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2313,7 +2313,21 @@ async function routeWorkstationAttachJobs(
   if (limit instanceof Response) {
     return limit;
   }
-  const jobs = await listActiveWorkstationAttachJobs(env, ownerPrincipal, workstationId, limit);
+  const { expiredPendingJobs, jobs } = await listActiveWorkstationAttachJobs(
+    env,
+    ownerPrincipal,
+    workstationId,
+    limit,
+  );
+  await Promise.all(
+    expiredPendingJobs.map((job) =>
+      repairNotebookRuntimeStateIfNoRuntimePeer(env, job.notebook_id, {
+        reason:
+          job.error_message ?? "pending workstation attach job expired before host accepted it",
+        operation: "workstation_attach_job_pending_expired",
+      }),
+    ),
+  );
   return json({
     ok: true,
     workstation: workstationResponseRow(workstation, {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1732,6 +1732,7 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
       env,
       ownerPrincipal,
       workstations,
+      leases,
       now,
     );
     return json({
@@ -2095,9 +2096,18 @@ async function routeNotebookWorkstationAttachment(
     return json({ error: "workstation not found" }, 404);
   }
 
-  const defaultWorkstationId = await getDefaultWorkstationId(env, ownerPrincipal);
-  const eventPresence = await workstationEventPresence(env, ownerPrincipal, workstationId);
-  const projectedStatus = workstationStatusForResponse(workstation, Date.now(), eventPresence);
+  const [defaultWorkstationId, eventPresence, leases] = await Promise.all([
+    getDefaultWorkstationId(env, ownerPrincipal),
+    workstationEventPresence(env, ownerPrincipal, workstationId),
+    listWorkstationLeases(env, ownerPrincipal),
+  ]);
+  const lease = leases.get(workstationId) ?? null;
+  const projectedStatus = workstationStatusForResponse(
+    workstation,
+    Date.now(),
+    eventPresence,
+    lease,
+  );
   if (projectedStatus !== "online") {
     await repairNotebookRuntimeStateIfNoRuntimePeer(env, notebookId, {
       reason: `workstation ${workstationId} is not online while attaching compute`,
@@ -2110,6 +2120,7 @@ async function routeNotebookWorkstationAttachment(
           defaultWorkstationId,
           now: Date.now(),
           eventPresence,
+          lease,
         }),
       },
       409,
@@ -2156,6 +2167,7 @@ async function routeNotebookWorkstationAttachment(
         defaultWorkstationId,
         now: Date.now(),
         eventPresence,
+        lease,
       }),
     },
     202,
@@ -2379,13 +2391,18 @@ async function workstationEventPresenceById(
   env: Env,
   ownerPrincipal: string,
   workstations: readonly WorkstationRow[],
+  leases: ReadonlyMap<string, WorkstationLeaseRecord>,
   now: number,
 ): Promise<Map<string, WorkstationEventPresence | null>> {
   if (!env.WORKSTATION_EVENTS || workstations.length === 0) {
     return new Map();
   }
   const staleWorkstations = workstations.filter((workstation) =>
-    workstationListNeedsEventPresence(workstation, now),
+    workstationListNeedsEventPresence(
+      workstation,
+      now,
+      leases.get(workstation.workstation_id) ?? null,
+    ),
   );
   if (staleWorkstations.length === 0) {
     return new Map();
@@ -2403,8 +2420,15 @@ async function workstationEventPresenceById(
   return new Map(entries);
 }
 
-function workstationListNeedsEventPresence(workstation: WorkstationRow, now: number): boolean {
+function workstationListNeedsEventPresence(
+  workstation: WorkstationRow,
+  now: number,
+  lease: WorkstationLeaseRecord | null | undefined,
+): boolean {
   if (workstation.status !== "online" || !workstation.last_seen_at) {
+    return false;
+  }
+  if (lease && !lease.online && workstationLeaseIsFreshEnough(workstation, lease)) {
     return false;
   }
   const lastSeen = Date.parse(workstation.last_seen_at);
@@ -2807,12 +2831,7 @@ export function workstationStatusForResponse(
   eventPresence: WorkstationEventPresence | null | undefined = null,
   lease: WorkstationLeaseRecord | null | undefined = null,
 ): WorkstationStatus {
-  if (
-    eventPresence?.connected === true &&
-    (workstation.status === "online" || workstation.status === "offline")
-  ) {
-    return "online";
-  }
+  const statusUsesLiveness = workstation.status === "online" || workstation.status === "offline";
   // The registry-DO lease is the proactive liveness signal: its alarm sweeps a
   // workstation offline at expiry instead of waiting for a read to notice.
   // Still check the expiry timestamp directly so a late alarm can't report a
@@ -2821,14 +2840,11 @@ export function workstationStatusForResponse(
   // best-effort, so if that write lagged or failed, D1 is the newer signal and
   // a stale offline lease must not override it. Falls back to the lazy D1
   // staleness check when no (or a stale) lease exists.
-  if (lease && (workstation.status === "online" || workstation.status === "offline")) {
-    const rowSeen = workstation.last_seen_at ? Date.parse(workstation.last_seen_at) : NaN;
-    const leaseSeen = Date.parse(lease.last_seen_at);
-    const leaseIsFreshEnough =
-      !Number.isFinite(rowSeen) || (Number.isFinite(leaseSeen) && leaseSeen >= rowSeen);
-    if (leaseIsFreshEnough) {
-      return lease.online && lease.lease_expires_at > now ? "online" : "offline";
-    }
+  if (statusUsesLiveness && lease && workstationLeaseIsFreshEnough(workstation, lease)) {
+    return lease.online && lease.lease_expires_at > now ? "online" : "offline";
+  }
+  if (statusUsesLiveness && eventPresence?.connected === true) {
+    return "online";
   }
   if (workstation.status === "online" && workstation.last_seen_at) {
     const lastSeen = Date.parse(workstation.last_seen_at);
@@ -2837,6 +2853,15 @@ export function workstationStatusForResponse(
     }
   }
   return workstation.status;
+}
+
+function workstationLeaseIsFreshEnough(
+  workstation: WorkstationRow,
+  lease: WorkstationLeaseRecord,
+): boolean {
+  const rowSeen = workstation.last_seen_at ? Date.parse(workstation.last_seen_at) : NaN;
+  const leaseSeen = Date.parse(lease.last_seen_at);
+  return !Number.isFinite(rowSeen) || (Number.isFinite(leaseSeen) && leaseSeen >= rowSeen);
 }
 
 function parseStoredWorkstationEnvironments(value: string | null): unknown[] {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -510,6 +510,43 @@ export class NotebookRoom {
     if (reason instanceof Response) {
       return reason;
     }
+    const expectedRuntimeSessionId = optionalBoundedStringField(
+      payload?.expected_runtime_session_id ?? payload?.expectedRuntimeSessionId,
+      "expected_runtime_session_id",
+      128,
+    );
+    if (expectedRuntimeSessionId instanceof Response) {
+      return expectedRuntimeSessionId;
+    }
+
+    const startedAt = Date.now();
+    const materializer = this.materializerFor(notebookId);
+    if (expectedRuntimeSessionId) {
+      const currentAttachment = await materializer.getWorkstationAttachment();
+      const currentRuntimeSessionId = currentAttachment?.runtime_session_id ?? null;
+      if (currentRuntimeSessionId !== expectedRuntimeSessionId) {
+        cloudLog("info", "room.runtime_state_repair.skipped_session_mismatch", {
+          notebook_id: notebookId,
+          expected_runtime_session_id: expectedRuntimeSessionId,
+          current_runtime_session_id: currentRuntimeSessionId,
+          runtime_peer_count: this.runtimePeerCount(),
+          duration_ms: durationMs(startedAt),
+          counter: "runtime_state_repairs_skipped_session_mismatch",
+          counter_delta: 1,
+        });
+        return json(
+          {
+            ok: true,
+            changed: false,
+            skipped: true,
+            skip_reason: "runtime_session_mismatch",
+            forced: force,
+            runtime_peer_count: this.runtimePeerCount(),
+          },
+          200,
+        );
+      }
+    }
 
     if (this.hasRuntimePeer()) {
       if (!force) {
@@ -527,9 +564,7 @@ export class NotebookRoom {
       });
     }
 
-    const startedAt = Date.now();
     try {
-      const materializer = this.materializerFor(notebookId);
       const result = await materializer.reconcileRuntimePeerGone(reason);
       this.invalidateSelectedRuntimePeerSession(notebookId);
       if (result.changed) {

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -124,6 +124,9 @@ export type WorkstationAttachJobStatus =
   | "cancelled";
 
 export const WORKSTATION_ATTACH_JOB_STALE_MS = 2 * 60_000;
+// Pending jobs cover host cold start before the agent accepts the request; give
+// a slow host one extra minute beyond the accepted/running heartbeat timeout.
+export const WORKSTATION_ATTACH_PENDING_STALE_MS = 3 * 60_000;
 
 export interface WorkstationRow {
   owner_principal: string;
@@ -175,6 +178,11 @@ export interface WorkstationAttachJobRow {
 export interface CreateWorkstationAttachJobResult {
   job: WorkstationAttachJobRow;
   cancelledActiveJob: WorkstationAttachJobRow | null;
+}
+
+export interface ListActiveWorkstationAttachJobsResult {
+  jobs: WorkstationAttachJobRow[];
+  expiredPendingJobs: WorkstationAttachJobRow[];
 }
 
 const WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
@@ -1150,10 +1158,24 @@ export async function createWorkstationAttachJob(
   const now = new Date();
   const nowIso = now.toISOString();
   const staleBefore = new Date(now.getTime() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
-  await expireStaleWorkstationAttachJobs(env, input, { now: nowIso, staleBefore });
+  const pendingStaleBefore = new Date(
+    now.getTime() - WORKSTATION_ATTACH_PENDING_STALE_MS,
+  ).toISOString();
+  await expireStaleWorkstationAttachJobs(
+    env,
+    { notebookId: input.notebookId, ownerPrincipal: input.ownerPrincipal },
+    {
+      now: nowIso,
+      pendingStaleBefore,
+      staleBefore,
+    },
+  );
   let cancelledActiveJob: WorkstationAttachJobRow | null = null;
 
-  const existing = await getActiveWorkstationAttachJob(env, input, staleBefore);
+  const existing = await getActiveWorkstationAttachJob(env, input, {
+    pendingStaleBefore,
+    staleBefore,
+  });
   if (existing) {
     if (input.replaceActive !== true && existing.workstation_id === input.workstationId) {
       return { job: existing, cancelledActiveJob: null };
@@ -1200,7 +1222,10 @@ export async function createWorkstationAttachJob(
       }
       return { job, cancelledActiveJob };
     } catch (error) {
-      const racedExisting = await getActiveWorkstationAttachJob(env, input, staleBefore);
+      const racedExisting = await getActiveWorkstationAttachJob(env, input, {
+        pendingStaleBefore,
+        staleBefore,
+      });
       if (!racedExisting || attempt > 0) {
         throw error;
       }
@@ -1222,13 +1247,23 @@ export async function listActiveWorkstationAttachJobs(
   ownerPrincipal: string,
   workstationId: string,
   limit = 10,
-): Promise<WorkstationAttachJobRow[]> {
+): Promise<ListActiveWorkstationAttachJobsResult> {
   if (!env.DB) {
-    return [];
+    return { jobs: [], expiredPendingJobs: [] };
   }
 
   await ensureCatalogSchema(env);
-  const staleBefore = new Date(Date.now() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const staleBefore = new Date(now.getTime() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
+  const pendingStaleBefore = new Date(
+    now.getTime() - WORKSTATION_ATTACH_PENDING_STALE_MS,
+  ).toISOString();
+  const expiredPendingJobs = await expireStaleWorkstationAttachJobs(
+    env,
+    { ownerPrincipal, workstationId },
+    { now: nowIso, pendingStaleBefore, staleBefore },
+  );
   const rows = await env.DB.prepare(
     `SELECT id,
             notebook_id,
@@ -1245,15 +1280,18 @@ export async function listActiveWorkstationAttachJobs(
       WHERE owner_principal = ?
         AND workstation_id = ?
         AND (
-          status = 'pending'
+          (status = 'pending' AND requested_at >= ?)
           OR (status IN ('accepted', 'running') AND updated_at >= ?)
         )
       ORDER BY requested_at ASC
       LIMIT ?`,
   )
-    .bind(ownerPrincipal, workstationId, staleBefore, limit)
+    .bind(ownerPrincipal, workstationId, pendingStaleBefore, staleBefore, limit)
     .all<WorkstationAttachJobRow>();
-  return rows.results ?? [];
+  return {
+    jobs: rows.results ?? [],
+    expiredPendingJobs,
+  };
 }
 
 export async function updateWorkstationAttachJobStatus(
@@ -1312,7 +1350,13 @@ async function getActiveWorkstationAttachJob(
     notebookId: string;
     ownerPrincipal: string;
   },
-  staleBefore: string,
+  {
+    pendingStaleBefore,
+    staleBefore,
+  }: {
+    pendingStaleBefore: string;
+    staleBefore: string;
+  },
 ): Promise<WorkstationAttachJobRow | null> {
   const row = await env
     .DB!.prepare(
@@ -1331,13 +1375,13 @@ async function getActiveWorkstationAttachJob(
       WHERE notebook_id = ?
         AND owner_principal = ?
         AND (
-          status = 'pending'
+          (status = 'pending' AND requested_at >= ?)
           OR (status IN ('accepted', 'running') AND updated_at >= ?)
         )
       ORDER BY requested_at DESC
       LIMIT 1`,
     )
-    .bind(input.notebookId, input.ownerPrincipal, staleBefore)
+    .bind(input.notebookId, input.ownerPrincipal, pendingStaleBefore, staleBefore)
     .first<WorkstationAttachJobRow>();
   return row;
 }
@@ -1345,17 +1389,20 @@ async function getActiveWorkstationAttachJob(
 async function expireStaleWorkstationAttachJobs(
   env: Env,
   input: {
-    notebookId: string;
+    notebookId?: string;
     ownerPrincipal: string;
+    workstationId?: string;
   },
   {
     now,
+    pendingStaleBefore,
     staleBefore,
   }: {
     now: string;
+    pendingStaleBefore: string;
     staleBefore: string;
   },
-): Promise<void> {
+): Promise<WorkstationAttachJobRow[]> {
   await env
     .DB!.prepare(
       `UPDATE workstation_attach_jobs
@@ -1363,13 +1410,59 @@ async function expireStaleWorkstationAttachJobs(
               updated_at = ?,
               finished_at = ?,
               error_message = 'stale workstation attach job expired after heartbeat timeout'
-        WHERE notebook_id = ?
+        WHERE (? IS NULL OR notebook_id = ?)
           AND owner_principal = ?
+          AND (? IS NULL OR workstation_id = ?)
           AND status IN ('accepted', 'running')
           AND updated_at < ?`,
     )
-    .bind(now, now, input.notebookId, input.ownerPrincipal, staleBefore)
+    .bind(
+      now,
+      now,
+      input.notebookId ?? null,
+      input.notebookId ?? null,
+      input.ownerPrincipal,
+      input.workstationId ?? null,
+      input.workstationId ?? null,
+      staleBefore,
+    )
     .run();
+  const expiredPending = await env
+    .DB!.prepare(
+      `UPDATE workstation_attach_jobs
+          SET status = 'failed',
+              updated_at = ?,
+              finished_at = ?,
+              error_message = 'stale workstation attach job expired before host accepted the request'
+        WHERE (? IS NULL OR notebook_id = ?)
+          AND owner_principal = ?
+          AND (? IS NULL OR workstation_id = ?)
+          AND status = 'pending'
+          AND requested_at < ?
+        RETURNING id,
+                  notebook_id,
+                  owner_principal,
+                  workstation_id,
+                  status,
+                  requested_by_actor_label,
+                  requested_at,
+                  updated_at,
+                  accepted_at,
+                  finished_at,
+                  error_message`,
+    )
+    .bind(
+      now,
+      now,
+      input.notebookId ?? null,
+      input.notebookId ?? null,
+      input.ownerPrincipal,
+      input.workstationId ?? null,
+      input.workstationId ?? null,
+      pendingStaleBefore,
+    )
+    .all<WorkstationAttachJobRow>();
+  return expiredPending.results ?? [];
 }
 
 async function cancelActiveWorkstationAttachJobs(

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -185,7 +185,9 @@ export interface ListActiveWorkstationAttachJobsResult {
   expiredPendingJobs: WorkstationAttachJobRow[];
 }
 
-const WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
+const WORKSTATION_ATTACH_JOBS_DROP_LEGACY_ACTIVE_UNIQUE_INDEX = `DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx`;
+
+const WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_owner_unique_idx
     ON workstation_attach_jobs(notebook_id, owner_principal)
     WHERE status IN ('pending', 'accepted', 'running')`;
 
@@ -355,6 +357,7 @@ const SCHEMA_STATEMENTS = [
     error_message TEXT,
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
+  WORKSTATION_ATTACH_JOBS_DROP_LEGACY_ACTIVE_UNIQUE_INDEX,
   WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX,
   `CREATE INDEX IF NOT EXISTS workstation_attach_jobs_poll_idx
     ON workstation_attach_jobs(owner_principal, workstation_id, status, requested_at)`,
@@ -1171,6 +1174,7 @@ export async function createWorkstationAttachJob(
     },
   );
   let cancelledActiveJob: WorkstationAttachJobRow | null = null;
+  let activeJobToCancel: WorkstationAttachJobRow | null = null;
 
   const existing = await getActiveWorkstationAttachJob(env, input, {
     pendingStaleBefore,
@@ -1180,11 +1184,8 @@ export async function createWorkstationAttachJob(
     if (input.replaceActive !== true && existing.workstation_id === input.workstationId) {
       return { job: existing, cancelledActiveJob: null };
     }
-    await cancelActiveWorkstationAttachJobs(env, input, {
-      now: nowIso,
-      errorMessage: "replaced by a newer workstation attach request",
-    });
     cancelledActiveJob = existing;
+    activeJobToCancel = existing;
   }
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -1210,7 +1211,17 @@ export async function createWorkstationAttachJob(
       nowIso,
     );
     try {
-      await insert.run();
+      if (activeJobToCancel) {
+        await env.DB.batch([
+          cancelActiveWorkstationAttachJobsStatement(env, input, {
+            now: nowIso,
+            errorMessage: "replaced by a newer workstation attach request",
+          }),
+          insert,
+        ]);
+      } else {
+        await insert.run();
+      }
       const job = await getWorkstationAttachJob(
         env,
         input.ownerPrincipal,
@@ -1232,11 +1243,8 @@ export async function createWorkstationAttachJob(
       if (input.replaceActive !== true && racedExisting.workstation_id === input.workstationId) {
         return { job: racedExisting, cancelledActiveJob };
       }
-      await cancelActiveWorkstationAttachJobs(env, input, {
-        now: nowIso,
-        errorMessage: "replaced by a newer workstation attach request",
-      });
       cancelledActiveJob ??= racedExisting;
+      activeJobToCancel = racedExisting;
     }
   }
   throw new Error("workstation attach job was not created");
@@ -1326,7 +1334,18 @@ export async function updateWorkstationAttachJobStatus(
       WHERE id = ?
         AND owner_principal = ?
         AND workstation_id = ?
-        AND status IN ('pending', 'accepted', 'running')`,
+        AND status IN ('pending', 'accepted', 'running')
+        AND CASE status
+              WHEN 'pending' THEN 0
+              WHEN 'accepted' THEN 1
+              WHEN 'running' THEN 2
+              ELSE 3
+            END <= CASE ?
+              WHEN 'pending' THEN 0
+              WHEN 'accepted' THEN 1
+              WHEN 'running' THEN 2
+              ELSE 3
+            END`,
   )
     .bind(
       input.status,
@@ -1339,6 +1358,7 @@ export async function updateWorkstationAttachJobStatus(
       input.jobId,
       input.ownerPrincipal,
       input.workstationId,
+      input.status,
     )
     .run();
   return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, input.jobId);
@@ -1465,7 +1485,7 @@ async function expireStaleWorkstationAttachJobs(
   return expiredPending.results ?? [];
 }
 
-async function cancelActiveWorkstationAttachJobs(
+function cancelActiveWorkstationAttachJobsStatement(
   env: Env,
   input: {
     notebookId: string;
@@ -1478,8 +1498,8 @@ async function cancelActiveWorkstationAttachJobs(
     now: string;
     errorMessage: string;
   },
-): Promise<void> {
-  await env
+): D1PreparedStatement {
+  return env
     .DB!.prepare(
       `UPDATE workstation_attach_jobs
           SET status = 'cancelled',
@@ -1490,8 +1510,7 @@ async function cancelActiveWorkstationAttachJobs(
           AND owner_principal = ?
           AND status IN ('pending', 'accepted', 'running')`,
     )
-    .bind(now, now, errorMessage, input.notebookId, input.ownerPrincipal)
-    .run();
+    .bind(now, now, errorMessage, input.notebookId, input.ownerPrincipal);
 }
 
 async function getWorkstationAttachJob(

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -172,6 +172,15 @@ export interface WorkstationAttachJobRow {
   error_message: string | null;
 }
 
+export interface CreateWorkstationAttachJobResult {
+  job: WorkstationAttachJobRow;
+  cancelledActiveJob: WorkstationAttachJobRow | null;
+}
+
+const WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
+    ON workstation_attach_jobs(notebook_id, owner_principal)
+    WHERE status IN ('pending', 'accepted', 'running')`;
+
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -338,9 +347,7 @@ const SCHEMA_STATEMENTS = [
     error_message TEXT,
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
-    ON workstation_attach_jobs(notebook_id, owner_principal, workstation_id)
-    WHERE status IN ('pending', 'accepted', 'running')`,
+  WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX,
   `CREATE INDEX IF NOT EXISTS workstation_attach_jobs_poll_idx
     ON workstation_attach_jobs(owner_principal, workstation_id, status, requested_at)`,
   `CREATE TABLE IF NOT EXISTS workstation_pairing_codes (
@@ -1134,7 +1141,7 @@ export async function createWorkstationAttachJob(
     workstationId: string;
     actorLabel: string;
   },
-): Promise<WorkstationAttachJobRow | null> {
+): Promise<CreateWorkstationAttachJobResult | null> {
   if (!env.DB) {
     return null;
   }
@@ -1144,20 +1151,24 @@ export async function createWorkstationAttachJob(
   const nowIso = now.toISOString();
   const staleBefore = new Date(now.getTime() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
   await expireStaleWorkstationAttachJobs(env, input, { now: nowIso, staleBefore });
-  if (input.replaceActive === true) {
+  let cancelledActiveJob: WorkstationAttachJobRow | null = null;
+
+  const existing = await getActiveWorkstationAttachJob(env, input, staleBefore);
+  if (existing) {
+    if (input.replaceActive !== true && existing.workstation_id === input.workstationId) {
+      return { job: existing, cancelledActiveJob: null };
+    }
     await cancelActiveWorkstationAttachJobs(env, input, {
       now: nowIso,
       errorMessage: "replaced by a newer workstation attach request",
     });
-  }
-  const existing = await getActiveWorkstationAttachJob(env, input, staleBefore);
-  if (existing) {
-    return existing;
+    cancelledActiveJob = existing;
   }
 
-  const jobId = crypto.randomUUID();
-  const insert = env.DB.prepare(
-    `INSERT INTO workstation_attach_jobs (
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const jobId = crypto.randomUUID();
+    const insert = env.DB.prepare(
+      `INSERT INTO workstation_attach_jobs (
        id,
        notebook_id,
        owner_principal,
@@ -1167,25 +1178,43 @@ export async function createWorkstationAttachJob(
        requested_at,
        updated_at
      ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`,
-  ).bind(
-    jobId,
-    input.notebookId,
-    input.ownerPrincipal,
-    input.workstationId,
-    input.actorLabel,
-    nowIso,
-    nowIso,
-  );
-  try {
-    await insert.run();
-  } catch (error) {
-    const racedExisting = await getActiveWorkstationAttachJob(env, input, staleBefore);
-    if (racedExisting) {
-      return racedExisting;
+    ).bind(
+      jobId,
+      input.notebookId,
+      input.ownerPrincipal,
+      input.workstationId,
+      input.actorLabel,
+      nowIso,
+      nowIso,
+    );
+    try {
+      await insert.run();
+      const job = await getWorkstationAttachJob(
+        env,
+        input.ownerPrincipal,
+        input.workstationId,
+        jobId,
+      );
+      if (!job) {
+        throw new Error("workstation attach job insert did not return a row");
+      }
+      return { job, cancelledActiveJob };
+    } catch (error) {
+      const racedExisting = await getActiveWorkstationAttachJob(env, input, staleBefore);
+      if (!racedExisting || attempt > 0) {
+        throw error;
+      }
+      if (input.replaceActive !== true && racedExisting.workstation_id === input.workstationId) {
+        return { job: racedExisting, cancelledActiveJob };
+      }
+      await cancelActiveWorkstationAttachJobs(env, input, {
+        now: nowIso,
+        errorMessage: "replaced by a newer workstation attach request",
+      });
+      cancelledActiveJob ??= racedExisting;
     }
-    throw error;
   }
-  return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, jobId);
+  throw new Error("workstation attach job was not created");
 }
 
 export async function listActiveWorkstationAttachJobs(
@@ -1282,7 +1311,6 @@ async function getActiveWorkstationAttachJob(
   input: {
     notebookId: string;
     ownerPrincipal: string;
-    workstationId: string;
   },
   staleBefore: string,
 ): Promise<WorkstationAttachJobRow | null> {
@@ -1302,7 +1330,6 @@ async function getActiveWorkstationAttachJob(
        FROM workstation_attach_jobs
       WHERE notebook_id = ?
         AND owner_principal = ?
-        AND workstation_id = ?
         AND (
           status = 'pending'
           OR (status IN ('accepted', 'running') AND updated_at >= ?)
@@ -1310,7 +1337,7 @@ async function getActiveWorkstationAttachJob(
       ORDER BY requested_at DESC
       LIMIT 1`,
     )
-    .bind(input.notebookId, input.ownerPrincipal, input.workstationId, staleBefore)
+    .bind(input.notebookId, input.ownerPrincipal, staleBefore)
     .first<WorkstationAttachJobRow>();
   return row;
 }
@@ -1320,7 +1347,6 @@ async function expireStaleWorkstationAttachJobs(
   input: {
     notebookId: string;
     ownerPrincipal: string;
-    workstationId: string;
   },
   {
     now,
@@ -1339,11 +1365,10 @@ async function expireStaleWorkstationAttachJobs(
               error_message = 'stale workstation attach job expired after heartbeat timeout'
         WHERE notebook_id = ?
           AND owner_principal = ?
-          AND workstation_id = ?
           AND status IN ('accepted', 'running')
           AND updated_at < ?`,
     )
-    .bind(now, now, input.notebookId, input.ownerPrincipal, input.workstationId, staleBefore)
+    .bind(now, now, input.notebookId, input.ownerPrincipal, staleBefore)
     .run();
 }
 
@@ -1352,7 +1377,6 @@ async function cancelActiveWorkstationAttachJobs(
   input: {
     notebookId: string;
     ownerPrincipal: string;
-    workstationId: string;
   },
   {
     now,
@@ -1371,10 +1395,9 @@ async function cancelActiveWorkstationAttachJobs(
               error_message = ?
         WHERE notebook_id = ?
           AND owner_principal = ?
-          AND workstation_id = ?
           AND status IN ('pending', 'accepted', 'running')`,
     )
-    .bind(now, now, errorMessage, input.notebookId, input.ownerPrincipal, input.workstationId)
+    .bind(now, now, errorMessage, input.notebookId, input.ownerPrincipal)
     .run();
 }
 

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1340,12 +1340,7 @@ export async function updateWorkstationAttachJobStatus(
               WHEN 'accepted' THEN 1
               WHEN 'running' THEN 2
               ELSE 3
-            END <= CASE ?
-              WHEN 'pending' THEN 0
-              WHEN 'accepted' THEN 1
-              WHEN 'running' THEN 2
-              ELSE 3
-            END`,
+            END <= ?`,
   )
     .bind(
       input.status,
@@ -1358,10 +1353,25 @@ export async function updateWorkstationAttachJobStatus(
       input.jobId,
       input.ownerPrincipal,
       input.workstationId,
-      input.status,
+      workstationAttachJobStatusRank(input.status),
     )
     .run();
   return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, input.jobId);
+}
+
+function workstationAttachJobStatusRank(status: WorkstationAttachJobStatus): number {
+  switch (status) {
+    case "pending":
+      return 0;
+    case "accepted":
+      return 1;
+    case "running":
+      return 2;
+    case "failed":
+    case "completed":
+    case "cancelled":
+      return 3;
+  }
 }
 
 async function getActiveWorkstationAttachJob(

--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -65,7 +65,11 @@ const STABLE_AUTH: CloudPrototypeAuthState = {
   problem: null,
 };
 
-function workstation(id: string, displayName: string): NotebookRegisteredWorkstation {
+function workstation(
+  id: string,
+  displayName: string,
+  overrides: Partial<NotebookRegisteredWorkstation> = {},
+): NotebookRegisteredWorkstation {
   return {
     id,
     displayName,
@@ -80,6 +84,7 @@ function workstation(id: string, displayName: string): NotebookRegisteredWorksta
     memoryBytes: null,
     updatedAt: null,
     environments: [],
+    ...overrides,
   };
 }
 
@@ -182,6 +187,59 @@ describe("CloudWorkstationsStore registry gate", () => {
     assert.equal(store.snapshot.registry.defaultWorkstationId, "ws-1");
     assert.equal(store.snapshot.registry.workstations.length, 1);
 
+    dispose();
+  });
+
+  it("keeps workstation order stable when liveness changes", async () => {
+    const store = new CloudWorkstationsStore();
+    const inputs$ = new BehaviorSubject<CloudWorkstationsInputs>(baseInputs());
+    const emittedOrders: string[][] = [];
+    const subscription = store.registry$.subscribe((current) => {
+      if (current.workstations.length > 0) {
+        emittedOrders.push(current.workstations.map((workstation) => workstation.id));
+      }
+    });
+    let loadCalls = 0;
+    const dispose = store.activate(
+      inputs$,
+      baseDeps({
+        loadWorkstations: async () => {
+          loadCalls += 1;
+          return loadCalls === 1
+            ? registry({
+                workstations: [
+                  workstation("ws-b", "Beta", { status: "online" }),
+                  workstation("ws-a", "Alpha", { status: "offline" }),
+                ],
+              })
+            : registry({
+                workstations: [
+                  workstation("ws-a", "Alpha", { status: "online" }),
+                  workstation("ws-b", "Beta", { status: "offline" }),
+                ],
+              });
+        },
+      }),
+    );
+
+    await drainMicrotasks();
+    assert.deepEqual(
+      store.snapshot.registry.workstations.map((workstation) => workstation.id),
+      ["ws-a", "ws-b"],
+    );
+
+    await store.refreshNow();
+    await drainMicrotasks();
+    assert.deepEqual(
+      store.snapshot.registry.workstations.map((workstation) => workstation.id),
+      ["ws-a", "ws-b"],
+    );
+    assert.deepEqual(emittedOrders, [
+      ["ws-a", "ws-b"],
+      ["ws-a", "ws-b"],
+    ]);
+
+    subscription.unsubscribe();
     dispose();
   });
 

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -178,6 +178,55 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
     assert.match(events.notifications[0].body.reason as string, /lease expired/);
   });
 
+  it("deletes an online lease and leaves no lease for a concurrent sweep to notify", async () => {
+    const { state, scheduledAlarm, settle, deliverAlarm } = fakeStateWithAlarm();
+    const events = fakeWorkstationEvents();
+    const object = new OwnerComputeIndex(state, events.env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+
+    const deleted = await object.fetch(leaseDelete("ws-a", "user:dev:alice"));
+    assert.equal(deleted.status, 200);
+    assert.deepEqual(await deleted.json(), {
+      ok: true,
+      deleted: true,
+      went_offline: true,
+      reason: null,
+    });
+    assert.equal((await listLeases(object)).length, 0);
+    assert.equal(scheduledAlarm(), null);
+
+    deliverAlarm();
+    await object.alarm();
+    await settle();
+
+    assert.equal(events.notifications.length, 0);
+  });
+
+  it("does not ask delete callers to notify again when the sweep already marked offline", async () => {
+    const { state, values, settle, deliverAlarm } = fakeStateWithAlarm();
+    const events = fakeWorkstationEvents();
+    const object = new OwnerComputeIndex(state, events.env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    const stored = values.get("lease:ws-a") as Record<string, unknown>;
+    values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
+
+    deliverAlarm();
+    await object.alarm();
+    await settle();
+
+    const deleted = await object.fetch(leaseDelete("ws-a", "user:dev:alice"));
+    assert.equal(deleted.status, 200);
+    assert.deepEqual(await deleted.json(), {
+      ok: true,
+      deleted: true,
+      went_offline: false,
+      reason: "lease expired: no heartbeat within the lease window",
+    });
+    assert.equal(events.notifications.length, 1);
+  });
+
   it("does not push for a lease that is already offline", async () => {
     const { state, values, settle, deliverAlarm } = fakeStateWithAlarm();
     const events = fakeWorkstationEvents();
@@ -248,6 +297,17 @@ function leaseUpsert(workstationId: string, ownerPrincipal: string, ttlMs: numbe
       workstation_id: workstationId,
       owner_principal: ownerPrincipal,
       ttl_ms: ttlMs,
+    }),
+  });
+}
+
+function leaseDelete(workstationId: string, ownerPrincipal: string): Request {
+  return new Request("https://compute.internal/lease/delete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      workstation_id: workstationId,
+      owner_principal: ownerPrincipal,
     }),
   });
 }

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3609,6 +3609,129 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 9, 8, 7]);
   });
 
+  it("skips runtime-state repair when the expected runtime session is stale", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const harness = roomHarness(room);
+    let checkpointed = 0;
+    let reconcileCalls = 0;
+    const attachment = {
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      runtime_session_id: "fresh-job",
+      status: "connecting",
+      status_message: "Waiting for Lab2 to accept the compute request.",
+      cpu_count: 8,
+      memory_bytes: 16_000_000_000,
+      working_directory: "/home/ubuntu/project",
+      updated_at: "2026-05-22T00:00:01.000Z",
+    };
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      getWorkstationAttachment: async () => attachment,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/runtime-state-repair", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          expected_runtime_session_id: "expired-job",
+          reason: "expired pending attach job",
+        }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: false,
+      skipped: true,
+      skip_reason: "runtime_session_mismatch",
+      forced: false,
+      runtime_peer_count: 0,
+    });
+    assert.equal(reconcileCalls, 0);
+    assert.equal(checkpointed, 0);
+    assert.equal(attachment.status, "connecting");
+    assert.equal(attachment.runtime_session_id, "fresh-job");
+  });
+
+  it("repairs RuntimeStateDoc when the expected runtime session still owns the attachment", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const harness = roomHarness(room);
+    let checkpointed = 0;
+    let repairReason: string | undefined;
+    const attachment = {
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      runtime_session_id: "expired-job",
+      status: "connecting",
+      status_message: "Waiting for Lab2 to accept the compute request.",
+      cpu_count: 8,
+      memory_bytes: 16_000_000_000,
+      working_directory: "/home/ubuntu/project",
+      updated_at: "2026-05-22T00:00:01.000Z",
+    };
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      getWorkstationAttachment: async () => attachment,
+      reconcileRuntimePeerGone: async (reason: string) => {
+        repairReason = reason;
+        attachment.status = "error";
+        attachment.status_message = "runtime peer left";
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/runtime-state-repair", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          expected_runtime_session_id: "expired-job",
+          reason: "expired pending attach job",
+        }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: true,
+      forced: false,
+      checkpoint_persisted: true,
+      runtime_peer_count: 0,
+    });
+    assert.equal(repairReason, "expired pending attach job");
+    assert.equal(checkpointed, 1);
+    assert.equal(attachment.status, "error");
+    assert.equal(attachment.runtime_session_id, "expired-job");
+  });
+
   it("refuses manual runtime-state repair while a runtime_peer is connected", async () => {
     const state = hibernatedState([]);
     const room = new NotebookRoom(state.state, {} as Env);

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3305,6 +3305,7 @@ describe("Worker artifact routes", () => {
     assert.notEqual(body.job.job_id, "running-job-a");
     assert.equal(body.job.status, "pending");
     assert.equal(body.job.workstation_id, "ws-lab-b");
+    assert.equal(env.DB.batchSizes.at(-1), 2);
     assert.equal(env.DB.workstationAttachJobs.get("running-job-a")?.status, "cancelled");
     assert.match(
       env.DB.workstationAttachJobs.get("running-job-a")?.error_message ?? "",
@@ -3453,6 +3454,7 @@ describe("Worker artifact routes", () => {
     const body = (await attach.json()) as { job: { job_id: string; status: string } };
     assert.notEqual(body.job.job_id, "running-job");
     assert.equal(body.job.status, "pending");
+    assert.equal(env.DB.batchSizes.at(-1), 2);
     assert.equal(env.DB.workstationAttachJobs.get("running-job")?.status, "cancelled");
     assert.match(
       env.DB.workstationAttachJobs.get("running-job")?.error_message ?? "",
@@ -3578,6 +3580,7 @@ describe("Worker artifact routes", () => {
       {
         path: "/internal/n/nb-stale-pending/runtime-state-repair",
         body: {
+          expected_runtime_session_id: "stale-pending-job",
           reason: "stale workstation attach job expired before host accepted the request",
         },
       },
@@ -3792,14 +3795,84 @@ describe("Worker artifact routes", () => {
     assert.equal(attachmentMessage, "Lab2 accepted the request and is starting compute.");
   });
 
+  it("rejects delayed workstation status patches that would move a job backward", async () => {
+    let publishCount = 0;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            publishCount += 1;
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-running",
+      notebookId: "nb-running",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "running",
+      updatedAt: "2026-05-22T00:00:02.000Z",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs/job-running", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "accepted" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 409);
+    assert.equal(publishCount, 0);
+    const row = env.DB.workstationAttachJobs.get("job-running");
+    assert.equal(row?.status, "running");
+    assert.equal(row?.updated_at, "2026-05-22T00:00:02.000Z");
+    assert.deepEqual(await response.json(), {
+      error: "workstation attach job is no longer active",
+      job: {
+        job_id: "job-running",
+        notebook_id: "nb-running",
+        workstation_id: "ws-lab2",
+        status: "running",
+        requested_at: "2026-05-22T00:00:00.000Z",
+        updated_at: "2026-05-22T00:00:02.000Z",
+        accepted_at: null,
+        finished_at: null,
+        error_message: null,
+        runtime_peer: {
+          cloud_url: "http://localhost",
+          notebook_id: "nb-running",
+          scope: "runtime_peer",
+        },
+      },
+    });
+  });
+
   it("repairs RuntimeStateDoc when a workstation attach job fails before runtime peer connects", async () => {
-    const roomRequests: string[] = [];
+    const roomRequests: Array<{ body: unknown; path: string }> = [];
     const env = fakeEnv({
       NOTEBOOK_ROOMS: {
         idFromName: (name: string) => ({ toString: () => name }),
         get: () => ({
           fetch: async (request: Request) => {
-            roomRequests.push(new URL(request.url).pathname);
+            roomRequests.push({
+              body: await request.json(),
+              path: new URL(request.url).pathname,
+            });
             return new Response(JSON.stringify({ ok: true, changed: true }), {
               status: 200,
               headers: { "Content-Type": "application/json" },
@@ -3833,8 +3906,32 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 200);
     assert.deepEqual(roomRequests, [
-      "/internal/n/nb-fail/workstation-attachment",
-      "/internal/n/nb-fail/runtime-state-repair",
+      {
+        path: "/internal/n/nb-fail/workstation-attachment",
+        body: {
+          attachment: {
+            workstation_id: "ws-lab2",
+            display_name: "Lab2",
+            provider: "runtime_peer",
+            default_environment_label: "Current Python",
+            environment_policy: "current_python",
+            runtime_session_id: "job-fail",
+            status: "error",
+            status_message: "spawn failed",
+            cpu_count: 8,
+            memory_bytes: 16_000_000_000,
+            working_directory: "/home/ubuntu/project",
+            updated_at: env.DB.workstationAttachJobs.get("job-fail")?.updated_at,
+          },
+        },
+      },
+      {
+        path: "/internal/n/nb-fail/runtime-state-repair",
+        body: {
+          expected_runtime_session_id: "job-fail",
+          reason: "spawn failed",
+        },
+      },
     ]);
   });
 
@@ -7164,6 +7261,38 @@ describe("Worker artifact routes", () => {
 });
 
 describe("catalog schema migrations", () => {
+  it("converges workstation attach active uniqueness to the owner-level index name", async () => {
+    const legacyDrop = "DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx";
+    const ownerIndexCreate =
+      "CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_owner_unique_idx";
+    const legacyIndexCreate =
+      "CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx";
+
+    const storageSource = await readFile(new URL("../src/storage.ts", import.meta.url), "utf8");
+    const dropOffset = storageSource.indexOf(legacyDrop);
+    const createOffset = storageSource.indexOf(ownerIndexCreate);
+    assert.ok(dropOffset >= 0, "runtime schema drops the old 3-column index name");
+    assert.ok(createOffset >= 0, "runtime schema creates the new owner-level index name");
+    assert.ok(dropOffset < createOffset, "runtime schema drops the old name before creating new");
+    assert.equal(
+      storageSource.includes(`${legacyIndexCreate}\n    ON workstation_attach_jobs`),
+      false,
+      "runtime schema does not recreate the old index name",
+    );
+
+    const migration = await readFile(
+      new URL("../migrations/0008_workstation_attach_active_owner_unique.sql", import.meta.url),
+      "utf8",
+    );
+    assert.ok(migration.includes(legacyDrop), "migration drops the old index name");
+    assert.ok(migration.includes(ownerIndexCreate), "migration creates the new index name");
+    assert.equal(
+      migration.includes(`${legacyIndexCreate}\n  ON workstation_attach_jobs`),
+      false,
+      "migration does not recreate the old index name",
+    );
+  });
+
   it("adds dashboard summary and cover columns via ALTER TABLE when absent", async () => {
     const db = new FakeD1();
     // Simulate a pre-migration deployment: the columns do not exist yet.
@@ -8125,6 +8254,27 @@ function isActiveWorkstationAttachJobStatus(status: WorkstationAttachJobRow["sta
   return status === "pending" || status === "accepted" || status === "running";
 }
 
+function workstationAttachJobStatusRank(status: WorkstationAttachJobRow["status"]): number {
+  switch (status) {
+    case "pending":
+      return 0;
+    case "accepted":
+      return 1;
+    case "running":
+      return 2;
+    case "failed":
+    case "completed":
+    case "cancelled":
+      return 3;
+  }
+}
+
+function cloneWorkstationAttachJobs(
+  jobs: ReadonlyMap<string, WorkstationAttachJobRow>,
+): Map<string, WorkstationAttachJobRow> {
+  return new Map([...jobs].map(([id, job]) => [id, { ...job }]));
+}
+
 function seedPendingInvite(
   env: FakeEnv,
   input: {
@@ -8598,9 +8748,18 @@ class FakeD1 implements D1Database {
 
   async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
     this.batchSizes.push(statements.length);
+    const attachJobsBefore = cloneWorkstationAttachJobs(this.workstationAttachJobs);
     const results: D1Result<T>[] = [];
-    for (const statement of statements) {
-      results.push(await statement.run<T>());
+    try {
+      for (const statement of statements) {
+        results.push(await statement.run<T>());
+      }
+    } catch (error) {
+      this.workstationAttachJobs.clear();
+      for (const [id, job] of attachJobsBefore) {
+        this.workstationAttachJobs.set(id, job);
+      }
+      throw error;
     }
     return results;
   }
@@ -9289,6 +9448,12 @@ class FakeD1Statement implements D1PreparedStatement {
           job.status !== "pending" &&
           job.status !== "accepted" &&
           job.status !== "running"
+        ) {
+          return okResult(undefined, { changes: 0 });
+        }
+        if (
+          this.query.includes("CASE status") &&
+          workstationAttachJobStatusRank(job.status) > workstationAttachJobStatusRank(status)
         ) {
           return okResult(undefined, { changes: 0 });
         }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2636,6 +2636,49 @@ describe("Worker artifact routes", () => {
     assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
   });
 
+  it("does not probe event-socket status when a fresh online lease decides a stale list row", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = fakeEnv({ OWNER_COMPUTE_INDEX: compute, WORKSTATION_EVENTS: events });
+    const now = Date.now();
+    const staleLastSeenAt = new Date(now - 4 * 60_000).toISOString();
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt: staleLastSeenAt,
+    });
+    seedWorkstationLease(compute, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt: new Date(now).toISOString(),
+      online: true,
+    });
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      workstations: Array<{
+        workstation_id: string;
+        status: string;
+      }>;
+    };
+    assert.equal(body.workstations[0]?.workstation_id, "ws-lab2");
+    assert.equal(body.workstations[0]?.status, "online");
+    assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
+  });
+
   it("does not fan out event-socket status checks for fresh workstation rows", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
@@ -3617,6 +3660,45 @@ describe("Worker artifact routes", () => {
       [["fresh-pending-job", "pending"]],
     );
     assert.equal(env.DB.workstationAttachJobs.get("fresh-pending-job")?.status, "pending");
+  });
+
+  it("honors a fresh offline workstation lease in the attach-jobs poll response", async () => {
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = fakeEnv({ OWNER_COMPUTE_INDEX: compute });
+    const lastSeenAt = new Date().toISOString();
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt,
+    });
+    seedWorkstationLease(compute, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt,
+      online: false,
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      workstation: {
+        status: string;
+        workstation_id: string;
+      };
+    };
+    assert.equal(body.workstation.workstation_id, "ws-lab2");
+    assert.equal(body.workstation.status, "offline");
   });
 
   it("only lists attach jobs for the authenticated workstation owner", async () => {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -33,6 +33,7 @@ import type { NotebookComputeSessionSummary } from "runtimed";
 import type { WorkstationLeaseRecord } from "../src/compute-session-index.ts";
 import { NotebookHandle, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
+  WORKSTATION_ATTACH_PENDING_STALE_MS,
   WORKSTATION_ATTACH_JOB_STALE_MS,
   blobKey,
   commsDocSnapshotKey,
@@ -3425,6 +3426,95 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("expires stale pending attach jobs on poll and repairs runtime state", async () => {
+    const repairRequests: Array<{ body: unknown; path: string }> = [];
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            repairRequests.push({
+              body: await request.json(),
+              path: new URL(request.url).pathname,
+            });
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "stale-pending-job",
+      notebookId: "nb-stale-pending",
+      ownerPrincipal: "user:dev:alice",
+      requestedAt: new Date(Date.now() - WORKSTATION_ATTACH_PENDING_STALE_MS - 5_000).toISOString(),
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { jobs: Array<{ job_id: string; status: string }> };
+    assert.deepEqual(body.jobs, []);
+    const expired = env.DB.workstationAttachJobs.get("stale-pending-job");
+    assert.equal(expired?.status, "failed");
+    assert.ok(expired?.finished_at);
+    assert.match(expired?.error_message ?? "", /expired before host accepted/);
+    assert.deepEqual(repairRequests, [
+      {
+        path: "/internal/n/nb-stale-pending/runtime-state-repair",
+        body: {
+          reason: "stale workstation attach job expired before host accepted the request",
+        },
+      },
+    ]);
+  });
+
+  it("keeps fresh pending attach jobs visible on poll", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "fresh-pending-job",
+      notebookId: "nb-fresh-pending",
+      ownerPrincipal: "user:dev:alice",
+      requestedAt: new Date().toISOString(),
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { jobs: Array<{ job_id: string; status: string }> };
+    assert.deepEqual(
+      body.jobs.map((job) => [job.job_id, job.status]),
+      [["fresh-pending-job", "pending"]],
+    );
+    assert.equal(env.DB.workstationAttachJobs.get("fresh-pending-job")?.status, "pending");
+  });
+
   it("only lists attach jobs for the authenticated workstation owner", async () => {
     const env = fakeEnv();
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
@@ -3433,6 +3523,7 @@ describe("Worker artifact routes", () => {
       id: "job-alice",
       notebookId: "nb-alice",
       ownerPrincipal: "user:dev:alice",
+      requestedAt: new Date().toISOString(),
       workstationId: "ws-lab2",
     });
     seedWorkstationAttachJob(env, {
@@ -7893,6 +7984,7 @@ function seedWorkstationAttachJob(
     workstationId: string;
     errorMessage?: string | null;
     finishedAt?: string | null;
+    requestedAt?: string;
     status?: WorkstationAttachJobRow["status"];
     updatedAt?: string;
   },
@@ -7904,7 +7996,7 @@ function seedWorkstationAttachJob(
     workstation_id: input.workstationId,
     status: input.status ?? "pending",
     requested_by_actor_label: "user:dev:alice/browser:tab",
-    requested_at: "2026-05-22T00:00:00.000Z",
+    requested_at: input.requestedAt ?? "2026-05-22T00:00:00.000Z",
     updated_at: input.updatedAt ?? "2026-05-22T00:00:00.000Z",
     accepted_at: null,
     finished_at: input.finishedAt ?? null,
@@ -7912,9 +8004,18 @@ function seedWorkstationAttachJob(
   });
 }
 
-function isActiveWorkstationAttachJob(job: WorkstationAttachJobRow, staleBefore: string): boolean {
+function isActiveWorkstationAttachJob(
+  job: WorkstationAttachJobRow,
+  {
+    pendingStaleBefore,
+    staleBefore,
+  }: {
+    pendingStaleBefore: string;
+    staleBefore: string;
+  },
+): boolean {
   return (
-    job.status === "pending" ||
+    (job.status === "pending" && job.requested_at >= pendingStaleBefore) ||
     ((job.status === "accepted" || job.status === "running") && job.updated_at >= staleBefore)
   );
 }
@@ -8955,20 +9056,33 @@ class FakeD1Statement implements D1PreparedStatement {
       return okResult(undefined, { changes: 1 });
     } else if (
       this.query.includes("UPDATE workstation_attach_jobs") &&
-      this.query.includes("stale workstation attach job expired")
+      this.query.includes("stale workstation attach job expired after heartbeat timeout")
     ) {
-      const [updatedAt, finishedAt, notebookId, ownerPrincipal, staleBefore] = this.values as [
+      const [
+        updatedAt,
+        finishedAt,
+        notebookId,
+        notebookIdRepeat,
+        ownerPrincipal,
+        workstationId,
+        workstationIdRepeat,
+        staleBefore,
+      ] = this.values as [
         string,
         string,
+        string | null,
+        string | null,
         string,
-        string,
+        string | null,
+        string | null,
         string,
       ];
       let changes = 0;
       for (const job of this.db.workstationAttachJobs.values()) {
         if (
-          job.notebook_id === notebookId &&
+          (notebookId === null || job.notebook_id === notebookIdRepeat) &&
           job.owner_principal === ownerPrincipal &&
+          (workstationId === null || job.workstation_id === workstationIdRepeat) &&
           (job.status === "accepted" || job.status === "running") &&
           job.updated_at < staleBefore
         ) {
@@ -9518,14 +9632,19 @@ class FakeD1Statement implements D1PreparedStatement {
     }
     if (this.query.includes("FROM workstation_attach_jobs")) {
       if (this.query.includes("notebook_id = ?")) {
-        const [notebookId, ownerPrincipal, staleBefore] = this.values as [string, string, string];
+        const [notebookId, ownerPrincipal, pendingStaleBefore, staleBefore] = this.values as [
+          string,
+          string,
+          string,
+          string,
+        ];
         return (
           ([...this.db.workstationAttachJobs.values()]
             .filter(
               (job) =>
                 job.notebook_id === notebookId &&
                 job.owner_principal === ownerPrincipal &&
-                isActiveWorkstationAttachJob(job, staleBefore),
+                isActiveWorkstationAttachJob(job, { pendingStaleBefore, staleBefore }),
             )
             .sort((left, right) => right.requested_at.localeCompare(left.requested_at))[0] as
             | T
@@ -9598,6 +9717,48 @@ class FakeD1Statement implements D1PreparedStatement {
     if (pragmaMatch) {
       const columns = this.db.tableColumns.get(pragmaMatch[1] ?? "") ?? new Set<string>();
       return okResult([...columns].map((name) => ({ name })) as T[]);
+    }
+    if (
+      this.query.includes("UPDATE workstation_attach_jobs") &&
+      this.query.includes("stale workstation attach job expired before host accepted the request")
+    ) {
+      const [
+        updatedAt,
+        finishedAt,
+        notebookId,
+        notebookIdRepeat,
+        ownerPrincipal,
+        workstationId,
+        workstationIdRepeat,
+        pendingStaleBefore,
+      ] = this.values as [
+        string,
+        string,
+        string | null,
+        string | null,
+        string,
+        string | null,
+        string | null,
+        string,
+      ];
+      const expired: WorkstationAttachJobRow[] = [];
+      for (const job of this.db.workstationAttachJobs.values()) {
+        if (
+          (notebookId === null || job.notebook_id === notebookIdRepeat) &&
+          job.owner_principal === ownerPrincipal &&
+          (workstationId === null || job.workstation_id === workstationIdRepeat) &&
+          job.status === "pending" &&
+          job.requested_at < pendingStaleBefore
+        ) {
+          job.status = "failed";
+          job.updated_at = updatedAt;
+          job.finished_at = finishedAt;
+          job.error_message =
+            "stale workstation attach job expired before host accepted the request";
+          expired.push({ ...job });
+        }
+      }
+      return okResult(expired as T[], { changes: expired.length });
     }
     if (
       this.query.includes("FROM workstation_credentials") &&
@@ -9679,12 +9840,8 @@ class FakeD1Statement implements D1PreparedStatement {
       );
     }
     if (this.query.includes("FROM workstation_attach_jobs")) {
-      const [ownerPrincipal, workstationId, staleBefore, limitValue] = this.values as [
-        string,
-        string,
-        string,
-        number,
-      ];
+      const [ownerPrincipal, workstationId, pendingStaleBefore, staleBefore, limitValue] = this
+        .values as [string, string, string, string, number];
       const limit = Number.isFinite(limitValue) ? limitValue : Number.POSITIVE_INFINITY;
       return okResult(
         [...this.db.workstationAttachJobs.values()]
@@ -9692,7 +9849,7 @@ class FakeD1Statement implements D1PreparedStatement {
             (job) =>
               job.owner_principal === ownerPrincipal &&
               job.workstation_id === workstationId &&
-              isActiveWorkstationAttachJob(job, staleBefore),
+              isActiveWorkstationAttachJob(job, { pendingStaleBefore, staleBefore }),
           )
           .sort((left, right) => left.requested_at.localeCompare(right.requested_at))
           .slice(0, limit) as T[],

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2422,6 +2422,107 @@ describe("Worker artifact routes", () => {
     assert.equal(body.workstations[0]?.is_default, true);
   });
 
+  it("deregisters an owned workstation, deletes its lease, and pushes went_offline once", async () => {
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ OWNER_COMPUTE_INDEX: compute, WORKSTATION_EVENTS: events });
+    const ownerPrincipal = "user:dev:alice";
+    const workstationId = "ws-lab2";
+    const objectName = workstationEventsObjectName(ownerPrincipal, workstationId);
+    seedWorkstation(env, { ownerPrincipal, workstationId });
+    seedWorkstationLease(compute, {
+      ownerPrincipal,
+      workstationId,
+      lastSeenAt: new Date().toISOString(),
+    });
+    env.DB.workstationDefaults.set(ownerPrincipal, workstationId);
+
+    const deleted = await worker.fetch(
+      new Request(`http://localhost/api/workstations/${workstationId}`, {
+        method: "DELETE",
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(deleted.status, 200);
+    assert.deepEqual(await deleted.json(), {
+      ok: true,
+      workstation_id: workstationId,
+      deregistered: true,
+    });
+    assert.equal(compute.leases.has(workstationId), false);
+    assert.equal(env.DB.workstations.has(workstationKey(ownerPrincipal, workstationId)), false);
+    assert.equal(env.DB.workstationDefaults.has(ownerPrincipal), false);
+
+    const wentOffline = events.requests.filter(
+      (entry) =>
+        entry.objectName === objectName &&
+        new URL(entry.url).pathname === "/notify" &&
+        (entry.body as { event?: string } | null)?.event === "went_offline",
+    );
+    assert.equal(wentOffline.length, 1);
+    assert.deepEqual(wentOffline[0]?.body, {
+      event: "went_offline",
+      workstation_id: workstationId,
+      reason: "workstation deregistered",
+    });
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      default_workstation_id: string | null;
+      workstations: Array<Record<string, unknown>>;
+    };
+    assert.equal(body.default_workstation_id, null);
+    assert.deepEqual(body.workstations, []);
+  });
+
+  it("does not let another principal deregister a workstation", async () => {
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ OWNER_COMPUTE_INDEX: compute, WORKSTATION_EVENTS: events });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationLease(compute, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt: new Date().toISOString(),
+    });
+
+    const deleted = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2", {
+        method: "DELETE",
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "bob",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(deleted.status, 404);
+    assert.equal(compute.leases.has("ws-lab2"), true);
+    assert.equal(env.DB.workstations.has(workstationKey("user:dev:alice", "ws-lab2")), true);
+    assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/notify"));
+  });
+
   it("forwards user-owned workstation event socket upgrades", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
@@ -8572,6 +8673,7 @@ interface FakeOwnerComputeIndexRequest {
   notebookIds: string[];
   objectName: string;
   pathname: string;
+  workstationId: string | null;
 }
 
 class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
@@ -8591,8 +8693,33 @@ class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
       fetch: async (request: Request) => {
         const pathname = new URL(request.url).pathname;
         if (pathname === "/lease/list") {
-          requests.push({ objectName, notebookIds: [], pathname });
+          requests.push({ objectName, notebookIds: [], pathname, workstationId: null });
           return Response.json({ ok: true, leases: Array.from(this.leases.values()) });
+        }
+        if (pathname === "/lease/delete") {
+          const payload = (await request.json().catch(() => ({}))) as {
+            owner_principal?: string;
+            workstation_id?: string;
+          };
+          const workstationId =
+            typeof payload.workstation_id === "string" ? payload.workstation_id : null;
+          requests.push({ objectName, notebookIds: [], pathname, workstationId });
+          const lease = workstationId ? this.leases.get(workstationId) : undefined;
+          if (!workstationId || !lease || lease.owner_principal !== payload.owner_principal) {
+            return Response.json({
+              ok: true,
+              deleted: false,
+              went_offline: false,
+              reason: null,
+            });
+          }
+          this.leases.delete(workstationId);
+          return Response.json({
+            ok: true,
+            deleted: true,
+            went_offline: lease.online,
+            reason: lease.offline_reason,
+          });
         }
         if (pathname !== "/list") {
           return Response.json({ error: "not found" }, { status: 404 });
@@ -8601,7 +8728,7 @@ class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
           notebook_ids?: string[];
         };
         const notebookIds = Array.isArray(payload.notebook_ids) ? payload.notebook_ids : [];
-        requests.push({ objectName, notebookIds, pathname });
+        requests.push({ objectName, notebookIds, pathname, workstationId: null });
         return Response.json({
           ok: true,
           sessions: notebookIds.map((notebookId) => sessions.get(notebookId)).filter(Boolean),
@@ -9026,6 +9153,17 @@ class FakeD1Statement implements D1PreparedStatement {
       const [ownerPrincipal, workstationId] = this.values as [string, string, string];
       this.db.workstationDefaults.set(ownerPrincipal, workstationId);
       return okResult(undefined, { changes: 1 });
+    } else if (this.query.includes("DELETE FROM workstation_defaults")) {
+      const [ownerPrincipal, workstationId] = this.values as [string, string];
+      if (this.db.workstationDefaults.get(ownerPrincipal) === workstationId) {
+        this.db.workstationDefaults.delete(ownerPrincipal);
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("DELETE FROM workstations")) {
+      const [ownerPrincipal, workstationId] = this.values as [string, string];
+      const deleted = this.db.workstations.delete(workstationKey(ownerPrincipal, workstationId));
+      return okResult(undefined, { changes: deleted ? 1 : 0 });
     } else if (this.query.includes("INSERT INTO workstation_attach_jobs")) {
       const [id, notebookId, ownerPrincipal, workstationId, actorLabel, requestedAt, updatedAt] =
         this.values as [string, string, string, string, string, string, string];

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3873,11 +3873,16 @@ describe("Worker artifact routes", () => {
     );
 
     assert.equal(response.status, 200);
+    const body = (await response.json()) as { job: { job_id: string; status: string } };
+    assert.equal(body.job.job_id, "job-claim");
+    assert.equal(body.job.status, "accepted");
+    assert.equal(env.DB.workstationAttachJobs.get("job-claim")?.status, "accepted");
+    assert.ok(env.DB.workstationAttachJobs.get("job-claim")?.accepted_at);
     assert.equal(attachmentStatus, "connecting");
     assert.equal(attachmentMessage, "Lab2 accepted the request and is starting compute.");
   });
 
-  it("rejects delayed workstation status patches that would move a job backward", async () => {
+  it("no-ops delayed workstation status patches that would move a job backward", async () => {
     let publishCount = 0;
     const env = fakeEnv({
       NOTEBOOK_ROOMS: {
@@ -4017,7 +4022,7 @@ describe("Worker artifact routes", () => {
     ]);
   });
 
-  it("rejects late workstation status patches after a replacement cancelled the job", async () => {
+  it("keeps terminal workstation attach jobs sticky after replacement cancellation", async () => {
     let publishCount = 0;
     const env = fakeEnv({
       NOTEBOOK_ROOMS: {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -30,6 +30,7 @@ import type {
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
 import type { NotebookComputeSessionSummary } from "runtimed";
+import type { WorkstationLeaseRecord } from "../src/compute-session-index.ts";
 import { NotebookHandle, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
   WORKSTATION_ATTACH_JOB_STALE_MS,
@@ -2490,6 +2491,49 @@ describe("Worker artifact routes", () => {
     assert.equal(statusRequest?.objectName, objectName);
   });
 
+  it("does not probe event-socket status when a fresh offline lease decides the list row", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = fakeEnv({ OWNER_COMPUTE_INDEX: compute, WORKSTATION_EVENTS: events });
+    const now = Date.now();
+    const lastSeenAt = new Date(now - 4 * 60_000).toISOString();
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt,
+    });
+    seedWorkstationLease(compute, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt,
+      online: false,
+    });
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      workstations: Array<{
+        workstation_id: string;
+        status: string;
+      }>;
+    };
+    assert.equal(body.workstations[0]?.workstation_id, "ws-lab2");
+    assert.equal(body.workstations[0]?.status, "offline");
+    assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
+  });
+
   it("does not fan out event-socket status checks for fresh workstation rows", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
@@ -3000,6 +3044,78 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.workstation_id, "ws-lab2");
     assert.ok(events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
     assert.ok(events.requests.some((entry) => new URL(entry.url).pathname === "/notify"));
+  });
+
+  it("rejects attach when a fresh offline lease outvotes a lingering event socket", async () => {
+    const roomRequests: string[] = [];
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = fakeEnv({
+      OWNER_COMPUTE_INDEX: compute,
+      WORKSTATION_EVENTS: events,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            roomRequests.push(new URL(request.url).pathname);
+            return Response.json({ ok: true, changed: true });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    const now = Date.now();
+    const lastSeenAt = new Date(now - 4 * 60_000).toISOString();
+    seedNotebook(env, "attach-lease-demo");
+    seedAcl(env, { notebookId: "attach-lease-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt,
+    });
+    seedWorkstationLease(compute, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt,
+      online: false,
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-lease-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 409);
+    const body = (await attach.json()) as {
+      error?: string;
+      workstation?: { workstation_id?: string; status?: string };
+    };
+    assert.equal(body.error, "workstation is not online");
+    assert.equal(body.workstation?.workstation_id, "ws-lab2");
+    assert.equal(body.workstation?.status, "offline");
+    assert.deepEqual(roomRequests, ["/internal/n/attach-lease-demo/runtime-state-repair"]);
+    assert.equal(env.DB.workstationAttachJobs.size, 0);
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "attach-lease-demo" &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "runtime_peer",
+      ),
+      false,
+    );
+    assert.ok(events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
+    assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/notify"));
   });
 
   it("reuses the active workstation attach job for repeated owner requests", async () => {
@@ -7635,6 +7751,27 @@ function seedWorkstation(
   });
 }
 
+function seedWorkstationLease(
+  compute: FakeOwnerComputeIndexNamespace,
+  input: {
+    ownerPrincipal: string;
+    workstationId: string;
+    lastSeenAt: string;
+    leaseExpiresAt?: number;
+    offlineReason?: string | null;
+    online?: boolean;
+  },
+): void {
+  compute.leases.set(input.workstationId, {
+    workstation_id: input.workstationId,
+    owner_principal: input.ownerPrincipal,
+    last_seen_at: input.lastSeenAt,
+    lease_expires_at: input.leaseExpiresAt ?? Date.now() + 60_000,
+    online: input.online ?? true,
+    offline_reason: input.offlineReason ?? null,
+  });
+}
+
 function seedWorkstationAttachJob(
   env: FakeEnv,
   input: {
@@ -8217,10 +8354,12 @@ class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
 interface FakeOwnerComputeIndexRequest {
   notebookIds: string[];
   objectName: string;
+  pathname: string;
 }
 
 class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
   readonly requests: FakeOwnerComputeIndexRequest[] = [];
+  readonly leases = new Map<string, WorkstationLeaseRecord>();
   readonly sessions = new Map<string, NotebookComputeSessionSummary>();
 
   idFromName(name: string): { toString(): string } {
@@ -8234,6 +8373,10 @@ class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
     return {
       fetch: async (request: Request) => {
         const pathname = new URL(request.url).pathname;
+        if (pathname === "/lease/list") {
+          requests.push({ objectName, notebookIds: [], pathname });
+          return Response.json({ ok: true, leases: Array.from(this.leases.values()) });
+        }
         if (pathname !== "/list") {
           return Response.json({ error: "not found" }, { status: 404 });
         }
@@ -8241,7 +8384,7 @@ class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
           notebook_ids?: string[];
         };
         const notebookIds = Array.isArray(payload.notebook_ids) ? payload.notebook_ids : [];
-        requests.push({ objectName, notebookIds });
+        requests.push({ objectName, notebookIds, pathname });
         return Response.json({
           ok: true,
           sessions: notebookIds.map((notebookId) => sessions.get(notebookId)).filter(Boolean),

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3152,6 +3152,118 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.workstationAttachJobs.size, 1);
   });
 
+  it("switches active workstation attach jobs to the newly attached workstation", async () => {
+    let runtimeStateRequest: Request | undefined;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            runtimeStateRequest = request;
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab-a" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab-b" });
+    seedWorkstationAttachJob(env, {
+      id: "running-job-a",
+      notebookId: "attach-demo",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab-a",
+      status: "running",
+      updatedAt: new Date().toISOString(),
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab-b" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const body = (await attach.json()) as {
+      job: { job_id: string; status: string; workstation_id: string };
+    };
+    assert.notEqual(body.job.job_id, "running-job-a");
+    assert.equal(body.job.status, "pending");
+    assert.equal(body.job.workstation_id, "ws-lab-b");
+    assert.equal(env.DB.workstationAttachJobs.get("running-job-a")?.status, "cancelled");
+    assert.match(
+      env.DB.workstationAttachJobs.get("running-job-a")?.error_message ?? "",
+      /replaced by a newer workstation attach request/,
+    );
+    assert.ok(runtimeStateRequest);
+    const payload = (await runtimeStateRequest.json()) as {
+      attachment?: {
+        status?: string;
+        status_message?: string | null;
+        workstation_id?: string;
+        runtime_session_id?: string | null;
+      };
+      close_runtime_peers?: boolean;
+      close_reason?: string;
+    };
+    assert.equal(payload.close_runtime_peers, true);
+    assert.equal(payload.close_reason, "workstation attachment switched");
+    assert.equal(payload.attachment?.workstation_id, "ws-lab-b");
+  });
+
+  it("enforces one active workstation attach job per notebook owner", async () => {
+    const env = fakeEnv();
+    const now = new Date().toISOString();
+    const insert = (id: string, workstationId: string) =>
+      env.DB.prepare(
+        `INSERT INTO workstation_attach_jobs (
+           id,
+           notebook_id,
+           owner_principal,
+           workstation_id,
+           status,
+           requested_by_actor_label,
+           requested_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`,
+      )
+        .bind(
+          id,
+          "attach-demo",
+          "user:dev:alice",
+          workstationId,
+          "user:dev:alice/browser:tab",
+          now,
+          now,
+        )
+        .run();
+
+    await insert("pending-a", "ws-lab-a");
+    await assert.rejects(
+      insert("pending-b", "ws-lab-b"),
+      /UNIQUE constraint failed: workstation_attach_jobs.notebook_id, workstation_attach_jobs.owner_principal/,
+    );
+    const active = env.DB.workstationAttachJobs.get("pending-a");
+    assert.ok(active);
+    active.status = "cancelled";
+
+    await insert("pending-b", "ws-lab-b");
+    assert.equal(env.DB.workstationAttachJobs.get("pending-b")?.workstation_id, "ws-lab-b");
+  });
+
   it("expires stale running attach jobs before creating a replacement", async () => {
     const env = fakeEnv();
     seedNotebook(env, "attach-demo");
@@ -7807,6 +7919,10 @@ function isActiveWorkstationAttachJob(job: WorkstationAttachJobRow, staleBefore:
   );
 }
 
+function isActiveWorkstationAttachJobStatus(status: WorkstationAttachJobRow["status"]): boolean {
+  return status === "pending" || status === "accepted" || status === "running";
+}
+
 function seedPendingInvite(
   env: FakeEnv,
   input: {
@@ -8812,6 +8928,17 @@ class FakeD1Statement implements D1PreparedStatement {
     } else if (this.query.includes("INSERT INTO workstation_attach_jobs")) {
       const [id, notebookId, ownerPrincipal, workstationId, actorLabel, requestedAt, updatedAt] =
         this.values as [string, string, string, string, string, string, string];
+      const duplicate = [...this.db.workstationAttachJobs.values()].find(
+        (job) =>
+          job.notebook_id === notebookId &&
+          job.owner_principal === ownerPrincipal &&
+          isActiveWorkstationAttachJobStatus(job.status),
+      );
+      if (duplicate) {
+        throw new Error(
+          "D1_ERROR: UNIQUE constraint failed: workstation_attach_jobs.notebook_id, workstation_attach_jobs.owner_principal",
+        );
+      }
       this.db.workstationAttachJobs.set(id, {
         id,
         notebook_id: notebookId,
@@ -8830,14 +8957,18 @@ class FakeD1Statement implements D1PreparedStatement {
       this.query.includes("UPDATE workstation_attach_jobs") &&
       this.query.includes("stale workstation attach job expired")
     ) {
-      const [updatedAt, finishedAt, notebookId, ownerPrincipal, workstationId, staleBefore] = this
-        .values as [string, string, string, string, string, string];
+      const [updatedAt, finishedAt, notebookId, ownerPrincipal, staleBefore] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
       let changes = 0;
       for (const job of this.db.workstationAttachJobs.values()) {
         if (
           job.notebook_id === notebookId &&
           job.owner_principal === ownerPrincipal &&
-          job.workstation_id === workstationId &&
           (job.status === "accepted" || job.status === "running") &&
           job.updated_at < staleBefore
         ) {
@@ -8853,14 +8984,18 @@ class FakeD1Statement implements D1PreparedStatement {
       this.query.includes("UPDATE workstation_attach_jobs") &&
       this.query.includes("SET status = 'cancelled'")
     ) {
-      const [updatedAt, finishedAt, errorMessage, notebookId, ownerPrincipal, workstationId] = this
-        .values as [string, string, string, string, string, string];
+      const [updatedAt, finishedAt, errorMessage, notebookId, ownerPrincipal] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
       let changes = 0;
       for (const job of this.db.workstationAttachJobs.values()) {
         if (
           job.notebook_id === notebookId &&
           job.owner_principal === ownerPrincipal &&
-          job.workstation_id === workstationId &&
           (job.status === "pending" || job.status === "accepted" || job.status === "running")
         ) {
           job.status = "cancelled";
@@ -9383,19 +9518,13 @@ class FakeD1Statement implements D1PreparedStatement {
     }
     if (this.query.includes("FROM workstation_attach_jobs")) {
       if (this.query.includes("notebook_id = ?")) {
-        const [notebookId, ownerPrincipal, workstationId, staleBefore] = this.values as [
-          string,
-          string,
-          string,
-          string,
-        ];
+        const [notebookId, ownerPrincipal, staleBefore] = this.values as [string, string, string];
         return (
           ([...this.db.workstationAttachJobs.values()]
             .filter(
               (job) =>
                 job.notebook_id === notebookId &&
                 job.owner_principal === ownerPrincipal &&
-                job.workstation_id === workstationId &&
                 isActiveWorkstationAttachJob(job, staleBefore),
             )
             .sort((left, right) => right.requested_at.localeCompare(left.requested_at))[0] as

--- a/apps/notebook-cloud/test/workstation-status.test.ts
+++ b/apps/notebook-cloud/test/workstation-status.test.ts
@@ -51,11 +51,11 @@ describe("workstationStatusForResponse", () => {
     assert.equal(workstationStatusForResponse(stale, NOW, null, null), "offline");
   });
 
-  it("lets a live event socket override a swept lease", () => {
+  it("lets a fresh offline lease beat a connected event socket", () => {
     const swept = lease({ online: false });
     assert.equal(
       workstationStatusForResponse(row(), NOW, { connected: true, connections: 1 }, swept),
-      "online",
+      "offline",
     );
   });
 

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -235,6 +235,26 @@ const EMPTY_STATE: CloudWorkstationsState = {
   pairing: null,
 };
 
+function compareRegisteredWorkstationStableId(
+  left: NotebookRegisteredWorkstation,
+  right: NotebookRegisteredWorkstation,
+): number {
+  return left.id.localeCompare(right.id);
+}
+
+function registryWithStableWorkstationOrder(
+  registry: CloudWorkstationsRegistry,
+): CloudWorkstationsRegistry {
+  if (registry.workstations.length < 2) {
+    return registry;
+  }
+  const workstations = [...registry.workstations].sort(compareRegisteredWorkstationStableId);
+  const alreadyStable = workstations.every(
+    (workstation, index) => workstation === registry.workstations[index],
+  );
+  return alreadyStable ? registry : { ...registry, workstations };
+}
+
 /** Dedup identity for the registry projection. */
 export function cloudWorkstationsRegistryEquals(
   a: CloudWorkstationsRegistry,
@@ -862,7 +882,13 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
 
   /** Apply a resolved registry: mark ready and clear the error. */
   private applyRegistrySuccess(registry: CloudWorkstationsRegistry): void {
-    this.updateState((state) => ({ ...state, status: "ready", registry, error: null }));
+    const orderedRegistry = registryWithStableWorkstationOrder(registry);
+    this.updateState((state) => ({
+      ...state,
+      status: "ready",
+      registry: orderedRegistry,
+      error: null,
+    }));
   }
 
   /**


### PR DESCRIPTION
Fixes the multi-workstation strangeness in the cloud control plane: execution landing on the wrong box, dead workstations reading online, attaches that hang forever, removed boxes lingering, and the rail list reordering under the user. Completes the read-side portion of the Option C plan in `docs/memos/byoc-control-plane.md` on top of the #3949 lease/alarm spine.

The invariant behind the headline fix: a notebook is one Jupyter kernel on one compute instance. Attach is single-active per notebook, and switching boxes detaches the old one. GPU burst-out belongs to an orchestration layer inside the notebook (Metaflow and friends), not to the notebook holding multiple runtimes.

## The bug this started from

Attach to workstation B while default box A holds the prior attach job: nothing cancelled A, both hosts published into the room's single runtime-peer slot last-write-wins, and restart-and-run-all executed on A. The active-job uniqueness was scoped per workstation, so "one active attach per notebook" was never enforced. That invariant now lives in the schema: a partial unique index on `(notebook_id, owner_principal)` for live states, and attaching a different box cancels the prior job and closes its runtime peers.

## Commits

1. **Lease read authority.** The #3949 registry lease is the proactive liveness truth, but the status read ranked the events-DO socket first and the attach precheck skipped the lease entirely, so a dead box read online for the whole socket-reap window (~4.5 min) and attach could fire against a dead host (stuck-queued, the #3947 family). Lease-first everywhere, with one shared freshness helper: a lagged or dropped lease write never overrides a newer D1 heartbeat.
2. **One active workstation per notebook.** The schema invariant plus close-the-loser signaling described above.
3. **Pending attach-job expiry on the poll path.** Pending jobs previously expired only at the top of the next create, so a failed attach spun "attaching" forever. Pending rows now expire after a conservative cold-start window (3 min) on the host poll path, and expiry drives runtime-state repair.
4. **Deregister verb.** `DELETE` on a workstation drops its lease immediately and pushes `went_offline` exactly once, instead of lingering online up to the TTL and then firing a phantom offline push. Owner-scoped, guarded against double-notify with a concurrent sweep.
5. **Stable rail order.** The workstation list sorts by a stable key; liveness renders as styling, never as position. Rows no longer jump while boxes go idle.
6. **Race fixes from an adversarial concurrency review** (see below): runtime-state repair is guarded by job identity, cancel+insert on the switch path is one atomic `batch()`, and the runtime schema path converges existing DBs to the new unique index on its own (no migration-ordering trap).
7. **Lease honored on every read surface**: the list-probe filter skips the cross-DO presence probe whenever a fresh lease decides the row, and the attach-jobs poll endpoint response now carries the lease like every other surface.

## Review protocol

Each slice was implemented by Codex and adversarially reviewed by an opposing Claude model before the next slice stacked on it; a cross-slice verify ran the full gates and consistency checks at the end (read and attach paths share one freshness rule; the single-active invariant holds across every interleaving the harness models).

A dedicated concurrency review then attacked the awaits: 16 interleavings ruled out with reasons (the partial unique index is the serialization point for racing creates; `UPDATE ... RETURNING` makes double-expiry idempotent; expiry/list time predicates are exact complements; DO input gates cover the registry sweep; a heartbeat writes D1 before the lease, so lease freshness is monotone). The four real findings it produced are fixed in commit 6.

One planned slice was dropped by its reviewer, deliberately: a push-side went_offline freshness guard is unimplementable in the registry DO as designed (the DO does not hold the paired D1 timestamp at sweep time). The residual is a rare false `went_offline` push after a dropped lease write; the read side already masks it via the freshness rule. Recorded here instead of half-built.

## Accepted residuals and follow-ups

- Unversioned room attachment publishes are last-write-wins; a raced publish can briefly re-point execution routing until the next status heartbeat. The right fix is a monotonic guard in the room materializer (Rust/WASM), deferred to the runtime idle-TTL arc which touches the same code.
- Pending expiry has no host-independent driver when a host is fully dead; the registry alarm is the natural driver, same follow-up arc.
- Single-active is scoped per (notebook, owner). Two distinct principals with attach rights could each hold an active job; the room's single slot still applies. Multi-principal attach semantics are future work.
- Hosts whose cold boot exceeds 3 minutes before first poll will find their pending job expired; the constant is a named, documented ceiling.

## Deploy note

Migration `0008` renames the active-jobs unique index to the 2-column form. The runtime schema path also converges existing DBs by dropping the legacy index name and creating the new one, so the invariant does not depend on applying the migration before deploying. Fresh, migrated, and unmigrated databases all end at the same index.
