### PR TITLE
feat(cloud): runtime idle TTL and lazy launch-on-execute

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -80,6 +80,10 @@ export function buildAttachJobSpawnPlan({
     displayName,
   ];
 
+  if (job.trigger === "resume") {
+    args.splice(args.length - 2, 0, "--launch-mode", "execute");
+  }
+
   if (typeof job.notebook_path === "string" && job.notebook_path.length > 0) {
     args.push("--notebook-path", job.notebook_path);
   }

--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -2,7 +2,14 @@ import type { DurableObjectNamespace, DurableObjectState, Env } from "./cloudfla
 import { isNotebookComputeSessionSummary, type NotebookComputeSessionSummary } from "runtimed";
 import { json } from "./http-responses.ts";
 import { cloudLog, errorMessage } from "./observability.ts";
-import { workstationEventsObjectName } from "./workstation-events.ts";
+import {
+  failActiveWorkstationAttachJobsForWorkstation,
+  type WorkstationAttachJobRow,
+} from "./storage.ts";
+import {
+  workstationEventsObjectName,
+  type WorkstationAttachJobNotification,
+} from "./workstation-events.ts";
 
 const COMPUTE_SESSION_KEY_PREFIX = "session:";
 const WORKSTATION_LEASE_KEY_PREFIX = "lease:";
@@ -16,6 +23,9 @@ export const WORKSTATION_LEASE_GC_MS = 24 * 60 * 60_000;
 // Hard ceiling on a single went_offline delivery so a slow or dead events DO
 // cannot keep the background notify (and thus the registry DO) alive.
 const WORKSTATION_WENT_OFFLINE_NOTIFY_TIMEOUT_MS = 5_000;
+const WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_MESSAGE =
+  "workstation lease expired: no heartbeat within the lease window";
+const WORKSTATION_LEASE_RUNTIME_REPAIR_TIMEOUT_MS = 5_000;
 
 /**
  * A workstation liveness lease held in the owner-scoped registry DO. The
@@ -196,6 +206,7 @@ export class OwnerComputeIndex {
   private async sweepExpiredLeases(now: number): Promise<number> {
     const leases = await this.readLeases();
     const wentOffline: WorkstationLeaseRecord[] = [];
+    const failedAttachJobs: WorkstationAttachJobRow[] = [];
     for (const [key, lease] of leases) {
       // Drop leases that have stayed offline well past their window so the DO
       // does not accumulate dead records.
@@ -204,12 +215,14 @@ export class OwnerComputeIndex {
         continue;
       }
       if (lease.online && lease.lease_expires_at <= now) {
+        const failedJobs = await this.failActiveAttachJobsForExpiredLease(lease);
         const offline: WorkstationLeaseRecord = {
           ...lease,
           online: false,
           offline_reason: "lease expired: no heartbeat within the lease window",
         };
         await this.state.storage.put(key, offline);
+        failedAttachJobs.push(...failedJobs);
         wentOffline.push(offline);
         cloudLog("info", "fleet_registry.lease_expired", {
           owner_principal: lease.owner_principal,
@@ -227,13 +240,58 @@ export class OwnerComputeIndex {
     // events DO must not keep the handler running, which would pin this DO
     // resident and break hibernation. waitUntil lets the handler return now
     // while the bounded-timeout delivery drains in the background.
-    const notify = this.notifyWentOffline(wentOffline);
+    const notify = this.notifyExpiredLeaseSideEffects(wentOffline, failedAttachJobs);
     if (this.state.waitUntil) {
       this.state.waitUntil(notify);
     } else {
       void notify;
     }
     return wentOffline.length;
+  }
+
+  private async failActiveAttachJobsForExpiredLease(
+    lease: WorkstationLeaseRecord,
+  ): Promise<WorkstationAttachJobRow[]> {
+    if (!this.env.DB) {
+      return [];
+    }
+    try {
+      const failedJobs = await failActiveWorkstationAttachJobsForWorkstation(this.env, {
+        ownerPrincipal: lease.owner_principal,
+        workstationId: lease.workstation_id,
+        errorMessage: WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_MESSAGE,
+      });
+      if (failedJobs.length > 0) {
+        cloudLog("info", "fleet_registry.attach_jobs_failed_for_expired_lease", {
+          owner_principal: lease.owner_principal,
+          workstation_id: lease.workstation_id,
+          job_count: failedJobs.length,
+          counter: "fleet_registry_attach_jobs_failed_for_expired_lease",
+          counter_delta: failedJobs.length,
+        });
+      }
+      return failedJobs;
+    } catch (error) {
+      cloudLog("warn", "fleet_registry.attach_jobs_fail_for_expired_lease_failed", {
+        owner_principal: lease.owner_principal,
+        workstation_id: lease.workstation_id,
+        error: errorMessage(error),
+        counter: "fleet_registry_attach_jobs_fail_for_expired_lease_failed",
+        counter_delta: 1,
+      });
+      throw error;
+    }
+  }
+
+  private async notifyExpiredLeaseSideEffects(
+    wentOffline: WorkstationLeaseRecord[],
+    failedAttachJobs: WorkstationAttachJobRow[],
+  ): Promise<void> {
+    await Promise.allSettled([
+      this.notifyWentOffline(wentOffline),
+      this.notifyAttachJobsFailed(failedAttachJobs),
+      this.repairRuntimeStateForFailedAttachJobs(failedAttachJobs),
+    ]);
   }
 
   private async notifyWentOffline(leases: WorkstationLeaseRecord[]): Promise<void> {
@@ -265,6 +323,100 @@ export class OwnerComputeIndex {
             workstation_id: lease.workstation_id,
             error: errorMessage(error),
             counter: "fleet_registry_went_offline_notify_failed",
+            counter_delta: 1,
+          });
+        }
+      }),
+    );
+  }
+
+  private async notifyAttachJobsFailed(jobs: WorkstationAttachJobRow[]): Promise<void> {
+    const namespace = this.env.WORKSTATION_EVENTS;
+    if (!namespace || jobs.length === 0) {
+      return;
+    }
+    await Promise.allSettled(
+      jobs.map(async (job) => {
+        try {
+          const id = namespace.idFromName(
+            workstationEventsObjectName(job.owner_principal, job.workstation_id),
+          );
+          const notification: WorkstationAttachJobNotification = {
+            event: "attach_jobs",
+            workstation_id: job.workstation_id,
+            job_id: job.id,
+            notebook_id: job.notebook_id,
+            status: job.status,
+            requested_at: job.requested_at,
+            updated_at: job.updated_at,
+          };
+          await namespace.get(id).fetch(
+            new Request("https://workstation-events.internal/notify", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(notification),
+              signal: AbortSignal.timeout(WORKSTATION_WENT_OFFLINE_NOTIFY_TIMEOUT_MS),
+            }),
+          );
+        } catch (error) {
+          cloudLog("warn", "fleet_registry.attach_job_notify_failed", {
+            owner_principal: job.owner_principal,
+            workstation_id: job.workstation_id,
+            job_id: job.id,
+            error: errorMessage(error),
+            counter: "fleet_registry_attach_job_notify_failed",
+            counter_delta: 1,
+          });
+        }
+      }),
+    );
+  }
+
+  private async repairRuntimeStateForFailedAttachJobs(
+    jobs: WorkstationAttachJobRow[],
+  ): Promise<void> {
+    if (jobs.length === 0) {
+      return;
+    }
+    const namespace = this.env.NOTEBOOK_ROOMS;
+    await Promise.allSettled(
+      jobs.map(async (job) => {
+        try {
+          const id = namespace.idFromName(job.notebook_id);
+          const response = await namespace.get(id).fetch(
+            new Request(
+              `https://notebook-room.internal/internal/n/${encodeURIComponent(
+                job.notebook_id,
+              )}/runtime-state-repair`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  expected_runtime_session_id: job.id,
+                  reason: job.error_message ?? WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_MESSAGE,
+                }),
+                signal: AbortSignal.timeout(WORKSTATION_LEASE_RUNTIME_REPAIR_TIMEOUT_MS),
+              },
+            ),
+          );
+          if (response.ok || response.status === 409) {
+            return;
+          }
+          cloudLog("warn", "fleet_registry.attach_job_runtime_state_repair_failed", {
+            notebook_id: job.notebook_id,
+            workstation_id: job.workstation_id,
+            job_id: job.id,
+            response_status: response.status,
+            counter: "fleet_registry_attach_job_runtime_state_repair_failed",
+            counter_delta: 1,
+          });
+        } catch (error) {
+          cloudLog("warn", "fleet_registry.attach_job_runtime_state_repair_failed", {
+            notebook_id: job.notebook_id,
+            workstation_id: job.workstation_id,
+            job_id: job.id,
+            error: errorMessage(error),
+            counter: "fleet_registry_attach_job_runtime_state_repair_failed",
             counter_delta: 1,
           });
         }

--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -25,6 +25,7 @@ export const WORKSTATION_LEASE_GC_MS = 24 * 60 * 60_000;
 const WORKSTATION_WENT_OFFLINE_NOTIFY_TIMEOUT_MS = 5_000;
 const WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_MESSAGE =
   "workstation lease expired: no heartbeat within the lease window";
+const WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_TIMEOUT_MS = 5_000;
 const WORKSTATION_LEASE_RUNTIME_REPAIR_TIMEOUT_MS = 5_000;
 
 /**
@@ -206,7 +207,6 @@ export class OwnerComputeIndex {
   private async sweepExpiredLeases(now: number): Promise<number> {
     const leases = await this.readLeases();
     const wentOffline: WorkstationLeaseRecord[] = [];
-    const failedAttachJobs: WorkstationAttachJobRow[] = [];
     for (const [key, lease] of leases) {
       // Drop leases that have stayed offline well past their window so the DO
       // does not accumulate dead records.
@@ -215,14 +215,12 @@ export class OwnerComputeIndex {
         continue;
       }
       if (lease.online && lease.lease_expires_at <= now) {
-        const failedJobs = await this.failActiveAttachJobsForExpiredLease(lease);
         const offline: WorkstationLeaseRecord = {
           ...lease,
           online: false,
           offline_reason: "lease expired: no heartbeat within the lease window",
         };
         await this.state.storage.put(key, offline);
-        failedAttachJobs.push(...failedJobs);
         wentOffline.push(offline);
         cloudLog("info", "fleet_registry.lease_expired", {
           owner_principal: lease.owner_principal,
@@ -240,7 +238,7 @@ export class OwnerComputeIndex {
     // events DO must not keep the handler running, which would pin this DO
     // resident and break hibernation. waitUntil lets the handler return now
     // while the bounded-timeout delivery drains in the background.
-    const notify = this.notifyExpiredLeaseSideEffects(wentOffline, failedAttachJobs);
+    const notify = this.notifyExpiredLeaseSideEffects(wentOffline);
     if (this.state.waitUntil) {
       this.state.waitUntil(notify);
     } else {
@@ -285,13 +283,48 @@ export class OwnerComputeIndex {
 
   private async notifyExpiredLeaseSideEffects(
     wentOffline: WorkstationLeaseRecord[],
-    failedAttachJobs: WorkstationAttachJobRow[],
   ): Promise<void> {
     await Promise.allSettled([
       this.notifyWentOffline(wentOffline),
+      this.failAndNotifyAttachJobsForExpiredLeases(wentOffline),
+    ]);
+  }
+
+  private async failAndNotifyAttachJobsForExpiredLeases(
+    leases: WorkstationLeaseRecord[],
+  ): Promise<void> {
+    if (!this.env.DB || leases.length === 0) {
+      return;
+    }
+    const failedAttachJobs = await this.failActiveAttachJobsForExpiredLeases(leases);
+    await Promise.allSettled([
       this.notifyAttachJobsFailed(failedAttachJobs),
       this.repairRuntimeStateForFailedAttachJobs(failedAttachJobs),
     ]);
+  }
+
+  private async failActiveAttachJobsForExpiredLeases(
+    leases: WorkstationLeaseRecord[],
+  ): Promise<WorkstationAttachJobRow[]> {
+    const timeout = delay(WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_TIMEOUT_MS).then(
+      () => "timeout" as const,
+    );
+    const failures = Promise.allSettled(
+      leases.map((lease) => this.failActiveAttachJobsForExpiredLease(lease)),
+    ).then((results) =>
+      results.flatMap((result) => (result.status === "fulfilled" ? result.value : [])),
+    );
+    const result = await Promise.race([failures, timeout]);
+    if (result === "timeout") {
+      cloudLog("warn", "fleet_registry.attach_jobs_fail_for_expired_lease_timeout", {
+        lease_count: leases.length,
+        timeout_ms: WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_TIMEOUT_MS,
+        counter: "fleet_registry_attach_jobs_fail_for_expired_lease_timeout",
+        counter_delta: 1,
+      });
+      return [];
+    }
+    return result;
   }
 
   private async notifyWentOffline(leases: WorkstationLeaseRecord[]): Promise<void> {
@@ -768,6 +801,10 @@ function sessionKey(notebookId: string): string {
 
 function leaseKey(workstationId: string): string {
   return `${WORKSTATION_LEASE_KEY_PREFIX}${workstationId}`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function positiveInteger(value: unknown): number | null {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2209,6 +2209,7 @@ async function routeNotebookWorkstationAttachment(
     notebookId,
     ownerPrincipal,
     replaceActive: replaceExisting,
+    trigger: "user_attach",
     workstationId,
     actorLabel: identity.actorLabel,
   });
@@ -3058,6 +3059,7 @@ function workstationAttachJobResponseRow(
     notebook_id: job.notebook_id,
     workstation_id: job.workstation_id,
     status: job.status,
+    trigger: job.trigger,
     requested_at: job.requested_at,
     updated_at: job.updated_at,
     accepted_at: job.accepted_at,

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -4,8 +4,17 @@ import type {
   Env,
   WebSocketRequestResponsePair,
 } from "./cloudflare-types.ts";
-import { projectNotebookComputeSessionSummary, type WorkstationAttachmentState } from "runtimed";
-import { deleteOwnerComputeSession, upsertOwnerComputeSession } from "./compute-session-index.ts";
+import {
+  projectNotebookComputeSessionSummary,
+  projectNotebookWorkstationAttachmentFromClaim,
+  type WorkstationAttachmentState,
+} from "runtimed";
+import {
+  deleteOwnerComputeSession,
+  listWorkstationLeases,
+  upsertOwnerComputeSession,
+  type WorkstationLeaseRecord,
+} from "./compute-session-index.ts";
 import { identityDisplayLabel } from "./display-label.ts";
 import {
   allowsBlobUpload,
@@ -43,11 +52,21 @@ import {
   type SyncFrameBudgetSummary,
 } from "./sync-frame-budget.ts";
 import {
+  createWorkstationAttachJob,
   getNotebookRow,
+  getWorkstationRow,
+  grantNotebookAclRow,
   roomSummaryKey,
+  updateWorkstationAttachJobStatus,
   type NotebookRoomSummary,
   type NotebookRoomSummaryOccupant,
+  type WorkstationAttachJobRow,
+  type WorkstationRow,
 } from "./storage.ts";
+import {
+  workstationEventsObjectName,
+  type WorkstationAttachJobNotification,
+} from "./workstation-events.ts";
 
 interface Peer {
   id: string;
@@ -78,6 +97,7 @@ interface RuntimePeerWorkstationMetadata {
 interface SelectedRuntimePeerSession {
   workstationId: string;
   runtimeSessionId: string | null;
+  status: string;
 }
 
 interface RejectFrameOptions {
@@ -128,18 +148,28 @@ interface PendingRuntimePeerResponse {
 /// kernel that is about to come back: if a `runtime_peer` rejoins inside the
 /// window the alarm is disarmed.
 const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
+export const RUNTIME_IDLE_TTL_MS = 30 * 60_000;
 const ROOM_SUMMARY_REFRESH_MS = 60_000;
 const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
 const REJECTED_FRAME_POLICY_CLOSE_CODE = 1008;
 const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
 const DUPLICATE_RUNTIME_PEER_CLOSE_CODE = 1008;
 const DUPLICATE_RUNTIME_PEER_CLOSE_REASON = "replaced by newer runtime peer";
+const RUNTIME_IDLE_CLOSE_CODE = 1000;
+const RUNTIME_IDLE_CLOSE_REASON = "runtime idle timeout";
+const RUNTIME_IDLE_STATUS_MESSAGE =
+  "Compute stopped after 30 minutes without queued or active execution.";
+const EXECUTION_RESUME_ACTOR_LABEL = "execution resume";
+const WORKSTATION_EVENT_NOTIFY_TIMEOUT_MS = 5_000;
+const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
 
 /// Storage key holding the notebook id whose `runtime_peer` departure armed the
 /// reconciliation alarm. Persisted so a DO that hibernates between the alarm
 /// being set and firing still knows which room to reconcile.
 const RUNTIME_PEER_WATCH_KEY = "runtime_peer_gone_watch";
 const RUNTIME_PEER_WATCH_ALARM_AT_KEY = "runtime_peer_gone_watch_alarm_at";
+const RUNTIME_IDLE_WATCH_KEY = "runtime_idle_watch";
+const RUNTIME_IDLE_WATCH_ALARM_AT_KEY = "runtime_idle_watch_alarm_at";
 const ROOM_SUMMARY_REFRESH_KEY = "room_summary_refresh";
 const ROOM_SUMMARY_REFRESH_ALARM_AT_KEY = "room_summary_refresh_alarm_at";
 const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAction>([
@@ -1175,7 +1205,10 @@ export class NotebookRoom {
         : null;
     if (hostedExecutionAction) {
       const runtimePeer = await this.activeRuntimePeer(notebookId, peer.id);
-      if (!runtimePeer && !(await this.executionCanWaitForStartingRuntime(notebookId))) {
+      if (
+        !runtimePeer &&
+        !(await this.ensureRuntimeForHostedExecution(notebookId, hostedExecutionAction))
+      ) {
         await this.reconcileMissingRuntimePeer(
           notebookId,
           `no runtime peer is attached for ${hostedExecutionAction}`,
@@ -1248,6 +1281,7 @@ export class NotebookRoom {
         this.scheduleRoomHostCheckpoint(notebookId, materializer, "materialized_frame");
       }
       if (result.runtime_state_changed) {
+        this.refreshRuntimeIdleWatch(notebookId);
         this.state.waitUntil(
           this.publishCurrentComputeSessionSummary(notebookId, undefined, {
             onlyIfQueueDepthChanged: true,
@@ -1405,6 +1439,7 @@ export class NotebookRoom {
         this.deliverRoomHostFrames(notebookId, result);
         await this.checkpointRoomHost(notebookId, materializer, "runtime_peer_attachment");
       }
+      this.refreshRuntimeIdleWatch(notebookId);
       await this.publishCurrentComputeSessionSummary(notebookId);
       cloudLog("debug", "room.workstation_attachment.published", {
         notebook_id: notebookId,
@@ -1521,6 +1556,10 @@ export class NotebookRoom {
     const selected = await this.selectedRuntimePeerSession(notebookId);
     if (!selected) {
       return null;
+    }
+
+    if (!runtimePeerSessionStatusAcceptsPeer(selected.status)) {
+      return `selected runtime session is ${selected.status}`;
     }
 
     const presentedWorkstationId = runtimePeerWorkstationId(workstation);
@@ -1683,13 +1722,185 @@ export class NotebookRoom {
     return selected;
   }
 
-  private async executionCanWaitForStartingRuntime(notebookId: string): Promise<boolean> {
+  private async ensureRuntimeForHostedExecution(
+    notebookId: string,
+    action: HostedExecutionRequestAction,
+  ): Promise<boolean> {
     const materializer = this.materializerFor(notebookId);
     if (typeof materializer.getWorkstationAttachment !== "function") {
       return false;
     }
     const attachment = await materializer.getWorkstationAttachment();
-    return attachment?.status === "connecting";
+    if (attachment?.status === "connecting") {
+      return true;
+    }
+    if (!this.env.DB || !attachment || !runtimeAttachmentCanResumeForExecution(attachment)) {
+      return false;
+    }
+    return this.requestRuntimeResumeForExecution(notebookId, attachment, action);
+  }
+
+  private async requestRuntimeResumeForExecution(
+    notebookId: string,
+    attachment: WorkstationAttachmentState,
+    action: HostedExecutionRequestAction,
+  ): Promise<boolean> {
+    const notebook = await getNotebookRow(this.env, notebookId);
+    if (!notebook) {
+      return false;
+    }
+    const ownerPrincipal = notebook.owner_principal;
+    const workstationId = attachment.workstation_id.trim();
+    const workstation = await getWorkstationRow(this.env, ownerPrincipal, workstationId);
+    if (!workstation || !(await this.workstationCanResumeExecution(ownerPrincipal, workstation))) {
+      return false;
+    }
+
+    await grantNotebookAclRow(this.env, {
+      notebookId,
+      subjectKind: "principal",
+      subject: ownerPrincipal,
+      scope: "runtime_peer",
+      actorLabel: EXECUTION_RESUME_ACTOR_LABEL,
+    });
+
+    const attachJob = await createWorkstationAttachJob(this.env, {
+      notebookId,
+      ownerPrincipal,
+      replaceActive: false,
+      workstationId,
+      actorLabel: EXECUTION_RESUME_ACTOR_LABEL,
+    });
+    if (!attachJob) {
+      return false;
+    }
+
+    const nextAttachment = projectNotebookWorkstationAttachmentFromClaim({
+      workstation: workstationAttachmentTargetFromRow(workstation),
+      claim: {
+        status: attachJob.job.status,
+        errorMessage: attachJob.job.error_message,
+        runtimeSessionId: attachJob.job.id,
+        updatedAt: attachJob.job.updated_at,
+      },
+    });
+    const materializer = this.materializerFor(notebookId);
+    const result = await materializer.setWorkstationAttachment(nextAttachment);
+    if (!result.ignored_stale) {
+      this.cacheSelectedRuntimePeerSession(notebookId, nextAttachment);
+    }
+    if (result.changed) {
+      this.deliverRoomHostFrames(notebookId, result);
+      this.scheduleRoomHostCheckpoint(notebookId, materializer, "execution_runtime_resume");
+    }
+    this.state.waitUntil(
+      Promise.allSettled([
+        this.notifyWorkstationAttachJob(ownerPrincipal, attachJob.job),
+        this.publishCurrentComputeSessionSummary(notebookId, nextAttachment),
+      ]).then(() => undefined),
+    );
+    cloudLog("info", "room.execution_runtime_resume.requested", {
+      notebook_id: notebookId,
+      workstation_id: workstationId,
+      job_id: attachJob.job.id,
+      action,
+      counter: "execution_runtime_resume_requests",
+      counter_delta: 1,
+    });
+    return true;
+  }
+
+  private async workstationCanResumeExecution(
+    ownerPrincipal: string,
+    workstation: WorkstationRow,
+  ): Promise<boolean> {
+    if (workstation.status !== "online") {
+      return false;
+    }
+    const leases = await listWorkstationLeases(this.env, ownerPrincipal);
+    const lease = leases.get(workstation.workstation_id) ?? null;
+    if (lease && workstationLeaseIsFreshEnough(workstation, lease)) {
+      return lease.online && lease.lease_expires_at > Date.now();
+    }
+    if (!workstation.last_seen_at) {
+      return true;
+    }
+    const lastSeen = Date.parse(workstation.last_seen_at);
+    return !Number.isFinite(lastSeen) || Date.now() - lastSeen <= WORKSTATION_HEARTBEAT_STALE_MS;
+  }
+
+  private async notifyWorkstationAttachJob(
+    ownerPrincipal: string,
+    job: WorkstationAttachJobRow,
+  ): Promise<void> {
+    const namespace = this.env.WORKSTATION_EVENTS;
+    if (!namespace) {
+      return;
+    }
+    try {
+      const id = namespace.idFromName(
+        workstationEventsObjectName(ownerPrincipal, job.workstation_id),
+      );
+      const notification: WorkstationAttachJobNotification = {
+        event: "attach_jobs",
+        workstation_id: job.workstation_id,
+        job_id: job.id,
+        notebook_id: job.notebook_id,
+        status: job.status,
+        requested_at: job.requested_at,
+        updated_at: job.updated_at,
+      };
+      await namespace.get(id).fetch(
+        new Request("https://workstation-events.internal/notify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(notification),
+          signal: AbortSignal.timeout(WORKSTATION_EVENT_NOTIFY_TIMEOUT_MS),
+        }),
+      );
+    } catch (error) {
+      cloudLog("warn", "room.execution_runtime_resume.notify_failed", {
+        notebook_id: job.notebook_id,
+        workstation_id: job.workstation_id,
+        job_id: job.id,
+        error: errorMessage(error),
+        counter: "execution_runtime_resume_notify_failures",
+        counter_delta: 1,
+      });
+    }
+  }
+
+  private async markSelectedRuntimeSessionCompletedForIdle(notebookId: string): Promise<void> {
+    if (!this.env.DB) {
+      return;
+    }
+    const materializer = this.materializerFor(notebookId);
+    const [notebook, attachment] = await Promise.all([
+      getNotebookRow(this.env, notebookId),
+      materializer.getWorkstationAttachment(),
+    ]);
+    const workstationId = attachment?.workstation_id.trim();
+    const runtimeSessionId = attachment?.runtime_session_id?.trim();
+    if (!notebook || !workstationId || !runtimeSessionId) {
+      return;
+    }
+    const job = await updateWorkstationAttachJobStatus(this.env, {
+      ownerPrincipal: notebook.owner_principal,
+      workstationId,
+      jobId: runtimeSessionId,
+      status: "completed",
+      errorMessage: null,
+    });
+    if (!job || job.status !== "completed") {
+      cloudLog("warn", "room.runtime_idle_watch.attach_job_complete_skipped", {
+        notebook_id: notebookId,
+        workstation_id: workstationId,
+        runtime_session_id: runtimeSessionId,
+        status: job?.status ?? null,
+        counter: "runtime_idle_attach_job_complete_skipped",
+        counter_delta: 1,
+      });
+    }
   }
 
   private async reconcileMissingRuntimePeer(
@@ -2349,6 +2560,39 @@ export class NotebookRoom {
     );
   }
 
+  private refreshRuntimeIdleWatch(notebookId: string): void {
+    const storage = this.state.storage;
+    if (!storage.setAlarm || !storage.deleteAlarm) {
+      return;
+    }
+    this.state.waitUntil(
+      (async () => {
+        try {
+          const activity = await this.materializerFor(notebookId).getRuntimeExecutionActivity();
+          if (!this.hasRuntimePeer() || activity.executing || activity.queueDepth > 0) {
+            await storage.delete(RUNTIME_IDLE_WATCH_KEY);
+            await storage.delete(RUNTIME_IDLE_WATCH_ALARM_AT_KEY);
+            await this.rescheduleRoomAlarm();
+            return;
+          }
+          const existingAlarmAt = await storage.get<unknown>(RUNTIME_IDLE_WATCH_ALARM_AT_KEY);
+          if (isFiniteTimestamp(existingAlarmAt) && existingAlarmAt > Date.now()) {
+            return;
+          }
+          const alarmAt = Date.now() + RUNTIME_IDLE_TTL_MS;
+          await storage.put(RUNTIME_IDLE_WATCH_KEY, notebookId);
+          await storage.put(RUNTIME_IDLE_WATCH_ALARM_AT_KEY, alarmAt);
+          await this.rescheduleRoomAlarm();
+        } catch (error) {
+          cloudLog("warn", "room.runtime_idle_watch.refresh_failed", {
+            notebook_id: notebookId,
+            error: errorMessage(error),
+          });
+        }
+      })(),
+    );
+  }
+
   private async rescheduleRoomAlarm(): Promise<void> {
     const storage = this.state.storage;
     if (!storage.setAlarm || !storage.deleteAlarm) {
@@ -2357,6 +2601,7 @@ export class NotebookRoom {
 
     const alarmTimes = [
       await storage.get<unknown>(RUNTIME_PEER_WATCH_ALARM_AT_KEY),
+      await storage.get<unknown>(RUNTIME_IDLE_WATCH_ALARM_AT_KEY),
       await storage.get<unknown>(ROOM_SUMMARY_REFRESH_ALARM_AT_KEY),
     ]
       .filter(isFiniteTimestamp)
@@ -2381,6 +2626,11 @@ export class NotebookRoom {
       RUNTIME_PEER_WATCH_ALARM_AT_KEY,
       nowMs,
     );
+    const runtimeIdleWatch = await this.dueAlarmTask(
+      RUNTIME_IDLE_WATCH_KEY,
+      RUNTIME_IDLE_WATCH_ALARM_AT_KEY,
+      nowMs,
+    );
     const roomSummaryRefresh = await this.dueAlarmTask(
       ROOM_SUMMARY_REFRESH_KEY,
       ROOM_SUMMARY_REFRESH_ALARM_AT_KEY,
@@ -2391,6 +2641,12 @@ export class NotebookRoom {
       await storage.delete(RUNTIME_PEER_WATCH_KEY);
       await storage.delete(RUNTIME_PEER_WATCH_ALARM_AT_KEY);
       await this.handleRuntimePeerWatchAlarm(runtimeWatch);
+    }
+
+    if (runtimeIdleWatch) {
+      await storage.delete(RUNTIME_IDLE_WATCH_KEY);
+      await storage.delete(RUNTIME_IDLE_WATCH_ALARM_AT_KEY);
+      await this.handleRuntimeIdleWatchAlarm(runtimeIdleWatch);
     }
 
     if (roomSummaryRefresh) {
@@ -2450,6 +2706,68 @@ export class NotebookRoom {
       cloudLog("error", "room.runtime_peer_watch.reconcile_failed", {
         notebook_id: notebookId,
         error: errorMessage(error),
+      });
+    }
+  }
+
+  private async handleRuntimeIdleWatchAlarm(notebookId: string): Promise<void> {
+    let activity;
+    try {
+      activity = await this.materializerFor(notebookId).getRuntimeExecutionActivity();
+    } catch (error) {
+      cloudLog("warn", "room.runtime_idle_watch.activity_read_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+      });
+      return;
+    }
+
+    if (activity.executing || activity.queueDepth > 0) {
+      cloudLog("info", "room.runtime_idle_watch.deferred_for_execution", {
+        notebook_id: notebookId,
+        executing: activity.executing,
+        queue_depth: activity.queueDepth,
+        counter: "runtime_idle_teardowns_deferred_for_execution",
+        counter_delta: 1,
+      });
+      return;
+    }
+
+    if (!this.hasRuntimePeer()) {
+      await this.publishCurrentComputeSessionSummary(notebookId);
+      return;
+    }
+
+    const updatedAt = new Date().toISOString();
+    try {
+      await this.markSelectedRuntimeSessionCompletedForIdle(notebookId);
+      this.removeRuntimePeers(notebookId, {
+        code: RUNTIME_IDLE_CLOSE_CODE,
+        reason: RUNTIME_IDLE_CLOSE_REASON,
+        suppressRuntimePeerWatch: true,
+      });
+      const materializer = this.materializerFor(notebookId);
+      const result = await materializer.reconcileRuntimeIdleTimeout(
+        RUNTIME_IDLE_STATUS_MESSAGE,
+        updatedAt,
+      );
+      this.invalidateSelectedRuntimePeerSession(notebookId);
+      if (result.changed) {
+        this.deliverRoomHostFrames(notebookId, result);
+        this.scheduleRoomHostCheckpoint(notebookId, materializer, "runtime_idle_timeout");
+      }
+      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
+      cloudLog("info", "room.runtime_idle_watch.torn_down", {
+        notebook_id: notebookId,
+        counter: "runtime_idle_teardowns",
+        counter_delta: 1,
+      });
+    } catch (error) {
+      cloudLog("warn", "room.runtime_idle_watch.teardown_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+        counter: "runtime_idle_teardown_failures",
+        counter_delta: 1,
       });
     }
   }
@@ -2557,7 +2875,43 @@ function selectedRuntimePeerSessionFromAttachment(
   return {
     workstationId,
     runtimeSessionId: attachment.runtime_session_id?.trim() || null,
+    status: attachment.status.trim().toLowerCase(),
   };
+}
+
+function runtimePeerSessionStatusAcceptsPeer(status: string): boolean {
+  return status !== "disconnected";
+}
+
+function runtimeAttachmentCanResumeForExecution(attachment: WorkstationAttachmentState): boolean {
+  const workstationId = attachment.workstation_id.trim();
+  if (!workstationId || workstationId === "runtime-peer") {
+    return false;
+  }
+  const status = attachment.status.trim().toLowerCase();
+  return status === "ready" || status === "disconnected";
+}
+
+function workstationAttachmentTargetFromRow(workstation: WorkstationRow) {
+  return {
+    workstationId: workstation.workstation_id,
+    displayName: workstation.display_name,
+    provider: workstation.provider,
+    defaultEnvironmentLabel: workstation.default_environment_label,
+    environmentPolicy: workstation.environment_policy,
+    cpuCount: workstation.cpu_count,
+    memoryBytes: workstation.memory_bytes,
+    workingDirectory: workstation.working_directory,
+  };
+}
+
+function workstationLeaseIsFreshEnough(
+  workstation: WorkstationRow,
+  lease: WorkstationLeaseRecord,
+): boolean {
+  const rowSeen = workstation.last_seen_at ? Date.parse(workstation.last_seen_at) : NaN;
+  const leaseSeen = Date.parse(lease.last_seen_at);
+  return !Number.isFinite(rowSeen) || (Number.isFinite(leaseSeen) && leaseSeen >= rowSeen);
 }
 
 function runtimePeerMatchesSelectedSession(

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1768,6 +1768,7 @@ export class NotebookRoom {
       notebookId,
       ownerPrincipal,
       replaceActive: false,
+      trigger: "resume",
       workstationId,
       actorLabel: EXECUTION_RESUME_ACTOR_LABEL,
     });

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -2561,6 +2561,23 @@ export class NotebookRoom {
     );
   }
 
+  private async clearRuntimePeerWatch(notebookId: string): Promise<void> {
+    const storage = this.state.storage;
+    if (!storage.setAlarm || !storage.deleteAlarm) {
+      return;
+    }
+    try {
+      await storage.delete(RUNTIME_PEER_WATCH_KEY);
+      await storage.delete(RUNTIME_PEER_WATCH_ALARM_AT_KEY);
+      await this.rescheduleRoomAlarm();
+    } catch (error) {
+      cloudLog("warn", "room.runtime_peer_watch.clear_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+      });
+    }
+  }
+
   private refreshRuntimeIdleWatch(notebookId: string): void {
     const storage = this.state.storage;
     if (!storage.setAlarm || !storage.deleteAlarm) {
@@ -2683,18 +2700,33 @@ export class NotebookRoom {
       return;
     }
 
+    const materializer = this.materializerFor(notebookId);
     try {
-      const result = await this.materializerFor(notebookId).reconcileRuntimePeerGone(
+      const attachment = await materializer.getWorkstationAttachment();
+      if (attachment?.status === "idle") {
+        cloudLog("info", "room.runtime_peer_watch.skipped_idle", {
+          notebook_id: notebookId,
+          counter: "runtime_peer_watch_skipped_idle",
+          counter_delta: 1,
+        });
+        this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId, attachment));
+        return;
+      }
+    } catch (error) {
+      cloudLog("warn", "room.runtime_peer_watch.attachment_read_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+      });
+    }
+
+    try {
+      const result = await materializer.reconcileRuntimePeerGone(
         "runtime peer left the room and did not return within the grace window",
       );
       this.invalidateSelectedRuntimePeerSession(notebookId);
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        this.scheduleRoomHostCheckpoint(
-          notebookId,
-          this.materializerFor(notebookId),
-          "runtime_peer_watch_reconcile",
-        );
+        this.scheduleRoomHostCheckpoint(notebookId, materializer, "runtime_peer_watch_reconcile");
       }
       this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
       cloudLog("info", "room.runtime_peer_watch.reconciled", {
@@ -2757,6 +2789,7 @@ export class NotebookRoom {
         reason: RUNTIME_IDLE_CLOSE_REASON,
         suppressRuntimePeerWatch: true,
       });
+      await this.clearRuntimePeerWatch(notebookId);
       this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
       cloudLog("info", "room.runtime_idle_watch.torn_down", {
         notebook_id: notebookId,

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -2742,11 +2742,6 @@ export class NotebookRoom {
     const updatedAt = new Date().toISOString();
     try {
       await this.markSelectedRuntimeSessionCompletedForIdle(notebookId);
-      this.removeRuntimePeers(notebookId, {
-        code: RUNTIME_IDLE_CLOSE_CODE,
-        reason: RUNTIME_IDLE_CLOSE_REASON,
-        suppressRuntimePeerWatch: true,
-      });
       const materializer = this.materializerFor(notebookId);
       const result = await materializer.reconcileRuntimeIdleTimeout(
         RUNTIME_IDLE_STATUS_MESSAGE,
@@ -2757,6 +2752,11 @@ export class NotebookRoom {
         this.deliverRoomHostFrames(notebookId, result);
         this.scheduleRoomHostCheckpoint(notebookId, materializer, "runtime_idle_timeout");
       }
+      this.removeRuntimePeers(notebookId, {
+        code: RUNTIME_IDLE_CLOSE_CODE,
+        reason: RUNTIME_IDLE_CLOSE_REASON,
+        suppressRuntimePeerWatch: true,
+      });
       this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
       cloudLog("info", "room.runtime_idle_watch.torn_down", {
         notebook_id: notebookId,

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -447,15 +447,29 @@ export class NotebookRoom {
     try {
       const materializer = this.materializerFor(notebookId);
       const result = await materializer.setWorkstationAttachment(attachment);
-      this.cacheSelectedRuntimePeerSession(notebookId, attachment);
-      if (closeRuntimePeers) {
+      if (result.ignored_stale) {
+        cloudLog("warn", "room.workstation_attachment.stale_publish_ignored", {
+          notebook_id: notebookId,
+          runtime_session_id: attachment?.runtime_session_id ?? null,
+          updated_at: attachment?.updated_at ?? null,
+          counter: "workstation_attachment_stale_publishes_ignored",
+          counter_delta: 1,
+        });
+      } else {
+        this.cacheSelectedRuntimePeerSession(notebookId, attachment);
+      }
+      if (closeRuntimePeers && !result.ignored_stale) {
         this.removeRuntimePeers(notebookId, {
           code: 1012,
           reason: closeReason,
           suppressRuntimePeerWatch: true,
         });
       }
-      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId, attachment));
+      this.state.waitUntil(
+        result.ignored_stale
+          ? this.publishCurrentComputeSessionSummary(notebookId)
+          : this.publishCurrentComputeSessionSummary(notebookId, attachment),
+      );
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
       }
@@ -468,7 +482,8 @@ export class NotebookRoom {
         checkpoint_persisted: checkpointPersisted,
         duration_ms: durationMs(startedAt),
         outbound_frame_count: result.outbound.length,
-        closed_runtime_peers: closeRuntimePeers,
+        ignored_stale: result.ignored_stale ?? false,
+        closed_runtime_peers: closeRuntimePeers && !result.ignored_stale,
         counter: "workstation_attachment_control_published",
         counter_delta: result.changed ? 1 : 0,
       });
@@ -1374,7 +1389,18 @@ export class NotebookRoom {
       const materializer = this.materializerFor(notebookId);
       const attachment = runtimePeerWorkstationAttachment(peer);
       const result = await materializer.setWorkstationAttachment(attachment);
-      this.cacheSelectedRuntimePeerSession(notebookId, attachment);
+      if (result.ignored_stale) {
+        cloudLog("warn", "room.workstation_attachment.stale_publish_ignored", {
+          notebook_id: notebookId,
+          peer_id: peer.id,
+          runtime_session_id: attachment.runtime_session_id,
+          updated_at: attachment.updated_at,
+          counter: "workstation_attachment_stale_publishes_ignored",
+          counter_delta: 1,
+        });
+      } else {
+        this.cacheSelectedRuntimePeerSession(notebookId, attachment);
+      }
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
         await this.checkpointRoomHost(notebookId, materializer, "runtime_peer_attachment");
@@ -1385,6 +1411,7 @@ export class NotebookRoom {
         peer_id: peer.id,
         scope: peer.identity.scope,
         changed: result.changed,
+        ignored_stale: result.ignored_stale ?? false,
         duration_ms: durationMs(startedAt),
         outbound_frame_count: result.outbound.length,
         counter: "workstation_attachments_published",

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -2881,7 +2881,7 @@ function selectedRuntimePeerSessionFromAttachment(
 }
 
 function runtimePeerSessionStatusAcceptsPeer(status: string): boolean {
-  return status !== "disconnected";
+  return status !== "disconnected" && status !== "idle";
 }
 
 function runtimeAttachmentCanResumeForExecution(attachment: WorkstationAttachmentState): boolean {
@@ -2890,7 +2890,7 @@ function runtimeAttachmentCanResumeForExecution(attachment: WorkstationAttachmen
     return false;
   }
   const status = attachment.status.trim().toLowerCase();
-  return status === "ready" || status === "disconnected";
+  return status === "ready" || status === "disconnected" || status === "idle";
 }
 
 function workstationAttachmentTargetFromRow(workstation: WorkstationRow) {

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -22,6 +22,7 @@ interface RoomHostOutboundFrame {
 
 export interface RoomHostFrameResult {
   changed: boolean;
+  ignored_stale?: boolean;
   notebook_changed: boolean;
   runtime_state_changed: boolean;
   outbound: RoomHostOutboundFrame[];
@@ -768,6 +769,7 @@ function normalizeResult(value: unknown): RoomHostFrameResult {
   const result = value as Partial<RoomHostFrameResult> | undefined;
   return {
     changed: result?.changed ?? false,
+    ignored_stale: result?.ignored_stale ?? false,
     notebook_changed: result?.notebook_changed ?? false,
     runtime_state_changed: result?.runtime_state_changed ?? false,
     outbound: result?.outbound ?? [],

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -28,6 +28,11 @@ export interface RoomHostFrameResult {
   outbound: RoomHostOutboundFrame[];
 }
 
+export interface RuntimeExecutionActivity {
+  executing: boolean;
+  queueDepth: number;
+}
+
 interface RoomCheckpointMetadata {
   version: number;
   notebook_heads: string[];
@@ -92,6 +97,12 @@ export class RoomMaterializer {
     return this.withHost((host) => Math.max(0, Math.trunc(host.get_runtime_queue_depth())));
   }
 
+  async getRuntimeExecutionActivity(): Promise<RuntimeExecutionActivity> {
+    return this.withHost((host) =>
+      normalizeRuntimeExecutionActivityJson(host.get_runtime_execution_activity_json()),
+    );
+  }
+
   async getWorkstationAttachment(): Promise<WorkstationAttachmentState | null> {
     return this.withHost((host) =>
       normalizeWorkstationAttachmentJson(host.get_workstation_attachment_json()),
@@ -112,6 +123,15 @@ export class RoomMaterializer {
   ): Promise<RoomHostFrameResult> {
     return this.withHost((host) =>
       normalizeResult(host.set_workstation_attachment_json(JSON.stringify(attachment))),
+    );
+  }
+
+  async reconcileRuntimeIdleTimeout(
+    reason: string,
+    updatedAt: string,
+  ): Promise<RoomHostFrameResult> {
+    return this.withHost((host) =>
+      normalizeResult(host.reconcile_runtime_idle_timeout(reason, updatedAt)),
     );
   }
 
@@ -782,6 +802,27 @@ function normalizeWorkstationAttachmentJson(value: string): WorkstationAttachmen
     return parsed;
   }
   throw new Error("RoomHostHandle returned an invalid workstation attachment");
+}
+
+function normalizeRuntimeExecutionActivityJson(value: string): RuntimeExecutionActivity {
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("RoomHostHandle returned invalid runtime execution activity");
+  }
+  const record = parsed as Record<string, unknown>;
+  const queueDepth = record.queue_depth;
+  if (
+    typeof record.executing !== "boolean" ||
+    typeof queueDepth !== "number" ||
+    !Number.isSafeInteger(queueDepth) ||
+    queueDepth < 0
+  ) {
+    throw new Error("RoomHostHandle returned invalid runtime execution activity");
+  }
+  return {
+    executing: record.executing,
+    queueDepth,
+  };
 }
 
 function commentAuthorActorLabelsFromProjection(projection: unknown): string[] {

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -120,6 +120,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_comments_doc_heads_hex(): string[];
     get_comments_projection(): unknown;
     get_heads_hex(): string[];
+    get_runtime_execution_activity_json(): string;
     get_runtime_queue_depth(): number;
     get_runtime_state_heads_hex(): string[];
     load_comms_doc(commsBytes: Uint8Array): void;
@@ -131,6 +132,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
       canWriteAllNotebookChanges: boolean,
       frameBytes: Uint8Array,
     ): unknown;
+    reconcile_runtime_idle_timeout(reason: string, updatedAt: string): unknown;
     remove_peer(peerId: string): void;
     save_notebook(): Uint8Array;
     save_comms_doc(): Uint8Array;

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1196,7 +1196,8 @@ export async function createWorkstationAttachJob(
   });
   if (existing) {
     if (input.replaceActive !== true && existing.workstation_id === input.workstationId) {
-      return { job: existing, cancelledActiveJob: null };
+      const job = await upgradeDedupedAttachJobTriggerToUserAttach(env, existing, trigger, nowIso);
+      return { job, cancelledActiveJob: null };
     }
     cancelledActiveJob = existing;
     activeJobToCancel = existing;
@@ -1257,7 +1258,13 @@ export async function createWorkstationAttachJob(
         throw error;
       }
       if (input.replaceActive !== true && racedExisting.workstation_id === input.workstationId) {
-        return { job: racedExisting, cancelledActiveJob };
+        const job = await upgradeDedupedAttachJobTriggerToUserAttach(
+          env,
+          racedExisting,
+          trigger,
+          nowIso,
+        );
+        return { job, cancelledActiveJob };
       }
       cancelledActiveJob ??= racedExisting;
       activeJobToCancel = racedExisting;
@@ -1474,6 +1481,33 @@ async function getActiveWorkstationAttachJob(
     .bind(input.notebookId, input.ownerPrincipal, pendingStaleBefore, staleBefore)
     .first<WorkstationAttachJobRow>();
   return row;
+}
+
+async function upgradeDedupedAttachJobTriggerToUserAttach(
+  env: Env,
+  job: WorkstationAttachJobRow,
+  requestedTrigger: WorkstationAttachJobTrigger,
+  now: string,
+): Promise<WorkstationAttachJobRow> {
+  if (requestedTrigger !== "user_attach" || job.trigger === "user_attach") {
+    return job;
+  }
+  await env
+    .DB!.prepare(
+      `UPDATE workstation_attach_jobs
+          SET trigger = 'user_attach',
+              updated_at = ?
+        WHERE id = ?
+          AND owner_principal = ?
+          AND workstation_id = ?
+          AND trigger = 'resume'
+          AND status IN ('pending', 'accepted', 'running')`,
+    )
+    .bind(now, job.id, job.owner_principal, job.workstation_id)
+    .run();
+  return (
+    (await getWorkstationAttachJob(env, job.owner_principal, job.workstation_id, job.id)) ?? job
+  );
 }
 
 async function expireStaleWorkstationAttachJobs(

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -190,6 +190,26 @@ export interface ListActiveWorkstationAttachJobsResult {
 
 const WORKSTATION_ATTACH_JOBS_DROP_LEGACY_ACTIVE_UNIQUE_INDEX = `DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx`;
 
+const WORKSTATION_ATTACH_JOBS_DEDUPE_ACTIVE_OWNER = `UPDATE workstation_attach_jobs
+   SET status = 'cancelled',
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+       finished_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+       error_message = 'cancelled by active workstation attach job uniqueness migration'
+ WHERE status IN ('pending', 'accepted', 'running')
+   AND id IN (
+     SELECT id
+       FROM (
+         SELECT id,
+                ROW_NUMBER() OVER (
+                  PARTITION BY notebook_id, owner_principal
+                  ORDER BY requested_at DESC, updated_at DESC, id DESC
+                ) AS active_rank
+           FROM workstation_attach_jobs
+          WHERE status IN ('pending', 'accepted', 'running')
+       )
+      WHERE active_rank > 1
+   );`;
+
 const WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_owner_unique_idx
     ON workstation_attach_jobs(notebook_id, owner_principal)
     WHERE status IN ('pending', 'accepted', 'running')`;
@@ -361,6 +381,7 @@ const SCHEMA_STATEMENTS = [
     error_message TEXT,
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
+  WORKSTATION_ATTACH_JOBS_DEDUPE_ACTIVE_OWNER,
   WORKSTATION_ATTACH_JOBS_DROP_LEGACY_ACTIVE_UNIQUE_INDEX,
   WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX,
   `CREATE INDEX IF NOT EXISTS workstation_attach_jobs_poll_idx
@@ -500,7 +521,9 @@ export async function ensureCatalogSchema(env: Env): Promise<void> {
 }
 
 async function initializeCatalogSchema(env: Env): Promise<void> {
-  await Promise.all(SCHEMA_STATEMENTS.map((statement) => env.DB!.prepare(statement).run()));
+  for (const statement of SCHEMA_STATEMENTS) {
+    await env.DB!.prepare(statement).run();
+  }
   await runCatalogMigrations(env);
   await backfillNotebookAcl(env);
 }

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1359,6 +1359,47 @@ export async function updateWorkstationAttachJobStatus(
   return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, input.jobId);
 }
 
+export async function failActiveWorkstationAttachJobsForWorkstation(
+  env: Env,
+  input: {
+    ownerPrincipal: string;
+    workstationId: string;
+    errorMessage: string;
+    now?: string;
+  },
+): Promise<WorkstationAttachJobRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const now = input.now ?? new Date().toISOString();
+  const failed = await env.DB.prepare(
+    `UPDATE workstation_attach_jobs
+        SET status = 'failed',
+            updated_at = ?,
+            finished_at = ?,
+            error_message = ?
+      WHERE owner_principal = ?
+        AND workstation_id = ?
+        AND status IN ('pending', 'accepted', 'running')
+      RETURNING id,
+                notebook_id,
+                owner_principal,
+                workstation_id,
+                status,
+                requested_by_actor_label,
+                requested_at,
+                updated_at,
+                accepted_at,
+                finished_at,
+                error_message`,
+  )
+    .bind(now, now, input.errorMessage, input.ownerPrincipal, input.workstationId)
+    .all<WorkstationAttachJobRow>();
+  return failed.results ?? [];
+}
+
 function workstationAttachJobStatusRank(status: WorkstationAttachJobStatus): number {
   switch (status) {
     case "pending":

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -123,6 +123,8 @@ export type WorkstationAttachJobStatus =
   | "completed"
   | "cancelled";
 
+export type WorkstationAttachJobTrigger = "user_attach" | "resume";
+
 export const WORKSTATION_ATTACH_JOB_STALE_MS = 2 * 60_000;
 // Pending jobs cover host cold start before the agent accepts the request; give
 // a slow host one extra minute beyond the accepted/running heartbeat timeout.
@@ -167,6 +169,7 @@ export interface WorkstationAttachJobRow {
   owner_principal: string;
   workstation_id: string;
   status: WorkstationAttachJobStatus;
+  trigger: WorkstationAttachJobTrigger;
   requested_by_actor_label: string;
   requested_at: string;
   updated_at: string;
@@ -349,6 +352,7 @@ const SCHEMA_STATEMENTS = [
     owner_principal TEXT NOT NULL,
     workstation_id TEXT NOT NULL,
     status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'running', 'failed', 'completed', 'cancelled')),
+    trigger TEXT NOT NULL DEFAULT 'user_attach',
     requested_by_actor_label TEXT NOT NULL,
     requested_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
@@ -429,6 +433,11 @@ const SCHEMA_MIGRATIONS = [
     table: "notebook_revisions",
     column: "cover_mime",
     statement: `ALTER TABLE notebook_revisions ADD COLUMN cover_mime TEXT`,
+  },
+  {
+    table: "workstation_attach_jobs",
+    column: "trigger",
+    statement: `ALTER TABLE workstation_attach_jobs ADD COLUMN trigger TEXT NOT NULL DEFAULT 'user_attach'`,
   },
   {
     table: "notebooks",
@@ -1149,6 +1158,7 @@ export async function createWorkstationAttachJob(
     notebookId: string;
     ownerPrincipal: string;
     replaceActive?: boolean;
+    trigger?: WorkstationAttachJobTrigger;
     workstationId: string;
     actorLabel: string;
   },
@@ -1164,6 +1174,10 @@ export async function createWorkstationAttachJob(
   const pendingStaleBefore = new Date(
     now.getTime() - WORKSTATION_ATTACH_PENDING_STALE_MS,
   ).toISOString();
+  const trigger = input.trigger ?? "user_attach";
+  if (!isWorkstationAttachJobTrigger(trigger)) {
+    throw new Error(`invalid workstation attach job trigger: ${trigger}`);
+  }
   await expireStaleWorkstationAttachJobs(
     env,
     { notebookId: input.notebookId, ownerPrincipal: input.ownerPrincipal },
@@ -1197,15 +1211,17 @@ export async function createWorkstationAttachJob(
        owner_principal,
        workstation_id,
        status,
+       trigger,
        requested_by_actor_label,
        requested_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`,
+     ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
     ).bind(
       jobId,
       input.notebookId,
       input.ownerPrincipal,
       input.workstationId,
+      trigger,
       input.actorLabel,
       nowIso,
       nowIso,
@@ -1278,6 +1294,7 @@ export async function listActiveWorkstationAttachJobs(
             owner_principal,
             workstation_id,
             status,
+            trigger,
             requested_by_actor_label,
             requested_at,
             updated_at,
@@ -1388,6 +1405,7 @@ export async function failActiveWorkstationAttachJobsForWorkstation(
                 owner_principal,
                 workstation_id,
                 status,
+                trigger,
                 requested_by_actor_label,
                 requested_at,
                 updated_at,
@@ -1436,6 +1454,7 @@ async function getActiveWorkstationAttachJob(
             owner_principal,
             workstation_id,
             status,
+            trigger,
             requested_by_actor_label,
             requested_at,
             updated_at,
@@ -1515,6 +1534,7 @@ async function expireStaleWorkstationAttachJobs(
                   owner_principal,
                   workstation_id,
                   status,
+                  trigger,
                   requested_by_actor_label,
                   requested_at,
                   updated_at,
@@ -1577,6 +1597,7 @@ async function getWorkstationAttachJob(
             owner_principal,
             workstation_id,
             status,
+            trigger,
             requested_by_actor_label,
             requested_at,
             updated_at,
@@ -1591,6 +1612,10 @@ async function getWorkstationAttachJob(
     .bind(jobId, ownerPrincipal, workstationId)
     .first<WorkstationAttachJobRow>();
   return row;
+}
+
+function isWorkstationAttachJobTrigger(value: string): value is WorkstationAttachJobTrigger {
+  return value === "user_attach" || value === "resume";
 }
 
 export interface CreateNotebookWithOwnerAclResult {

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -241,6 +241,39 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
     );
   });
 
+  it("does not block the lease alarm on attach-job failure side effects", async () => {
+    const { state, values, settle, deliverAlarm } = fakeStateWithAlarm();
+    const jobs = new Map<string, WorkstationAttachJobRow>([
+      ["pending-job", attachJob("pending-job", "pending")],
+    ]);
+    let releaseD1!: () => void;
+    const d1Gate = new Promise<void>((resolve) => {
+      releaseD1 = resolve;
+    });
+    const object = new OwnerComputeIndex(state, {
+      DB: fakeAttachJobsDb(jobs, {
+        beforeFailActiveJobs: () => d1Gate,
+      }),
+    } as Env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    const stored = values.get("lease:ws-a") as Record<string, unknown>;
+    values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
+
+    deliverAlarm();
+    const alarmPromise = object.alarm();
+    const alarmResult = await Promise.race([
+      alarmPromise.then(() => "returned" as const),
+      testDelay(20).then(() => "blocked" as const),
+    ]);
+    releaseD1();
+    await alarmPromise;
+    await settle();
+
+    assert.equal(alarmResult, "returned");
+    assert.equal(jobs.get("pending-job")?.status, "failed");
+  });
+
   it("deletes an online lease and leaves no lease for a concurrent sweep to notify", async () => {
     const { state, scheduledAlarm, settle, deliverAlarm } = fakeStateWithAlarm();
     const events = fakeWorkstationEvents();
@@ -372,9 +405,12 @@ function fakeNotebookRooms(): {
   return { namespace: namespace as unknown as DurableObjectNamespace, repairs };
 }
 
-function fakeAttachJobsDb(jobs: Map<string, WorkstationAttachJobRow>): D1Database {
+function fakeAttachJobsDb(
+  jobs: Map<string, WorkstationAttachJobRow>,
+  options: { beforeFailActiveJobs?: () => Promise<void> } = {},
+): D1Database {
   return {
-    prepare: (query: string) => fakeD1Statement(query, jobs),
+    prepare: (query: string) => fakeD1Statement(query, jobs, options),
     exec: async () => d1Result(),
     batch: async <T>(statements: D1PreparedStatement[]) =>
       Promise.all(statements.map((statement) => statement.run<T>())),
@@ -384,6 +420,7 @@ function fakeAttachJobsDb(jobs: Map<string, WorkstationAttachJobRow>): D1Databas
 function fakeD1Statement(
   query: string,
   jobs: Map<string, WorkstationAttachJobRow>,
+  options: { beforeFailActiveJobs?: () => Promise<void> },
 ): D1PreparedStatement {
   let boundValues: D1Value[] = [];
   const statement: D1PreparedStatement = {
@@ -395,6 +432,7 @@ function fakeD1Statement(
     run: async <T>() => d1Result<T>(),
     all: async <T>() => {
       if (query.includes("UPDATE workstation_attach_jobs") && query.includes("RETURNING id")) {
+        await options.beforeFailActiveJobs?.();
         const [updatedAt, finishedAt, errorMessage, ownerPrincipal, workstationId] = boundValues;
         const failed: WorkstationAttachJobRow[] = [];
         for (const job of jobs.values()) {
@@ -421,6 +459,10 @@ function fakeD1Statement(
     },
   };
   return statement;
+}
+
+function testDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function d1Result<T = unknown>(results: T[] = []): D1Result<T> {

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -438,6 +438,7 @@ function attachJob(
     owner_principal: "user:dev:alice",
     workstation_id: "ws-a",
     status,
+    trigger: "user_attach",
     requested_by_actor_label: "alice",
     requested_at: "2026-07-07T00:00:00.000Z",
     updated_at: "2026-07-07T00:00:00.000Z",

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import type {
+  D1Database,
+  D1PreparedStatement,
+  D1Result,
+  D1Value,
+  DurableObjectNamespace,
+  DurableObjectState,
+  Env,
+} from "../src/cloudflare-types.ts";
 import {
   OwnerComputeIndex,
   ownerComputeIndexObjectName,
   WORKSTATION_LEASE_GC_MS,
 } from "../src/compute-session-index.ts";
+import type { WorkstationAttachJobRow, WorkstationAttachJobStatus } from "../src/storage.ts";
 import type { NotebookComputeSessionSummary } from "runtimed";
 
 describe("OwnerComputeIndex", () => {
@@ -178,6 +187,60 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
     assert.match(events.notifications[0].body.reason as string, /lease expired/);
   });
 
+  it("fails active attach jobs when a lease lapses", async () => {
+    const { state, values, settle, deliverAlarm } = fakeStateWithAlarm();
+    const events = fakeWorkstationEvents();
+    const rooms = fakeNotebookRooms();
+    const jobs = new Map<string, WorkstationAttachJobRow>([
+      ["pending-job", attachJob("pending-job", "pending", { notebook_id: "nb-pending" })],
+      ["accepted-job", attachJob("accepted-job", "accepted", { notebook_id: "nb-accepted" })],
+      ["running-job", attachJob("running-job", "running", { notebook_id: "nb-running" })],
+      ["completed-job", attachJob("completed-job", "completed", { notebook_id: "nb-done" })],
+    ]);
+    const object = new OwnerComputeIndex(state, {
+      ...events.env,
+      DB: fakeAttachJobsDb(jobs),
+      NOTEBOOK_ROOMS: rooms.namespace,
+    } as Env);
+
+    await object.fetch(leaseUpsert("ws-a", "user:dev:alice", 60_000));
+    const stored = values.get("lease:ws-a") as Record<string, unknown>;
+    values.set("lease:ws-a", { ...stored, lease_expires_at: Date.now() - 1 });
+
+    deliverAlarm();
+    await object.alarm();
+    await settle();
+
+    const expectedError = "workstation lease expired: no heartbeat within the lease window";
+    for (const jobId of ["pending-job", "accepted-job", "running-job"]) {
+      assert.equal(jobs.get(jobId)?.status, "failed");
+      assert.equal(jobs.get(jobId)?.error_message, expectedError);
+      assert.ok(jobs.get(jobId)?.finished_at);
+    }
+    assert.equal(jobs.get("completed-job")?.status, "completed");
+    assert.equal(jobs.get("completed-job")?.error_message, null);
+
+    const attachNotifications = events.notifications.filter(
+      (entry) => entry.body.event === "attach_jobs",
+    );
+    assert.deepEqual(
+      new Set(attachNotifications.map((entry) => entry.body.job_id)),
+      new Set(["pending-job", "accepted-job", "running-job"]),
+    );
+    assert.equal(
+      events.notifications.some((entry) => entry.body.event === "went_offline"),
+      true,
+    );
+    assert.deepEqual(
+      new Set(rooms.repairs.map((repair) => repair.body.expected_runtime_session_id)),
+      new Set(["pending-job", "accepted-job", "running-job"]),
+    );
+    assert.equal(
+      rooms.repairs.every((repair) => repair.body.reason === expectedError),
+      true,
+    );
+  });
+
   it("deletes an online lease and leaves no lease for a concurrent sweep to notify", async () => {
     const { state, scheduledAlarm, settle, deliverAlarm } = fakeStateWithAlarm();
     const events = fakeWorkstationEvents();
@@ -286,6 +349,104 @@ function fakeWorkstationEvents(): {
   return {
     env: { WORKSTATION_EVENTS: namespace } as unknown as Env,
     notifications,
+  };
+}
+
+function fakeNotebookRooms(): {
+  namespace: DurableObjectNamespace;
+  repairs: Array<{ objectName: string; body: Record<string, unknown> }>;
+} {
+  const repairs: Array<{ objectName: string; body: Record<string, unknown> }> = [];
+  const namespace = {
+    idFromName: (name: string) => ({ toString: () => name, name }),
+    get: (id: { name: string }) => ({
+      fetch: async (request: Request) => {
+        repairs.push({
+          objectName: id.name,
+          body: (await request.json()) as Record<string, unknown>,
+        });
+        return Response.json({ ok: true, repaired: true });
+      },
+    }),
+  };
+  return { namespace: namespace as unknown as DurableObjectNamespace, repairs };
+}
+
+function fakeAttachJobsDb(jobs: Map<string, WorkstationAttachJobRow>): D1Database {
+  return {
+    prepare: (query: string) => fakeD1Statement(query, jobs),
+    exec: async () => d1Result(),
+    batch: async <T>(statements: D1PreparedStatement[]) =>
+      Promise.all(statements.map((statement) => statement.run<T>())),
+  };
+}
+
+function fakeD1Statement(
+  query: string,
+  jobs: Map<string, WorkstationAttachJobRow>,
+): D1PreparedStatement {
+  let boundValues: D1Value[] = [];
+  const statement: D1PreparedStatement = {
+    bind: (...values: D1Value[]) => {
+      boundValues = values;
+      return statement;
+    },
+    first: async () => null,
+    run: async <T>() => d1Result<T>(),
+    all: async <T>() => {
+      if (query.includes("UPDATE workstation_attach_jobs") && query.includes("RETURNING id")) {
+        const [updatedAt, finishedAt, errorMessage, ownerPrincipal, workstationId] = boundValues;
+        const failed: WorkstationAttachJobRow[] = [];
+        for (const job of jobs.values()) {
+          if (
+            job.owner_principal !== ownerPrincipal ||
+            job.workstation_id !== workstationId ||
+            !["pending", "accepted", "running"].includes(job.status)
+          ) {
+            continue;
+          }
+          const next: WorkstationAttachJobRow = {
+            ...job,
+            status: "failed",
+            updated_at: String(updatedAt),
+            finished_at: String(finishedAt),
+            error_message: String(errorMessage),
+          };
+          jobs.set(job.id, next);
+          failed.push(next);
+        }
+        return d1Result(failed as T[]);
+      }
+      return d1Result<T>();
+    },
+  };
+  return statement;
+}
+
+function d1Result<T = unknown>(results: T[] = []): D1Result<T> {
+  return { results, success: true, meta: {} };
+}
+
+function attachJob(
+  id: string,
+  status: WorkstationAttachJobStatus,
+  overrides: Partial<WorkstationAttachJobRow> = {},
+): WorkstationAttachJobRow {
+  return {
+    id,
+    notebook_id: "nb-1",
+    owner_principal: "user:dev:alice",
+    workstation_id: "ws-a",
+    status,
+    requested_by_actor_label: "alice",
+    requested_at: "2026-07-07T00:00:00.000Z",
+    updated_at: "2026-07-07T00:00:00.000Z",
+    accepted_at: status === "pending" ? null : "2026-07-07T00:01:00.000Z",
+    finished_at: ["failed", "completed", "cancelled"].includes(status)
+      ? "2026-07-07T00:02:00.000Z"
+      : null,
+    error_message: null,
+    ...overrides,
   };
 }
 

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -59,6 +59,28 @@ describe("hosted workstation agent launch contract", () => {
     ]);
   });
 
+  it("uses execute launch mode for resume attach jobs", () => {
+    const plan = buildAttachJobSpawnPlan({
+      job: {
+        job_id: "job-resume",
+        notebook_id: "nb-resume",
+        trigger: "resume",
+      },
+      pythonPath: "/opt/k/bin/python",
+      agentRoot: "/tmp/agent",
+      baseUrl: "https://preview.runt.run",
+      workingDirectory: "/home/ubuntu/project",
+      workstationId: "ws-lab2",
+      displayName: "lab2 workstation",
+    });
+
+    assert.equal(
+      plan.args.some((arg, index) => arg === "--launch-mode" && plan.args[index + 1] === "execute"),
+      true,
+    );
+    assert.equal(plan.args.includes("/opt/k/bin/python"), true);
+  });
+
   it("can launch runtime peers with OIDC bearer auth without an API-key provider header", () => {
     const plan = buildAttachJobSpawnPlan({
       job: {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -35,7 +35,7 @@ import {
   splitTypedFrame,
 } from "../src/protocol.ts";
 import { decodePresenceFrame, encodePresenceFrame } from "../src/runtimed-wasm.ts";
-import type { RoomHostFrameResult } from "../src/room-materializer.ts";
+import { RoomMaterializer, type RoomHostFrameResult } from "../src/room-materializer.ts";
 import { roomSummaryKey, type NotebookRoomSummary } from "../src/storage.ts";
 import { initializeTestRuntimedWasm } from "./runtimed-wasm-test-loader.ts";
 
@@ -1542,6 +1542,49 @@ describe("NotebookRoom peer lifecycle", () => {
       1,
       "selected runtime session is cached after the first attachment read",
     );
+  });
+
+  it("rejects runtime-peer upgrades for idle selected sessions", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "idle",
+        status_message: "Compute stopped after 30 minutes without queued or active execution.",
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/codex/nteract",
+        runtime_session_id: "job-old",
+        updated_at: "2026-06-07T00:00:00.000Z",
+      }),
+    } as never);
+    const identity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const response = await room.fetch(
+      stampTrustedIdentity(
+        new Request("https://cloud.test/n/demo/sync", {
+          headers: {
+            Upgrade: "websocket",
+            "x-nteract-workstation-id": "lab2",
+            "x-nteract-runtime-session-id": "job-old",
+          },
+        }),
+        identity,
+      ),
+    );
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(await response.json(), { error: "selected runtime session is idle" });
   });
 
   it("refreshes the selected runtime session cache when a runtime peer publishes", async () => {
@@ -3351,6 +3394,151 @@ describe("NotebookRoom materialized sync routing", () => {
     assert.equal(accepted.type, "cloud_frame_accepted");
   });
 
+  it("creates an owner-scoped resume attach job when idle owner execution finds no runtime peer", async () => {
+    const db = new ResumeNotebookD1();
+    const room = new NotebookRoom(fakeState(), { DB: db } as unknown as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let materialized = 0;
+    let publishedAttachment: unknown = null;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "Lab2",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "idle",
+        status_message: "Compute stopped after 30 minutes without queued or active execution.",
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/srv/project",
+        updated_at: "2026-05-22T00:00:00.000Z",
+        runtime_session_id: "job-old",
+      }),
+      setWorkstationAttachment: async (attachment: unknown) => {
+        publishedAttachment = attachment;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+
+    assert.equal(materialized, 1);
+    assert.equal(db.attachJobs.length, 1);
+    assert.equal(db.attachJobs[0]?.owner_principal, "user:dev:alice");
+    assert.equal(db.attachJobs[0]?.trigger, "resume");
+    assert.equal(db.attachJobs[0]?.requested_by_actor_label, "execution resume");
+    assert.equal((publishedAttachment as { status?: string })?.status, "connecting");
+    assert.equal(
+      (publishedAttachment as { runtime_session_id?: string })?.runtime_session_id,
+      db.attachJobs[0]?.id,
+    );
+    assert.equal(
+      await harness.runtimePeerAuthorityError?.("demo", {
+        workstationId: "ws-lab2",
+        runtimeSessionId: db.attachJobs[0]?.id,
+      }),
+      null,
+    );
+    const accepted = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(accepted.type, "cloud_frame_accepted");
+  });
+
+  it("admits owner execution after real idle reconciliation idles the attachment", async () => {
+    const db = new ResumeNotebookD1();
+    const state = fakeState();
+    const env = { DB: db } as unknown as Env;
+    const room = new NotebookRoom(state, env);
+    const materializer = new RoomMaterializer("demo", state, env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", materializer as never);
+    await materializer.setWorkstationAttachment({
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: null,
+      memory_bytes: null,
+      working_directory: "/srv/project",
+      updated_at: "2026-05-22T00:00:00.000Z",
+      runtime_session_id: "job-old",
+    });
+
+    const idleResult = await materializer.reconcileRuntimeIdleTimeout(
+      "Compute stopped after 30 minutes without queued or active execution.",
+      "2026-07-08T00:30:00.000Z",
+    );
+    assert.equal(idleResult.changed, true);
+    assert.equal((await materializer.getWorkstationAttachment())?.status, "idle");
+
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({
+            id: "request-1",
+            action: "execute_cell",
+            cell_id: initialHostedCellIdForTest("demo"),
+          }),
+        ),
+      ),
+    );
+
+    assert.equal(db.attachJobs.length, 1);
+    const attachment = await materializer.getWorkstationAttachment();
+    assert.equal(attachment?.status, "connecting");
+    assert.equal(attachment?.runtime_session_id, db.attachJobs[0]?.id);
+    const accepted = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(accepted.type, "cloud_frame_accepted");
+  });
+
   it("rejects non-owner execution without creating a resume attach job", async () => {
     const db = new ResumeNotebookD1();
     const room = new NotebookRoom(fakeState(), { DB: db } as unknown as Env);
@@ -4756,6 +4944,19 @@ class NotebookOwnerD1Statement implements D1PreparedStatement {
 
 function d1OkResult<T = unknown>(results: T[] = []): D1Result<T> {
   return { results, success: true, meta: {} };
+}
+
+function initialHostedCellIdForTest(notebookId: string): string {
+  return `cell-room-${stableRoomKeyForTest(notebookId)}`;
+}
+
+function stableRoomKeyForTest(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of new TextEncoder().encode(value)) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
 }
 
 function hibernatedState(sockets: CloudflareWebSocket[]): {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -944,6 +944,53 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 1, 2, 3]);
   });
 
+  it("does not cache selected runtime session for ignored stale runtime-peer publishes", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimePeer = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-06-07T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        displayName: "Lab2 workstation",
+        defaultEnvironmentLabel: "Current Python",
+        environmentPolicy: "current_python",
+        runtimeSessionId: "job-stale",
+        workingDirectory: "/home/ubuntu/project",
+      },
+    };
+    let checkpointed = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      setWorkstationAttachment: async () => ({
+        ...noopMaterializedResult(),
+        ignored_stale: true,
+      }),
+    } as never);
+
+    await harness.publishRuntimePeerAttachment("demo", runtimePeer);
+
+    assert.equal(checkpointed, 0, "ignored stale publishes are not checkpointed");
+    assert.equal(
+      await harness.runtimePeerAuthorityError?.("demo", {
+        ...runtimePeer.workstation,
+        runtimeSessionId: "job-current",
+      }),
+      null,
+      "ignored stale publish does not poison selected runtime session authority",
+    );
+  });
+
   it("publishes workstation attachment control updates through the room host", async () => {
     const state = hibernatedState([]);
     const room = new NotebookRoom(state.state, {} as Env);
@@ -1132,6 +1179,64 @@ describe("NotebookRoom peer lifecycle", () => {
       ]),
       [["owner-compute:v1:user:dev:alice", "/upsert", "starting", 0, "ws-lab2"]],
     );
+  });
+
+  it("keeps runtime peers when replacement workstation attachment control is ignored as stale", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimeSocket = new FakeSocket();
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-06-07T00:00:00.000Z",
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      setWorkstationAttachment: async () => ({
+        ...noopMaterializedResult(),
+        ignored_stale: true,
+      }),
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          close_runtime_peers: true,
+          close_reason: "workstation restart requested",
+          attachment: {
+            workstation_id: "ws-lab2",
+            display_name: "Lab2 workstation",
+            provider: "runtime_peer",
+            default_environment_label: "Current Python",
+            environment_policy: "current_python",
+            status: "connecting",
+            status_message: "Waiting for Lab2 to accept the compute request.",
+            cpu_count: 8,
+            memory_bytes: 16_000_000_000,
+            working_directory: "/home/ubuntu/project",
+            updated_at: "2026-06-07T00:00:01.000Z",
+            runtime_session_id: "job-stale",
+          },
+        }),
+      }),
+    );
+
+    await state.drain();
+    assert.equal(response.status, 200);
+    assert.equal(harness.hasRuntimePeer(), true);
+    assert.equal(runtimeSocket.closed, false);
+    assert.equal(await state.getAlarm(), null, "ignored stale close does not arm stale repair");
   });
 
   it("does not resurrect a runtime-peer compute summary after attachment clear wins", async () => {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3340,6 +3340,7 @@ describe("NotebookRoom materialized sync routing", () => {
     assert.equal(materialized, 1);
     assert.equal(db.attachJobs.length, 1);
     assert.equal(db.attachJobs[0]?.owner_principal, "user:dev:alice");
+    assert.equal(db.attachJobs[0]?.trigger, "resume");
     assert.equal(db.attachJobs[0]?.requested_by_actor_label, "execution resume");
     assert.equal((publishedAttachment as { status?: string })?.status, "connecting");
     assert.equal(
@@ -4600,6 +4601,7 @@ class ResumeNotebookD1 implements D1Database {
     owner_principal: string;
     workstation_id: string;
     status: string;
+    trigger: string;
     requested_by_actor_label: string;
     requested_at: string;
     updated_at: string;
@@ -4690,6 +4692,7 @@ class ResumeNotebookD1Statement implements D1PreparedStatement {
         notebookId,
         ownerPrincipal,
         workstationId,
+        trigger,
         requestedByActorLabel,
         requestedAt,
         updatedAt,
@@ -4700,6 +4703,7 @@ class ResumeNotebookD1Statement implements D1PreparedStatement {
         owner_principal: ownerPrincipal,
         workstation_id: workstationId,
         status: "pending",
+        trigger,
         requested_by_actor_label: requestedByActorLabel,
         requested_at: requestedAt,
         updated_at: updatedAt,

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3800,6 +3800,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       receiveFrame: async () => noopMaterializedResult(),
       checkpoint: async () => undefined,
       removePeer: async () => undefined,
+      getWorkstationAttachment: async () => null,
       reconcileRuntimePeerGone: async () => {
         reconcileCalls += 1;
         return reconciled;
@@ -3819,6 +3820,72 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     await (room as unknown as { alarm(): Promise<void> }).alarm();
     await state.drain();
     assert.equal(reconcileCalls, 1, "alarm reconciles the orphaned room");
+  });
+
+  it("skips peer-gone reconcile when idle teardown already materialized", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const attachment = {
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "idle",
+      status_message: "Compute stopped after 30 minutes without queued or active execution.",
+      updated_at: "2026-05-22T00:00:02.000Z",
+      runtime_session_id: "job-idle",
+    };
+    let reconcileCalls = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getWorkstationAttachment: async () => attachment,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        attachment.status = "error";
+        attachment.status_message = "runtime peer disconnected";
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.removePeer("demo", runtimePeer);
+    await state.drain();
+    assert.equal(await state.getAlarm(), state.now + 30_000, "watch armed after departure");
+
+    const logs: unknown[][] = [];
+    const originalInfo = console.info;
+    console.info = (...args: unknown[]) => {
+      logs.push(args);
+    };
+    try {
+      await (room as unknown as { alarm(): Promise<void> }).alarm();
+      await state.drain();
+    } finally {
+      console.info = originalInfo;
+    }
+
+    assert.equal(reconcileCalls, 0, "idle attachment suppresses peer-gone reconcile");
+    assert.equal(attachment.status, "idle");
+    assert.equal(attachment.runtime_session_id, "job-idle");
+    assert.equal(attachment.updated_at, "2026-05-22T00:00:02.000Z");
+    const skipLog = logs
+      .map((args) => args[1])
+      .find(
+        (record): record is { event?: unknown; counter?: unknown } =>
+          typeof record === "object" &&
+          record !== null &&
+          (record as { counter?: unknown }).counter === "runtime_peer_watch_skipped_idle",
+      );
+    assert.equal(skipLog?.event, "room.runtime_peer_watch.skipped_idle");
   });
 
   it("tears down an idle runtime after the TTL without considering viewer sockets", async () => {
@@ -3880,6 +3947,46 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     assert.equal(runtimeSocket.closed, true);
     assert.equal(runtimeSocket.closeReason, "runtime idle timeout");
     assert.equal(viewerSocket.closed, false, "viewer presence must not defer idle teardown");
+  });
+
+  it("clears a racing peer-gone watch after idle teardown owns the room state", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimeSocket = new FakeSocket();
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    runtimePeer.socket = runtimeSocket.asCloudflareWebSocket();
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    let idleReconciles = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getRuntimeExecutionActivity: async () => ({ executing: false, queueDepth: 0 }),
+      reconcileRuntimeIdleTimeout: async () => {
+        idleReconciles += 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+
+    await state.state.storage.put("runtime_peer_gone_watch", "demo");
+    await state.state.storage.put("runtime_peer_gone_watch_alarm_at", Number.MAX_SAFE_INTEGER);
+    await state.state.storage.put("runtime_idle_watch", "demo");
+    await state.state.storage.put("runtime_idle_watch_alarm_at", 0);
+
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+
+    assert.equal(idleReconciles, 1);
+    assert.equal(runtimeSocket.closed, true);
+    assert.equal(runtimeSocket.closeReason, "runtime idle timeout");
+    assert.equal(await state.state.storage.get("runtime_peer_gone_watch"), undefined);
+    assert.equal(await state.state.storage.get("runtime_peer_gone_watch_alarm_at"), undefined);
+    assert.equal(await state.getAlarm(), null);
   });
 
   it("does not arm idle teardown while execution is active or queued", async () => {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3845,6 +3845,13 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
           ...noopMaterializedResult(),
           changed: true,
           runtime_state_changed: true,
+          outbound: [
+            {
+              peer_id: "rt",
+              frame_type: FrameType.RUNTIME_STATE_SYNC,
+              payload: new Uint8Array([7, 8, 9]),
+            },
+          ],
         };
       },
       getWorkstationAttachment: async () => ({
@@ -3869,6 +3876,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     await state.drain();
 
     assert.equal(idleReconciles, 1);
+    assert.deepEqual([...runtimeSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 7, 8, 9]);
     assert.equal(runtimeSocket.closed, true);
     assert.equal(runtimeSocket.closeReason, "runtime idle timeout");
     assert.equal(viewerSocket.closed, false, "viewer presence must not defer idle teardown");

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/identity.ts";
 import {
   NotebookRoom,
+  RUNTIME_IDLE_TTL_MS,
   presencePeerLabel,
   rejectedFramePolicy,
   runtimePeerWorkstationMetadataFromRequest,
@@ -3277,6 +3278,121 @@ describe("NotebookRoom materialized sync routing", () => {
     assert.equal(accepted.type, "cloud_frame_accepted");
   });
 
+  it("creates an owner-scoped resume attach job when owner execution finds no runtime peer", async () => {
+    const db = new ResumeNotebookD1();
+    const room = new NotebookRoom(fakeState(), { DB: db } as unknown as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let materialized = 0;
+    let publishedAttachment: unknown = null;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "Lab2",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "disconnected",
+        status_message: "Compute stopped after 30 minutes without queued or active execution.",
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/srv/project",
+        updated_at: "2026-05-22T00:00:00.000Z",
+        runtime_session_id: "job-old",
+      }),
+      setWorkstationAttachment: async (attachment: unknown) => {
+        publishedAttachment = attachment;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+
+    assert.equal(materialized, 1);
+    assert.equal(db.attachJobs.length, 1);
+    assert.equal(db.attachJobs[0]?.owner_principal, "user:dev:alice");
+    assert.equal(db.attachJobs[0]?.requested_by_actor_label, "execution resume");
+    assert.equal((publishedAttachment as { status?: string })?.status, "connecting");
+    assert.equal(
+      (publishedAttachment as { runtime_session_id?: string })?.runtime_session_id,
+      db.attachJobs[0]?.id,
+    );
+    const accepted = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(accepted.type, "cloud_frame_accepted");
+  });
+
+  it("rejects non-owner execution without creating a resume attach job", async () => {
+    const db = new ResumeNotebookD1();
+    const room = new NotebookRoom(fakeState(), { DB: db } as unknown as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "editor",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        throw new Error("non-owner execution should not reach the room host");
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getWorkstationAttachment: async () => {
+        throw new Error("non-owner execution should not inspect workstation attachment");
+      },
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+
+    assert.equal(db.attachJobs.length, 0);
+    const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(rejected.type, "cloud_frame_rejected");
+    assert.equal(rejected.reason, "editor cannot write request frames");
+  });
+
   it("rejects response-bearing runtime REQUEST frames instead of acknowledging no-ops", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(
@@ -3514,6 +3630,77 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     await (room as unknown as { alarm(): Promise<void> }).alarm();
     await state.drain();
     assert.equal(reconcileCalls, 1, "alarm reconciles the orphaned room");
+  });
+
+  it("tears down an idle runtime after the TTL without considering viewer sockets", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimeSocket = new FakeSocket();
+    const viewerSocket = new FakeSocket();
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    runtimePeer.socket = runtimeSocket.asCloudflareWebSocket();
+    const viewerPeer = peerWithScope("viewer", "viewer");
+    viewerPeer.socket = viewerSocket.asCloudflareWebSocket();
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.peers.set(viewerPeer.id, viewerPeer);
+    let idleReconciles = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getRuntimeExecutionActivity: async () => ({ executing: false, queueDepth: 0 }),
+      reconcileRuntimeIdleTimeout: async () => {
+        idleReconciles += 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "Lab2",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        updated_at: "2026-05-22T00:00:00.000Z",
+        runtime_session_id: "job-idle",
+      }),
+    } as never);
+
+    harness.refreshRuntimeIdleWatch?.("demo");
+    await state.drain();
+
+    assert.equal(await state.getAlarm(), state.now + RUNTIME_IDLE_TTL_MS);
+
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+
+    assert.equal(idleReconciles, 1);
+    assert.equal(runtimeSocket.closed, true);
+    assert.equal(runtimeSocket.closeReason, "runtime idle timeout");
+    assert.equal(viewerSocket.closed, false, "viewer presence must not defer idle teardown");
+  });
+
+  it("does not arm idle teardown while execution is active or queued", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    harness.peers.set("rt", peerWithScope("rt", "runtime_peer"));
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getRuntimeExecutionActivity: async () => ({ executing: true, queueDepth: 1 }),
+    } as never);
+
+    harness.refreshRuntimeIdleWatch?.("demo");
+    await state.drain();
+
+    assert.equal(await state.getAlarm(), null);
   });
 
   it("publishes active runtime peers to the owner compute index", async () => {
@@ -4147,13 +4334,16 @@ interface RoomHarness {
       syncPeer?(): Promise<RoomHostFrameResult>;
       receiveFrame(): Promise<RoomHostFrameResult>;
       checkpoint(): Promise<void>;
+      getRuntimeExecutionActivity?(): Promise<{ executing: boolean; queueDepth: number }>;
       getRuntimeQueueDepth?(): Promise<number>;
       getWorkstationAttachment?(): Promise<unknown>;
       removePeer?(peerId: string): Promise<void>;
+      reconcileRuntimeIdleTimeout?(reason: string, updatedAt: string): Promise<RoomHostFrameResult>;
       reconcileRuntimePeerGone?(reason: string): Promise<RoomHostFrameResult>;
       setWorkstationAttachment?(attachment: unknown): Promise<RoomHostFrameResult>;
     }
   >;
+  refreshRuntimeIdleWatch?(notebookId: string): void;
   refreshRuntimePeerWatch?(notebookId: string): void;
   roomSummaryOccupantKeys(): Set<string>;
   publishRoomSummaryIfHumanOccupantsChanged(
@@ -4400,6 +4590,129 @@ class CountingNotebookOwnerD1 extends NotebookOwnerD1 {
       this.notebookLookupCount += 1;
     }
     return super.prepare(query);
+  }
+}
+
+class ResumeNotebookD1 implements D1Database {
+  readonly attachJobs: Array<{
+    id: string;
+    notebook_id: string;
+    owner_principal: string;
+    workstation_id: string;
+    status: string;
+    requested_by_actor_label: string;
+    requested_at: string;
+    updated_at: string;
+    accepted_at: string | null;
+    finished_at: string | null;
+    error_message: string | null;
+  }> = [];
+
+  prepare(query: string): D1PreparedStatement {
+    return new ResumeNotebookD1Statement(this, query);
+  }
+
+  async exec(): Promise<D1Result> {
+    return d1OkResult();
+  }
+
+  async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    const results: D1Result<T>[] = [];
+    for (const statement of statements) {
+      results.push(await statement.run<T>());
+    }
+    return results;
+  }
+}
+
+class ResumeNotebookD1Statement implements D1PreparedStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly db: ResumeNotebookD1,
+    private readonly query: string,
+  ) {}
+
+  bind(...values: unknown[]): D1PreparedStatement {
+    this.values = values;
+    return this;
+  }
+
+  async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM notebooks") && this.query.includes("WHERE id = ?")) {
+      const notebookId = String(this.values[0] ?? "demo");
+      return {
+        id: notebookId,
+        owner_principal: "user:dev:alice",
+        title: "Demo",
+        created_at: "2026-06-23T00:00:00.000Z",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        latest_revision_id: null,
+      } as T;
+    }
+    if (this.query.includes("FROM workstations") && this.query.includes("workstation_id = ?")) {
+      return {
+        owner_principal: "user:dev:alice",
+        workstation_id: "ws-lab2",
+        display_name: "Lab2",
+        provider: "runtime_peer",
+        provider_label: null,
+        status: "online",
+        status_message: null,
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        working_directory: "/srv/project",
+        cpu_count: null,
+        memory_bytes: null,
+        environments_json: null,
+        created_at: "2026-06-23T00:00:00.000Z",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        last_seen_at: new Date().toISOString(),
+      } as T;
+    }
+    if (this.query.includes("FROM workstation_attach_jobs") && this.query.includes("LIMIT 1")) {
+      return null;
+    }
+    if (
+      this.query.includes("FROM workstation_attach_jobs") &&
+      this.query.includes("WHERE id = ?")
+    ) {
+      const [jobId] = this.values;
+      return (this.db.attachJobs.find((job) => job.id === jobId) ?? null) as T | null;
+    }
+    return null;
+  }
+
+  async run<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("INSERT INTO workstation_attach_jobs")) {
+      const [
+        id,
+        notebookId,
+        ownerPrincipal,
+        workstationId,
+        requestedByActorLabel,
+        requestedAt,
+        updatedAt,
+      ] = this.values.map((value) => String(value));
+      this.db.attachJobs.push({
+        id,
+        notebook_id: notebookId,
+        owner_principal: ownerPrincipal,
+        workstation_id: workstationId,
+        status: "pending",
+        requested_by_actor_label: requestedByActorLabel,
+        requested_at: requestedAt,
+        updated_at: updatedAt,
+        accepted_at: null,
+        finished_at: null,
+        error_message: null,
+      });
+    }
+    return d1OkResult<T>();
+  }
+
+  async all<T = unknown>(): Promise<D1Result<T>> {
+    return d1OkResult<T>([]);
   }
 }
 

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1700,6 +1700,7 @@ describe("RoomMaterializer", () => {
     const result = await materializer.setWorkstationAttachment(attachment);
 
     assert.equal(result.changed, true);
+    assert.equal(result.ignored_stale, false);
     assert.equal(result.runtime_state_changed, true);
     assert.ok(
       result.outbound.some(
@@ -1717,7 +1718,44 @@ describe("RoomMaterializer", () => {
 
     const again = await materializer.setWorkstationAttachment(attachment);
     assert.equal(again.changed, false, "same attachment is idempotent");
+    assert.equal(again.ignored_stale, false);
     assert.deepEqual(again.outbound, []);
+  });
+
+  it("passes through ignored stale workstation attachment publishes", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const current = {
+      workstation_id: "ws-current",
+      display_name: "Current workstation",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "runtime_peer",
+      status: "ready",
+      status_message: null,
+      cpu_count: null,
+      memory_bytes: null,
+      working_directory: null,
+      updated_at: "2026-06-07T00:00:02.000Z",
+      runtime_session_id: "job-current",
+    };
+    const seeded = await materializer.setWorkstationAttachment(current);
+    assert.equal(seeded.changed, true);
+    assert.equal(seeded.ignored_stale, false);
+
+    const stale = {
+      ...current,
+      workstation_id: "ws-stale",
+      display_name: "Stale workstation",
+      updated_at: "2026-06-07T00:00:01.000Z",
+      runtime_session_id: "job-stale",
+    };
+    const ignored = await materializer.setWorkstationAttachment(stale);
+
+    assert.equal(ignored.changed, false);
+    assert.equal(ignored.ignored_stale, true);
+    assert.deepEqual(ignored.outbound, []);
+    assert.deepEqual(await materializer.getWorkstationAttachment(), current);
   });
 
   it("allows owner-scoped CommsDoc changes to existing runtime comm topology", async () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -263,6 +263,46 @@ test("cloud shell capabilities require live runtime peer presence for executable
   assert.equal(capabilities.canExecute, false);
 });
 
+test("cloud shell capabilities let owners run to wake an idle attachment without claiming connectivity", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: false,
+    runtimePeerCount: 0,
+    runtimeLastSeenAt: "2026-06-07T21:02:00Z",
+    workstationAttachment: {
+      workstation_id: "ws-lab2",
+      display_name: "Lab 2",
+      provider: "local_daemon",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "idle",
+      status_message: null,
+      cpu_count: 8,
+      memory_bytes: 32 * 1024 ** 3,
+      working_directory: "/home/ubuntu/notebooks",
+      updated_at: "2026-06-07T21:00:00Z",
+    },
+  });
+
+  assert.equal(capabilities.runtime.connected, false);
+  assert.equal(capabilities.runtime.executionAvailable, true);
+  assert.equal(capabilities.runtime.target?.id, "ws-lab2");
+  assert.equal(capabilities.runtime.target?.label, "Lab 2");
+  assert.equal(capabilities.runtime.target?.status, "attached");
+  assert.equal(capabilities.runtime.target?.attachmentIdle, true);
+  assert.equal(capabilities.runtime.target?.statusLabel, "Idle");
+  assert.equal(
+    capabilities.runtime.target?.detail,
+    "Compute is attached and starts on the next run.",
+  );
+  assert.equal(capabilities.runtime.target?.runtimePeerCount, null);
+  assert.equal(capabilities.runtime.target?.roomLink, null);
+  assert.equal(capabilities.canExecute, true);
+});
+
 test("cloud shell capabilities surface RuntimeStateDoc kernel status on workstation targets", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3303,6 +3303,60 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.workstationAttachJobs.size, 1);
   });
 
+  it("upgrades a deduped resume attach job when the owner explicitly attaches", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "resume-job",
+      notebookId: "attach-demo",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      requestedAt: new Date().toISOString(),
+      trigger: "resume",
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const body = (await attach.json()) as { job: { job_id: string; trigger: string } };
+    assert.equal(body.job.job_id, "resume-job");
+    assert.equal(body.job.trigger, "user_attach");
+    assert.equal(env.DB.workstationAttachJobs.get("resume-job")?.trigger, "user_attach");
+
+    const poll = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(poll.status, 200);
+    const polled = (await poll.json()) as { jobs: Array<{ job_id: string; trigger: string }> };
+    assert.deepEqual(
+      polled.jobs.map((job) => ({ job_id: job.job_id, trigger: job.trigger })),
+      [{ job_id: "resume-job", trigger: "user_attach" }],
+    );
+  });
+
   it("switches active workstation attach jobs to the newly attached workstation", async () => {
     let runtimeStateRequest: Request | undefined;
     const env = fakeEnv({
@@ -9524,6 +9578,29 @@ class FakeD1Statement implements D1PreparedStatement {
         }
       }
       return okResult(undefined, { changes });
+    } else if (
+      this.query.includes("UPDATE workstation_attach_jobs") &&
+      this.query.includes("SET trigger = 'user_attach'")
+    ) {
+      const [updatedAt, jobId, ownerPrincipal, workstationId] = this.values as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const job = this.db.workstationAttachJobs.get(jobId);
+      if (
+        job &&
+        job.owner_principal === ownerPrincipal &&
+        job.workstation_id === workstationId &&
+        job.trigger === "resume" &&
+        isActiveWorkstationAttachJobStatus(job.status)
+      ) {
+        job.trigger = "user_attach";
+        job.updated_at = updatedAt;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (
       this.query.includes("UPDATE workstation_attach_jobs") &&
       this.query.includes("SET status = 'cancelled'")

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -38,6 +38,7 @@ import {
   blobKey,
   commsDocSnapshotKey,
   createNotebookWithOwnerAcl,
+  ensureCatalogSchema,
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
   roomSummaryKey,
@@ -60,6 +61,93 @@ const APP_SESSION_SECRET = "0123456789abcdef0123456789abcdef";
 
 before(async () => {
   await initializeTestRuntimedWasm();
+});
+
+describe("catalog schema runtime initialization", () => {
+  it("dedupes duplicate active attach jobs before creating the owner unique index", async () => {
+    const db = new FakeD1();
+    db.indexes.delete("workstation_attach_jobs_active_owner_unique_idx");
+    const env = fakeEnv({ DB: db });
+    const errorMessage = "cancelled by active workstation attach job uniqueness migration";
+
+    seedWorkstationAttachJob(env, {
+      id: "older-active",
+      notebookId: "notebook-duplicate-attach",
+      ownerPrincipal: "principal:alice",
+      workstationId: "ws-lab-a",
+      status: "accepted",
+      requestedAt: "2026-07-09T00:00:00.000Z",
+      updatedAt: "2026-07-09T00:00:01.000Z",
+    });
+    seedWorkstationAttachJob(env, {
+      id: "newer-active",
+      notebookId: "notebook-duplicate-attach",
+      ownerPrincipal: "principal:alice",
+      workstationId: "ws-lab-b",
+      status: "running",
+      requestedAt: "2026-07-09T00:01:00.000Z",
+      updatedAt: "2026-07-09T00:01:01.000Z",
+    });
+
+    await ensureCatalogSchema(env);
+
+    assert.equal(db.workstationAttachJobs.get("newer-active")?.status, "running");
+    const older = db.workstationAttachJobs.get("older-active");
+    assert.equal(older?.status, "cancelled");
+    assert.equal(older?.error_message, errorMessage);
+    assert.ok(older?.updated_at, "dedupe stamps updated_at");
+    assert.ok(older?.finished_at, "dedupe stamps finished_at");
+    assert.ok(
+      db.indexes.has("workstation_attach_jobs_active_owner_unique_idx"),
+      "owner unique index was created",
+    );
+
+    const dedupeOffset = db.executedStatements.findIndex(
+      (statement) => statement.includes("ROW_NUMBER() OVER") && statement.includes(errorMessage),
+    );
+    const dropOffset = db.executedStatements.findIndex((statement) =>
+      statement.includes("DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx"),
+    );
+    const createOffset = db.executedStatements.findIndex((statement) =>
+      statement.includes(
+        "CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_owner_unique_idx",
+      ),
+    );
+    assert.ok(dedupeOffset >= 0, "runtime schema executed the active attach-job dedupe");
+    assert.ok(dropOffset >= 0, "runtime schema dropped the legacy active index");
+    assert.ok(createOffset >= 0, "runtime schema created the owner active index");
+    assert.ok(dedupeOffset < dropOffset, "dedupe ran before the legacy index drop");
+    assert.ok(dropOffset < createOffset, "legacy index drop ran before owner index create");
+
+    await assert.rejects(
+      db
+        .prepare(
+          `INSERT INTO workstation_attach_jobs (
+             id,
+             notebook_id,
+             owner_principal,
+             workstation_id,
+             status,
+             trigger,
+             requested_by_actor_label,
+             requested_at,
+             updated_at
+           ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
+        )
+        .bind(
+          "third-active",
+          "notebook-duplicate-attach",
+          "principal:alice",
+          "ws-lab-c",
+          "user_attach",
+          "user:dev:alice/browser:tab",
+          "2026-07-09T00:02:00.000Z",
+          "2026-07-09T00:02:00.000Z",
+        )
+        .run(),
+      /UNIQUE constraint failed: workstation_attach_jobs\.notebook_id, workstation_attach_jobs\.owner_principal/,
+    );
+  });
 });
 
 describe("Worker artifact routes", () => {
@@ -7419,21 +7507,53 @@ describe("catalog schema migrations", () => {
       "CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx";
 
     const storageSource = await readFile(new URL("../src/storage.ts", import.meta.url), "utf8");
+    const migration = await readFile(
+      new URL("../migrations/0008_workstation_attach_active_owner_unique.sql", import.meta.url),
+      "utf8",
+    );
+    const dedupeStart = migration.indexOf("UPDATE workstation_attach_jobs");
+    const dedupeEnd = migration.indexOf("\n\nDROP INDEX", dedupeStart);
+    assert.ok(dedupeStart >= 0, "migration dedupes duplicate active attach jobs");
+    assert.ok(dedupeEnd > dedupeStart, "migration orders dedupe before index swap");
+    const dedupeUpdate = migration.slice(dedupeStart, dedupeEnd);
+    const dedupeOffset = storageSource.indexOf(dedupeUpdate);
+    assert.ok(dedupeOffset >= 0, "runtime schema includes the migration dedupe update");
+
+    const schemaStart = storageSource.indexOf("const SCHEMA_STATEMENTS = [");
+    assert.ok(schemaStart >= 0, "runtime schema statements are present");
+    const schemaDedupeOffset = storageSource.indexOf(
+      "WORKSTATION_ATTACH_JOBS_DEDUPE_ACTIVE_OWNER",
+      schemaStart,
+    );
+    const schemaDropOffset = storageSource.indexOf(
+      "WORKSTATION_ATTACH_JOBS_DROP_LEGACY_ACTIVE_UNIQUE_INDEX",
+      schemaStart,
+    );
+    const schemaCreateOffset = storageSource.indexOf(
+      "WORKSTATION_ATTACH_JOBS_ACTIVE_UNIQUE_INDEX",
+      schemaStart,
+    );
     const dropOffset = storageSource.indexOf(legacyDrop);
     const createOffset = storageSource.indexOf(ownerIndexCreate);
     assert.ok(dropOffset >= 0, "runtime schema drops the old 3-column index name");
     assert.ok(createOffset >= 0, "runtime schema creates the new owner-level index name");
-    assert.ok(dropOffset < createOffset, "runtime schema drops the old name before creating new");
+    assert.ok(schemaDedupeOffset >= 0, "runtime schema references the dedupe statement");
+    assert.ok(schemaDropOffset >= 0, "runtime schema references the legacy index drop");
+    assert.ok(schemaCreateOffset >= 0, "runtime schema references the owner index create");
+    assert.ok(
+      schemaDedupeOffset < schemaDropOffset,
+      "runtime schema dedupes before dropping the old index",
+    );
+    assert.ok(
+      schemaDropOffset < schemaCreateOffset,
+      "runtime schema drops the old name before creating new",
+    );
     assert.equal(
       storageSource.includes(`${legacyIndexCreate}\n    ON workstation_attach_jobs`),
       false,
       "runtime schema does not recreate the old index name",
     );
 
-    const migration = await readFile(
-      new URL("../migrations/0008_workstation_attach_active_owner_unique.sql", import.meta.url),
-      "utf8",
-    );
     assert.ok(migration.includes(legacyDrop), "migration drops the old index name");
     assert.ok(migration.includes(ownerIndexCreate), "migration creates the new index name");
     assert.equal(
@@ -8856,6 +8976,8 @@ class FakeD1 implements D1Database {
   readonly workstationPairingCodes = new Map<string, WorkstationPairingCodeRow>();
   readonly workstationCredentials = new Map<string, WorkstationCredentialRow>();
   readonly batchSizes: number[] = [];
+  readonly executedStatements: string[] = [];
+  readonly indexes = new Set<string>(["workstation_attach_jobs_active_owner_unique_idx"]);
   readonly tableColumns = new Map<string, Set<string>>([
     [
       "notebooks",
@@ -9086,6 +9208,7 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async run<T = unknown>(): Promise<D1Result<T>> {
+    this.db.executedStatements.push(this.query);
     const alterMatch = this.query.match(/ALTER TABLE\s+(\w+)\s+ADD COLUMN\s+(\w+)/i);
     if (alterMatch) {
       const [, table, column] = alterMatch;
@@ -9498,6 +9621,31 @@ class FakeD1Statement implements D1PreparedStatement {
       const [ownerPrincipal, workstationId] = this.values as [string, string];
       const deleted = this.db.workstations.delete(workstationKey(ownerPrincipal, workstationId));
       return okResult(undefined, { changes: deleted ? 1 : 0 });
+    } else if (
+      this.query.includes("DROP INDEX IF EXISTS workstation_attach_jobs_active_unique_idx")
+    ) {
+      this.db.indexes.delete("workstation_attach_jobs_active_unique_idx");
+    } else if (
+      this.query.includes(
+        "CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_owner_unique_idx",
+      )
+    ) {
+      if (!this.db.indexes.has("workstation_attach_jobs_active_owner_unique_idx")) {
+        const activeGroups = new Set<string>();
+        for (const job of this.db.workstationAttachJobs.values()) {
+          if (!isActiveWorkstationAttachJobStatus(job.status)) {
+            continue;
+          }
+          const key = `${job.notebook_id}\u0000${job.owner_principal}`;
+          if (activeGroups.has(key)) {
+            throw new Error(
+              "D1_ERROR: UNIQUE constraint failed: workstation_attach_jobs.notebook_id, workstation_attach_jobs.owner_principal",
+            );
+          }
+          activeGroups.add(key);
+        }
+        this.db.indexes.add("workstation_attach_jobs_active_owner_unique_idx");
+      }
     } else if (this.query.includes("INSERT INTO workstation_attach_jobs")) {
       const hasTriggerColumn = /\btrigger\b/i.test(this.query);
       const [id, notebookId, ownerPrincipal, workstationId] = this.values as [
@@ -9512,13 +9660,15 @@ class FakeD1Statement implements D1PreparedStatement {
       const actorLabel = String(this.values[hasTriggerColumn ? 5 : 4]);
       const requestedAt = String(this.values[hasTriggerColumn ? 6 : 5]);
       const updatedAt = String(this.values[hasTriggerColumn ? 7 : 6]);
-      const duplicate = [...this.db.workstationAttachJobs.values()].find(
-        (job) =>
-          job.notebook_id === notebookId &&
-          job.owner_principal === ownerPrincipal &&
-          isActiveWorkstationAttachJobStatus(job.status),
-      );
-      if (duplicate) {
+      if (
+        this.db.indexes.has("workstation_attach_jobs_active_owner_unique_idx") &&
+        [...this.db.workstationAttachJobs.values()].some(
+          (job) =>
+            job.notebook_id === notebookId &&
+            job.owner_principal === ownerPrincipal &&
+            isActiveWorkstationAttachJobStatus(job.status),
+        )
+      ) {
         throw new Error(
           "D1_ERROR: UNIQUE constraint failed: workstation_attach_jobs.notebook_id, workstation_attach_jobs.owner_principal",
         );
@@ -9538,6 +9688,39 @@ class FakeD1Statement implements D1PreparedStatement {
         error_message: null,
       });
       return okResult(undefined, { changes: 1 });
+    } else if (
+      this.query.includes("UPDATE workstation_attach_jobs") &&
+      this.query.includes("ROW_NUMBER() OVER") &&
+      this.query.includes("cancelled by active workstation attach job uniqueness migration")
+    ) {
+      const now = new Date().toISOString();
+      let changes = 0;
+      const groups = new Map<string, WorkstationAttachJobRow[]>();
+      for (const job of this.db.workstationAttachJobs.values()) {
+        if (!isActiveWorkstationAttachJobStatus(job.status)) {
+          continue;
+        }
+        const key = `${job.notebook_id}\u0000${job.owner_principal}`;
+        const group = groups.get(key) ?? [];
+        group.push(job);
+        groups.set(key, group);
+      }
+      for (const group of groups.values()) {
+        group.sort(
+          (left, right) =>
+            right.requested_at.localeCompare(left.requested_at) ||
+            right.updated_at.localeCompare(left.updated_at) ||
+            right.id.localeCompare(left.id),
+        );
+        for (const job of group.slice(1)) {
+          job.status = "cancelled";
+          job.updated_at = now;
+          job.finished_at = now;
+          job.error_message = "cancelled by active workstation attach job uniqueness migration";
+          changes += 1;
+        }
+      }
+      return okResult(undefined, { changes });
     } else if (
       this.query.includes("UPDATE workstation_attach_jobs") &&
       this.query.includes("stale workstation attach job expired after heartbeat timeout")

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2951,14 +2951,16 @@ describe("Worker artifact routes", () => {
 
     assert.equal(attach.status, 202);
     const body = (await attach.json()) as {
-      job: { job_id: string; notebook_id: string; status: string };
+      job: { job_id: string; notebook_id: string; status: string; trigger: string };
       workstation: { is_default?: boolean; workstation_id?: string };
     };
     assert.equal(body.job.notebook_id, "attach-demo");
     assert.equal(body.job.status, "pending");
+    assert.equal(body.job.trigger, "user_attach");
     assert.equal(body.workstation.workstation_id, "ws-lab1");
     assert.equal(body.workstation.is_default, false);
     assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.workstation_id, "ws-lab1");
+    assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.trigger, "user_attach");
     assert.equal(
       env.DB.acl.some(
         (row) =>
@@ -2989,10 +2991,14 @@ describe("Worker artifact routes", () => {
       fakeContext(),
     );
     assert.equal(poll.status, 200);
-    const polled = (await poll.json()) as { jobs: Array<{ job_id: string }> };
+    const polled = (await poll.json()) as { jobs: Array<{ job_id: string; trigger: string }> };
     assert.deepEqual(
       polled.jobs.map((job) => job.job_id),
       [body.job.job_id],
+    );
+    assert.deepEqual(
+      polled.jobs.map((job) => job.trigger),
+      ["user_attach"],
     );
   });
 
@@ -3785,6 +3791,7 @@ describe("Worker artifact routes", () => {
       notebook_id: "nb-1",
       workstation_id: "ws-lab2",
       status: "running",
+      trigger: "user_attach",
       requested_at: "2026-05-22T00:00:00.000Z",
       updated_at: env.DB.workstationAttachJobs.get("job-1")?.updated_at,
       accepted_at: env.DB.workstationAttachJobs.get("job-1")?.accepted_at,
@@ -3935,6 +3942,7 @@ describe("Worker artifact routes", () => {
         notebook_id: "nb-running",
         workstation_id: "ws-lab2",
         status: "running",
+        trigger: "user_attach",
         requested_at: "2026-05-22T00:00:00.000Z",
         updated_at: "2026-05-22T00:00:02.000Z",
         accepted_at: null,
@@ -4074,6 +4082,7 @@ describe("Worker artifact routes", () => {
         notebook_id: "nb-old",
         workstation_id: "ws-lab2",
         status: "cancelled",
+        trigger: "user_attach",
         requested_at: "2026-05-22T00:00:00.000Z",
         updated_at: "2026-05-22T00:00:00.000Z",
         accepted_at: null,
@@ -7392,6 +7401,9 @@ describe("catalog schema migrations", () => {
     assert.ok(revisionColumns);
     revisionColumns.delete("cover_blob_hash");
     revisionColumns.delete("cover_mime");
+    const attachJobColumns = db.tableColumns.get("workstation_attach_jobs");
+    assert.ok(attachJobColumns);
+    attachJobColumns.delete("trigger");
 
     const env = fakeEnv({ DB: db });
     await runCatalogMigrations(env);
@@ -7403,6 +7415,8 @@ describe("catalog schema migrations", () => {
     const migratedRevisions = db.tableColumns.get("notebook_revisions");
     assert.ok(migratedRevisions?.has("cover_blob_hash"), "cover_blob_hash added by migration");
     assert.ok(migratedRevisions?.has("cover_mime"), "cover_mime added by migration");
+    const migratedAttachJobs = db.tableColumns.get("workstation_attach_jobs");
+    assert.ok(migratedAttachJobs?.has("trigger"), "attach job trigger added by migration");
   });
 });
 
@@ -8303,6 +8317,7 @@ function seedWorkstationAttachJob(
     finishedAt?: string | null;
     requestedAt?: string;
     status?: WorkstationAttachJobRow["status"];
+    trigger?: WorkstationAttachJobRow["trigger"];
     updatedAt?: string;
   },
 ): void {
@@ -8312,6 +8327,7 @@ function seedWorkstationAttachJob(
     owner_principal: input.ownerPrincipal,
     workstation_id: input.workstationId,
     status: input.status ?? "pending",
+    trigger: input.trigger ?? "user_attach",
     requested_by_actor_label: "user:dev:alice/browser:tab",
     requested_at: input.requestedAt ?? "2026-05-22T00:00:00.000Z",
     updated_at: input.updatedAt ?? "2026-05-22T00:00:00.000Z",
@@ -8762,6 +8778,7 @@ interface WorkstationAttachJobRow {
   owner_principal: string;
   workstation_id: string;
   status: "pending" | "accepted" | "running" | "failed" | "completed" | "cancelled";
+  trigger: "user_attach" | "resume";
   requested_by_actor_label: string;
   requested_at: string;
   updated_at: string;
@@ -8818,6 +8835,23 @@ class FakeD1 implements D1Database {
         "cover_mime",
         "actor_label",
         "created_at",
+      ]),
+    ],
+    [
+      "workstation_attach_jobs",
+      new Set([
+        "id",
+        "notebook_id",
+        "owner_principal",
+        "workstation_id",
+        "status",
+        "trigger",
+        "requested_by_actor_label",
+        "requested_at",
+        "updated_at",
+        "accepted_at",
+        "finished_at",
+        "error_message",
       ]),
     ],
   ]);
@@ -9411,8 +9445,19 @@ class FakeD1Statement implements D1PreparedStatement {
       const deleted = this.db.workstations.delete(workstationKey(ownerPrincipal, workstationId));
       return okResult(undefined, { changes: deleted ? 1 : 0 });
     } else if (this.query.includes("INSERT INTO workstation_attach_jobs")) {
-      const [id, notebookId, ownerPrincipal, workstationId, actorLabel, requestedAt, updatedAt] =
-        this.values as [string, string, string, string, string, string, string];
+      const hasTriggerColumn = /\btrigger\b/i.test(this.query);
+      const [id, notebookId, ownerPrincipal, workstationId] = this.values as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const trigger = hasTriggerColumn
+        ? (this.values[4] as WorkstationAttachJobRow["trigger"])
+        : "user_attach";
+      const actorLabel = String(this.values[hasTriggerColumn ? 5 : 4]);
+      const requestedAt = String(this.values[hasTriggerColumn ? 6 : 5]);
+      const updatedAt = String(this.values[hasTriggerColumn ? 7 : 6]);
       const duplicate = [...this.db.workstationAttachJobs.values()].find(
         (job) =>
           job.notebook_id === notebookId &&
@@ -9430,6 +9475,7 @@ class FakeD1Statement implements D1PreparedStatement {
         owner_principal: ownerPrincipal,
         workstation_id: workstationId,
         status: "pending",
+        trigger,
         requested_by_actor_label: actorLabel,
         requested_at: requestedAt,
         updated_at: updatedAt,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -131,13 +131,14 @@ export function cloudNotebookShellCapabilities({
     normalizedSelfDisplayValue(selfDisplay?.imageUrl) ?? cloudIdentityImageUrl(authState);
   const visibleRuntimePeerCount = Math.max(0, Math.floor(runtimePeerCount));
   const hasRuntimePeer = visibleRuntimePeerCount > 0;
+  const attachmentIdleWake = workstationAttachment?.status === "idle";
   const attachmentConnected = workstationAttachmentIsConnected(workstationAttachment);
   const attachmentExecutionAvailable =
     workstationAttachmentCanExecute(workstationAttachment) && hasRuntimePeer;
   const hasAttachmentSnapshot = workstationAttachment !== null;
   const effectiveRuntimeConnected = hasAttachmentSnapshot ? attachmentConnected : runtimeAvailable;
   const effectiveRuntimeAvailable = hasAttachmentSnapshot
-    ? attachmentExecutionAvailable
+    ? attachmentExecutionAvailable || attachmentIdleWake
     : runtimeAvailable;
   const auth = {
     canSignIn: !hasAppSession && authState.mode !== "oidc",

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -368,10 +368,10 @@ fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io
 }
 
 pub fn cloud_close_is_graceful_shutdown(error: &std::io::Error) -> bool {
+    let message = error.to_string();
     error.kind() == std::io::ErrorKind::PermissionDenied
-        && error
-            .to_string()
-            .contains(RUNTIME_IDLE_TIMEOUT_CLOSE_REASON)
+        && message.starts_with("cloud room closed runtime peer:")
+        && message.ends_with("reason=runtime idle timeout")
 }
 
 /// Read frames from `source` until the room reaches a terminal ready state,
@@ -1057,6 +1057,13 @@ mod tests {
         );
         assert!(!cloud_close_is_graceful_shutdown(&arbitrary_clean_close));
         assert!(!transport.stream_error_is_graceful_shutdown(&arbitrary_clean_close));
+
+        let rejected_frame = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "cloud frame rejected: reason=runtime idle timeout is not valid in this context",
+        );
+        assert!(!cloud_close_is_graceful_shutdown(&rejected_frame));
+        assert!(!transport.stream_error_is_graceful_shutdown(&rejected_frame));
     }
 
     #[test]

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -60,6 +60,7 @@ use tracing::{debug, info, warn};
 /// First-byte constant for the session-control channel (`cloud_room_ready`
 /// arrives here). Re-export of the wire constant for local readability.
 const SESSION_CONTROL: u8 = notebook_wire::frame_types::SESSION_CONTROL;
+pub const RUNTIME_IDLE_TIMEOUT_CLOSE_REASON: &str = "runtime idle timeout";
 
 /// How long [`CloudWsFrameTransport::connect`] waits for the room to reach the
 /// `cloud_room_ready` / `cloud_frame_rejected` state after a successful WS
@@ -342,6 +343,7 @@ fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io
         reason,
         "too many rejected frames"
             | "replaced by newer runtime peer"
+            | RUNTIME_IDLE_TIMEOUT_CLOSE_REASON
             | "workstation attachment replaced"
             | "workstation restart requested"
             | "workstation mismatch"
@@ -363,6 +365,13 @@ fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io
             }
         ),
     ))
+}
+
+pub fn cloud_close_is_graceful_shutdown(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::PermissionDenied
+        && error
+            .to_string()
+            .contains(RUNTIME_IDLE_TIMEOUT_CLOSE_REASON)
 }
 
 /// Read frames from `source` until the room reaches a terminal ready state,
@@ -782,6 +791,10 @@ impl FrameTransport for CloudWsFrameTransport {
         error.kind() != std::io::ErrorKind::PermissionDenied
     }
 
+    fn stream_error_is_graceful_shutdown(&self, error: &std::io::Error) -> bool {
+        cloud_close_is_graceful_shutdown(error)
+    }
+
     async fn connect(&self) -> std::io::Result<(Self::Source, Self::Sink)> {
         let (source, sink, principal) = self.connect_cloud().await?;
         // Cache the principal for `Self::principal`. Reconnects to the same room
@@ -998,6 +1011,52 @@ mod tests {
         assert!(restart
             .to_string()
             .contains("workstation restart requested"));
+    }
+
+    #[test]
+    fn runtime_idle_timeout_close_reason_is_pinned_to_room_constant() {
+        // Mirrors apps/notebook-cloud/src/notebook-room.ts RUNTIME_IDLE_CLOSE_REASON.
+        assert_eq!(RUNTIME_IDLE_TIMEOUT_CLOSE_REASON, "runtime idle timeout");
+    }
+
+    #[test]
+    fn runtime_idle_timeout_close_is_terminal_and_graceful() {
+        let transport = CloudWsFrameTransport::new(test_config());
+        let idle = terminal_cloud_close_error(Some(1012), RUNTIME_IDLE_TIMEOUT_CLOSE_REASON)
+            .expect("runtime idle timeout should be terminal");
+        assert_eq!(idle.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(cloud_close_is_graceful_shutdown(&idle));
+        assert!(!transport.stream_error_is_recoverable(&idle));
+        assert!(transport.stream_error_is_graceful_shutdown(&idle));
+    }
+
+    #[test]
+    fn graceful_shutdown_helper_rejects_other_terminal_and_clean_closes() {
+        let transport = CloudWsFrameTransport::new(test_config());
+        for reason in [
+            "too many rejected frames",
+            "replaced by newer runtime peer",
+            "workstation attachment replaced",
+            "workstation restart requested",
+            "workstation mismatch",
+        ] {
+            let error = terminal_cloud_close_error(Some(1008), reason)
+                .expect("allowlisted reason should be terminal");
+            assert!(
+                !cloud_close_is_graceful_shutdown(&error),
+                "{reason} must remain terminal-failed"
+            );
+            assert!(!transport.stream_error_is_graceful_shutdown(&error));
+        }
+
+        assert!(terminal_cloud_close_error(Some(1000), "going away").is_none());
+        assert!(terminal_cloud_close_error(Some(1012), "server restart").is_none());
+        let arbitrary_clean_close = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "cloud room closed runtime peer: code=1000 reason=going away",
+        );
+        assert!(!cloud_close_is_graceful_shutdown(&arbitrary_clean_close));
+        assert!(!transport.stream_error_is_graceful_shutdown(&arbitrary_clean_close));
     }
 
     #[test]

--- a/crates/notebook-protocol/src/connection/transport.rs
+++ b/crates/notebook-protocol/src/connection/transport.rs
@@ -108,6 +108,12 @@ pub trait FrameTransport: Send + Sync {
     fn stream_error_is_recoverable(&self, _error: &std::io::Error) -> bool {
         true
     }
+
+    /// Whether a terminal read-side stream error means the peer deliberately
+    /// completed its work and should shut down without surfacing failure.
+    fn stream_error_is_graceful_shutdown(&self, _error: &std::io::Error) -> bool {
+        false
+    }
 }
 
 // -- UDS implementation -----------------------------------------------------
@@ -311,5 +317,17 @@ mod tests {
         );
         let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "mock");
         assert!(transport.stream_error_is_recoverable(&error));
+    }
+
+    #[test]
+    fn uds_stream_errors_are_not_graceful_shutdowns_by_default() {
+        let transport = UdsFrameTransport::new(
+            "/tmp/does-not-need-to-exist.sock",
+            "nb",
+            "runtime-agent:test",
+            "/tmp/blobs",
+        );
+        let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "mock");
+        assert!(!transport.stream_error_is_graceful_shutdown(&error));
     }
 }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -64,7 +64,8 @@
 //!     provider: Str
 //!     default_environment_label: Str
 //!     environment_policy: Str
-//!     status: Str             ("disconnected" | "connecting" | "ready" | "busy" | "error")
+//!     status: Str             ("disconnected" | "connecting" | "ready" | "busy" | "idle" | "error")
+//!                             "idle" means attached compute is stopped and can resume on execution.
 //!     status_message: Str|null
 //!     cpu_count: Uint|null
 //!     memory_bytes: Uint|null

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1842,7 +1842,12 @@ impl RoomHostHandle {
         }
 
         let current_attachment = self.state_doc.workstation_attachment();
-        if current_attachment.is_some() || self.state_doc.get_heads() != heads_before {
+        let attachment_is_idle = current_attachment
+            .as_ref()
+            .is_some_and(workstation_attachment_is_idle);
+        if !attachment_is_idle
+            && (current_attachment.is_some() || self.state_doc.get_heads() != heads_before)
+        {
             let next_attachment =
                 runtime_peer_gone_workstation_attachment(current_attachment, reason);
             self.state_doc
@@ -1994,6 +1999,10 @@ fn runtime_peer_gone_workstation_attachment(
     attachment.status = "error".to_string();
     attachment.status_message = Some(format!("runtime peer disconnected: {reason}"));
     attachment
+}
+
+fn workstation_attachment_is_idle(attachment: &WorkstationAttachmentState) -> bool {
+    attachment.status == "idle"
 }
 
 #[derive(Debug, Serialize)]
@@ -6294,6 +6303,53 @@ mod tests {
         assert_eq!(
             state.workstation.as_ref().map(|ws| ws.status.as_str()),
             Some("error")
+        );
+    }
+
+    #[test]
+    fn reconcile_runtime_peer_gone_does_not_demote_idle_attachment() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle(&RuntimeLifecycle::Shutdown)
+            .unwrap();
+        let mut attachment = workstation_attachment_fixture();
+        attachment.status = "idle".to_string();
+        attachment.status_message = Some(
+            "Compute stopped after 30 minutes without queued or active execution.".to_string(),
+        );
+        attachment.runtime_session_id = Some("job-idle".to_string());
+        attachment.updated_at = Some("2026-06-07T00:00:02.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&attachment))
+            .expect("seed idle attachment");
+
+        let result = host
+            .reconcile_runtime_peer_gone_inner("late disconnect")
+            .expect("reconcile ok");
+
+        assert!(!result.changed, "idle peer-gone reconcile is a no-op");
+        assert!(result.outbound.is_empty());
+        let state = host.state_doc.read_state();
+        assert_ne!(
+            state.kernel.lifecycle,
+            RuntimeLifecycle::Error,
+            "peer-gone reconcile must not write an error kernel state for idle"
+        );
+        assert!(
+            !state
+                .kernel
+                .error_details
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("runtime peer disconnected:"),
+            "peer-gone reconcile must not write a peer-gone kernel error for idle"
+        );
+        let attachment = state.workstation.as_ref().expect("idle attachment remains");
+        assert_eq!(attachment.status, "idle");
+        assert_eq!(attachment.runtime_session_id.as_deref(), Some("job-idle"));
+        assert_eq!(
+            attachment.updated_at.as_deref(),
+            Some("2026-06-07T00:00:02.000Z")
         );
     }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -866,9 +866,9 @@ impl RoomHostHandle {
     pub fn reconcile_runtime_idle_timeout(
         &mut self,
         reason: &str,
-        updated_at: &str,
+        _updated_at: &str,
     ) -> Result<JsValue, JsError> {
-        let result = self.reconcile_runtime_idle_timeout_inner(reason, updated_at)?;
+        let result = self.reconcile_runtime_idle_timeout_inner(reason)?;
         serialize_to_js(&result)
             .map_err(|e| JsError::new(&format!("serialize runtime idle timeout result: {e}")))
     }
@@ -1871,7 +1871,6 @@ impl RoomHostHandle {
     fn reconcile_runtime_idle_timeout_inner(
         &mut self,
         reason: &str,
-        updated_at: &str,
     ) -> Result<RoomHostFrameResult, JsError> {
         let state = self.state_doc.read_state();
         let activity = runtime_execution_activity(&state);
@@ -1895,7 +1894,6 @@ impl RoomHostHandle {
         if let Some(attachment) = runtime_idle_timeout_workstation_attachment(
             self.state_doc.workstation_attachment(),
             reason,
-            updated_at,
         ) {
             self.state_doc
                 .set_workstation_attachment(Some(&attachment))
@@ -2018,12 +2016,10 @@ fn runtime_execution_activity(state: &RuntimeState) -> RuntimeExecutionActivity 
 fn runtime_idle_timeout_workstation_attachment(
     current: Option<WorkstationAttachmentState>,
     reason: &str,
-    updated_at: &str,
 ) -> Option<WorkstationAttachmentState> {
     let mut attachment = current?;
     attachment.status = "idle".to_string();
     attachment.status_message = Some(reason.to_string());
-    attachment.updated_at = Some(updated_at.to_string());
     Some(attachment)
 }
 
@@ -6168,7 +6164,6 @@ mod tests {
         let result = host
             .reconcile_runtime_idle_timeout_inner(
                 "Compute stopped after 30 minutes without queued or active execution.",
-                "2026-07-08T00:30:00.000Z",
             )
             .expect("idle reconcile");
 
@@ -6194,7 +6189,40 @@ mod tests {
                 .workstation
                 .as_ref()
                 .and_then(|ws| ws.updated_at.as_deref()),
-            Some("2026-07-08T00:30:00.000Z")
+            Some("2026-06-07T00:00:00.000Z"),
+            "idle reconciliation preserves the original publish timestamp"
+        );
+    }
+
+    #[test]
+    fn reconcile_runtime_idle_timeout_keeps_session_and_timestamp_for_monotonic_guard() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))
+            .expect("set idle lifecycle");
+        let mut current = workstation_attachment_fixture();
+        current.runtime_session_id = Some("job-current".to_string());
+        current.updated_at = Some("2026-06-07T00:00:02.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&current))
+            .expect("seed attachment");
+
+        host.reconcile_runtime_idle_timeout_inner(
+            "Compute stopped after 30 minutes without queued or active execution.",
+        )
+        .expect("idle reconcile");
+
+        let state = host.state_doc.read_state();
+        let attachment = state.workstation.as_ref().expect("attachment remains");
+        assert_eq!(attachment.status, "idle");
+        assert_eq!(
+            attachment.runtime_session_id.as_deref(),
+            Some("job-current")
+        );
+        assert_eq!(
+            attachment.updated_at.as_deref(),
+            Some("2026-06-07T00:00:02.000Z"),
+            "internal idle rewrite must not outrank a newer cross-session publish"
         );
     }
 
@@ -6205,7 +6233,6 @@ mod tests {
         let result = host
             .reconcile_runtime_idle_timeout_inner(
                 "Compute stopped after 30 minutes without queued or active execution.",
-                "2026-07-08T00:30:00.000Z",
             )
             .expect("idle reconcile");
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -846,6 +846,33 @@ impl RoomHostHandle {
         self.state_doc.read_state().queue.queued.len()
     }
 
+    /// Execution-only activity snapshot for hosted runtime idle guards.
+    ///
+    /// The room host uses this to decide whether the runtime can be lazily
+    /// torn down after its idle TTL. It intentionally reports only execution
+    /// state from RuntimeStateDoc: no room occupant or WebSocket presence facts
+    /// participate in the decision.
+    pub fn get_runtime_execution_activity_json(&self) -> Result<String, JsError> {
+        serde_json::to_string(&runtime_execution_activity(&self.state_doc.read_state()))
+            .map_err(|e| JsError::new(&format!("serialize runtime execution activity: {e}")))
+    }
+
+    /// Cleanly reconcile an execution-idle hosted runtime after the idle TTL.
+    ///
+    /// This is not the crash watchdog: it does not mark executions failed and
+    /// it does not turn the kernel into Error. The caller must first decide the
+    /// runtime peer should be stopped. This method rechecks RuntimeStateDoc and
+    /// only shuts down when no execution is active and the queue is empty.
+    pub fn reconcile_runtime_idle_timeout(
+        &mut self,
+        reason: &str,
+        updated_at: &str,
+    ) -> Result<JsValue, JsError> {
+        let result = self.reconcile_runtime_idle_timeout_inner(reason, updated_at)?;
+        serialize_to_js(&result)
+            .map_err(|e| JsError::new(&format!("serialize runtime idle timeout result: {e}")))
+    }
+
     /// Generate current sync frames for a peer.
     ///
     /// The Worker calls this immediately after accepting a socket and after the
@@ -1841,6 +1868,56 @@ impl RoomHostHandle {
         Ok(result)
     }
 
+    fn reconcile_runtime_idle_timeout_inner(
+        &mut self,
+        reason: &str,
+        updated_at: &str,
+    ) -> Result<RoomHostFrameResult, JsError> {
+        let state = self.state_doc.read_state();
+        let activity = runtime_execution_activity(&state);
+        if activity.executing || activity.queue_depth > 0 {
+            return Ok(RoomHostFrameResult::empty());
+        }
+        drop(state);
+
+        let heads_before = self.state_doc.get_heads();
+        self.state_doc
+            .set_queue(None, &[])
+            .map_err(|e| JsError::new(&format!("reconcile idle queue: {e}")))?;
+
+        let lifecycle = self.state_doc.read_state().kernel.lifecycle;
+        if lifecycle_is_live(&lifecycle) {
+            self.state_doc
+                .set_lifecycle(&RuntimeLifecycle::Shutdown)
+                .map_err(|e| JsError::new(&format!("reconcile idle lifecycle: {e}")))?;
+        }
+
+        if let Some(attachment) = runtime_idle_timeout_workstation_attachment(
+            self.state_doc.workstation_attachment(),
+            reason,
+            updated_at,
+        ) {
+            self.state_doc
+                .set_workstation_attachment(Some(&attachment))
+                .map_err(|e| {
+                    JsError::new(&format!("reconcile idle workstation attachment: {e}"))
+                })?;
+        }
+
+        let changed = self.state_doc.get_heads() != heads_before;
+        let mut result = RoomHostFrameResult {
+            changed,
+            ignored_stale: false,
+            notebook_changed: false,
+            runtime_state_changed: changed,
+            outbound: Vec::new(),
+        };
+        if changed {
+            self.queue_runtime_state_sync_for_other_peers("", &mut result.outbound)?;
+        }
+        Ok(result)
+    }
+
     /// Native-testable core of [`Self::set_workstation_attachment_json`].
     fn set_workstation_attachment_inner(
         &mut self,
@@ -1919,6 +1996,35 @@ fn runtime_peer_gone_workstation_attachment(
     attachment.status = "error".to_string();
     attachment.status_message = Some(format!("runtime peer disconnected: {reason}"));
     attachment
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeExecutionActivity {
+    executing: bool,
+    queue_depth: usize,
+}
+
+fn runtime_execution_activity(state: &RuntimeState) -> RuntimeExecutionActivity {
+    RuntimeExecutionActivity {
+        executing: state.queue.executing.is_some()
+            || state
+                .executions
+                .values()
+                .any(|execution| execution.status == "running"),
+        queue_depth: state.queue.queued.len(),
+    }
+}
+
+fn runtime_idle_timeout_workstation_attachment(
+    current: Option<WorkstationAttachmentState>,
+    reason: &str,
+    updated_at: &str,
+) -> Option<WorkstationAttachmentState> {
+    let mut attachment = current?;
+    attachment.status = "disconnected".to_string();
+    attachment.status_message = Some(reason.to_string());
+    attachment.updated_at = Some(updated_at.to_string());
+    Some(attachment)
 }
 
 fn runtime_peer_attachment_is_ready(attachment: &WorkstationAttachmentState) -> bool {
@@ -6038,6 +6144,79 @@ mod tests {
             Some("2026-06-07T00:00:00.000Z"),
             "peer-gone reconciliation preserves the publish timestamp"
         );
+    }
+
+    #[test]
+    fn runtime_execution_activity_reports_running_and_queued_work() {
+        let host = host_with_inflight_work();
+        let activity = runtime_execution_activity(&host.state_doc.read_state());
+
+        assert!(activity.executing);
+        assert_eq!(activity.queue_depth, 1);
+    }
+
+    #[test]
+    fn reconcile_runtime_idle_timeout_shuts_down_idle_kernel_and_disconnects_attachment() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))
+            .expect("set idle lifecycle");
+        host.set_workstation_attachment_inner(Some(&workstation_attachment_fixture()))
+            .expect("seed attachment");
+
+        let result = host
+            .reconcile_runtime_idle_timeout_inner(
+                "Compute stopped after 30 minutes without queued or active execution.",
+                "2026-07-08T00:30:00.000Z",
+            )
+            .expect("idle reconcile");
+
+        assert!(result.changed);
+        assert!(result.runtime_state_changed);
+        let state = host.state_doc.read_state();
+        assert_eq!(state.kernel.lifecycle, RuntimeLifecycle::Shutdown);
+        assert!(state.queue.executing.is_none());
+        assert!(state.queue.queued.is_empty());
+        assert_eq!(
+            state.workstation.as_ref().map(|ws| ws.status.as_str()),
+            Some("disconnected")
+        );
+        assert_eq!(
+            state
+                .workstation
+                .as_ref()
+                .and_then(|ws| ws.status_message.as_deref()),
+            Some("Compute stopped after 30 minutes without queued or active execution.")
+        );
+        assert_eq!(
+            state
+                .workstation
+                .as_ref()
+                .and_then(|ws| ws.updated_at.as_deref()),
+            Some("2026-07-08T00:30:00.000Z")
+        );
+    }
+
+    #[test]
+    fn reconcile_runtime_idle_timeout_noops_while_execution_is_active() {
+        let mut host = host_with_inflight_work();
+
+        let result = host
+            .reconcile_runtime_idle_timeout_inner(
+                "Compute stopped after 30 minutes without queued or active execution.",
+                "2026-07-08T00:30:00.000Z",
+            )
+            .expect("idle reconcile");
+
+        assert!(!result.changed);
+        let state = host.state_doc.read_state();
+        assert_eq!(
+            state.kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Busy)
+        );
+        assert!(state.queue.executing.is_some());
+        assert_eq!(state.queue.queued.len(), 1);
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2021,7 +2021,7 @@ fn runtime_idle_timeout_workstation_attachment(
     updated_at: &str,
 ) -> Option<WorkstationAttachmentState> {
     let mut attachment = current?;
-    attachment.status = "disconnected".to_string();
+    attachment.status = "idle".to_string();
     attachment.status_message = Some(reason.to_string());
     attachment.updated_at = Some(updated_at.to_string());
     Some(attachment)
@@ -6156,7 +6156,7 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_runtime_idle_timeout_shuts_down_idle_kernel_and_disconnects_attachment() {
+    fn reconcile_runtime_idle_timeout_shuts_down_idle_kernel_and_idles_attachment() {
         let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
             .expect("create room host");
         host.state_doc
@@ -6180,7 +6180,7 @@ mod tests {
         assert!(state.queue.queued.is_empty());
         assert_eq!(
             state.workstation.as_ref().map(|ws| ws.status.as_str()),
-            Some("disconnected")
+            Some("idle")
         );
         assert_eq!(
             state

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -405,6 +405,7 @@ pub struct RoomHostOutboundFrame {
 #[derive(Serialize, Debug)]
 pub struct RoomHostFrameResult {
     pub changed: bool,
+    pub ignored_stale: bool,
     pub notebook_changed: bool,
     pub runtime_state_changed: bool,
     pub outbound: Vec<RoomHostOutboundFrame>,
@@ -414,6 +415,7 @@ impl RoomHostFrameResult {
     fn empty() -> Self {
         Self {
             changed: false,
+            ignored_stale: false,
             notebook_changed: false,
             runtime_state_changed: false,
             outbound: Vec::new(),
@@ -1081,6 +1083,7 @@ impl RoomHostHandle {
 
         let mut result = RoomHostFrameResult {
             changed,
+            ignored_stale: false,
             notebook_changed: changed,
             runtime_state_changed: false,
             outbound: Vec::new(),
@@ -1153,6 +1156,7 @@ impl RoomHostHandle {
 
         let mut result = RoomHostFrameResult {
             changed,
+            ignored_stale: false,
             notebook_changed: false,
             runtime_state_changed: changed,
             outbound: Vec::new(),
@@ -1217,6 +1221,7 @@ impl RoomHostHandle {
 
         let mut result = RoomHostFrameResult {
             changed,
+            ignored_stale: false,
             notebook_changed: false,
             runtime_state_changed: false,
             outbound: Vec::new(),
@@ -1287,6 +1292,7 @@ impl RoomHostHandle {
 
         let mut result = RoomHostFrameResult {
             changed,
+            ignored_stale: false,
             notebook_changed: false,
             runtime_state_changed: false,
             outbound: Vec::new(),
@@ -1457,6 +1463,7 @@ impl RoomHostHandle {
         // execution_id pointer (NotebookDoc) to the sender and all other peers.
         let mut result = RoomHostFrameResult {
             changed: true,
+            ignored_stale: false,
             notebook_changed: true,
             runtime_state_changed: true,
             outbound: Vec::new(),
@@ -1566,6 +1573,7 @@ impl RoomHostHandle {
 
         let mut result = RoomHostFrameResult {
             changed: true,
+            ignored_stale: false,
             notebook_changed: true,
             runtime_state_changed: true,
             outbound: Vec::new(),
@@ -1818,6 +1826,7 @@ impl RoomHostHandle {
         let changed = self.state_doc.get_heads() != heads_before;
         let mut result = RoomHostFrameResult {
             changed,
+            ignored_stale: false,
             notebook_changed: false,
             runtime_state_changed: changed,
             outbound: Vec::new(),
@@ -1838,6 +1847,16 @@ impl RoomHostHandle {
         attachment: Option<&WorkstationAttachmentState>,
     ) -> Result<RoomHostFrameResult, JsError> {
         let heads_before = self.state_doc.get_heads();
+        let current_attachment = self.state_doc.workstation_attachment();
+        if workstation_attachment_publish_is_stale(current_attachment.as_ref(), attachment) {
+            return Ok(RoomHostFrameResult {
+                changed: false,
+                ignored_stale: true,
+                notebook_changed: false,
+                runtime_state_changed: false,
+                outbound: Vec::new(),
+            });
+        }
         if attachment.is_some_and(runtime_peer_attachment_is_ready) {
             self.clear_stale_runtime_peer_gone_error()?;
         }
@@ -1847,6 +1866,7 @@ impl RoomHostHandle {
         let changed = self.state_doc.get_heads() != heads_before;
         let mut result = RoomHostFrameResult {
             changed,
+            ignored_stale: false,
             notebook_changed: false,
             runtime_state_changed: changed,
             outbound: Vec::new(),
@@ -1903,6 +1923,31 @@ fn runtime_peer_gone_workstation_attachment(
 
 fn runtime_peer_attachment_is_ready(attachment: &WorkstationAttachmentState) -> bool {
     attachment.provider == "runtime_peer" && attachment.status == "ready"
+}
+
+fn workstation_attachment_publish_is_stale(
+    current: Option<&WorkstationAttachmentState>,
+    incoming: Option<&WorkstationAttachmentState>,
+) -> bool {
+    let (Some(current), Some(incoming)) = (current, incoming) else {
+        return false;
+    };
+    let (Some(current_session_id), Some(incoming_session_id)) = (
+        current.runtime_session_id.as_deref(),
+        incoming.runtime_session_id.as_deref(),
+    ) else {
+        return false;
+    };
+    if current_session_id == incoming_session_id {
+        return false;
+    }
+    let (Some(current_updated_at), Some(incoming_updated_at)) = (
+        current.updated_at.as_deref(),
+        incoming.updated_at.as_deref(),
+    ) else {
+        return false;
+    };
+    incoming_updated_at < current_updated_at
 }
 
 /// Whether a kernel lifecycle still reads as "alive" — i.e. a viewer would see
@@ -5985,6 +6030,14 @@ mod tests {
                 .and_then(|ws| ws.status_message.as_deref()),
             Some("runtime peer disconnected: daemon dropped")
         );
+        assert_eq!(
+            state
+                .workstation
+                .as_ref()
+                .and_then(|ws| ws.updated_at.as_deref()),
+            Some("2026-06-07T00:00:00.000Z"),
+            "peer-gone reconciliation preserves the publish timestamp"
+        );
     }
 
     #[test]
@@ -6156,6 +6209,127 @@ mod tests {
         assert_eq!(
             state.workstation.as_ref().map(|ws| ws.provider.as_str()),
             Some("runtime_peer")
+        );
+    }
+
+    #[test]
+    fn set_workstation_attachment_ignores_cross_session_strictly_older_publish() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut current = workstation_attachment_fixture();
+        current.workstation_id = "ws-current".to_string();
+        current.runtime_session_id = Some("job-current".to_string());
+        current.updated_at = Some("2026-06-07T00:00:02.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&current))
+            .expect("seed current attachment");
+        let heads_before = host.state_doc.get_heads();
+
+        let mut stale = current.clone();
+        stale.workstation_id = "ws-stale".to_string();
+        stale.runtime_session_id = Some("job-stale".to_string());
+        stale.updated_at = Some("2026-06-07T00:00:01.000Z".to_string());
+
+        let result = host
+            .set_workstation_attachment_inner(Some(&stale))
+            .expect("stale publish is handled");
+
+        assert!(!result.changed);
+        assert!(result.ignored_stale);
+        assert_eq!(result.outbound.len(), 0);
+        assert_eq!(host.state_doc.get_heads(), heads_before);
+        assert_eq!(host.state_doc.read_state().workstation, Some(current));
+    }
+
+    #[test]
+    fn set_workstation_attachment_allows_same_session_older_timestamp() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut current = workstation_attachment_fixture();
+        current.runtime_session_id = Some("job-current".to_string());
+        current.updated_at = Some("2026-06-07T00:00:02.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&current))
+            .expect("seed current attachment");
+
+        let mut same_session = current.clone();
+        same_session.status = "connecting".to_string();
+        same_session.updated_at = Some("2026-06-07T00:00:01.000Z".to_string());
+        let result = host
+            .set_workstation_attachment_inner(Some(&same_session))
+            .expect("same-session publish passes");
+
+        assert!(result.changed);
+        assert!(!result.ignored_stale);
+        assert_eq!(host.state_doc.read_state().workstation, Some(same_session));
+    }
+
+    #[test]
+    fn set_workstation_attachment_allows_cross_session_equal_timestamp_tie() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut current = workstation_attachment_fixture();
+        current.runtime_session_id = Some("job-current".to_string());
+        current.updated_at = Some("2026-06-07T00:00:01.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&current))
+            .expect("seed current attachment");
+
+        let mut tied = current.clone();
+        tied.status = "connecting".to_string();
+        tied.runtime_session_id = Some("job-tied".to_string());
+        let result = host
+            .set_workstation_attachment_inner(Some(&tied))
+            .expect("equal timestamp publish passes");
+
+        assert!(result.changed);
+        assert!(!result.ignored_stale);
+        assert_eq!(host.state_doc.read_state().workstation, Some(tied));
+    }
+
+    #[test]
+    fn set_workstation_attachment_allows_sessionless_incoming_publish() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut current = workstation_attachment_fixture();
+        current.runtime_session_id = Some("job-current".to_string());
+        current.updated_at = Some("2026-06-07T00:00:02.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&current))
+            .expect("seed current attachment");
+
+        let mut legacy = current.clone();
+        legacy.status = "connecting".to_string();
+        legacy.runtime_session_id = None;
+        legacy.updated_at = Some("2026-06-07T00:00:01.000Z".to_string());
+        let result = host
+            .set_workstation_attachment_inner(Some(&legacy))
+            .expect("sessionless publish passes");
+
+        assert!(result.changed);
+        assert!(!result.ignored_stale);
+        assert_eq!(host.state_doc.read_state().workstation, Some(legacy));
+    }
+
+    #[test]
+    fn set_workstation_attachment_allows_publish_with_missing_updated_at() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut current = workstation_attachment_fixture();
+        current.runtime_session_id = Some("job-current".to_string());
+        current.updated_at = Some("2026-06-07T00:00:02.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&current))
+            .expect("seed current attachment");
+
+        let mut missing_updated_at = current.clone();
+        missing_updated_at.status = "connecting".to_string();
+        missing_updated_at.runtime_session_id = Some("job-missing-updated-at".to_string());
+        missing_updated_at.updated_at = None;
+        let result = host
+            .set_workstation_attachment_inner(Some(&missing_updated_at))
+            .expect("publish without updated_at passes");
+
+        assert!(result.changed);
+        assert!(!result.ignored_stale);
+        assert_eq!(
+            host.state_doc.read_state().workstation,
+            Some(missing_updated_at)
         );
     }
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -12,7 +12,7 @@ use clap::{Parser, Subcommand};
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Parser, Debug)]
 #[command(name = "runtimed")]
@@ -193,7 +193,7 @@ enum Commands {
         /// Whether the initial current-Python launch runs on attach or waits for
         /// synced execution intent.
         #[arg(long, value_parser = ["attach", "execute"], default_value = "attach")]
-        launch_mode: Option<String>,
+        launch_mode: String,
     },
 
     /// Serve this machine as a workstation for a hosted nteract cloud:
@@ -615,7 +615,7 @@ async fn main() -> anyhow::Result<()> {
                         operator,
                         workstation: Some(workstation_metadata),
                     };
-                    let launch_trigger = match launch_mode.as_deref().unwrap_or("attach") {
+                    let launch_trigger = match launch_mode.as_str() {
                         "execute" => runtimed::runtime_agent::LaunchTrigger::OnFirstExecution,
                         "attach" => runtimed::runtime_agent::LaunchTrigger::OnAttach,
                         _ => unreachable!("clap validates launch-mode"),
@@ -634,6 +634,11 @@ async fn main() -> anyhow::Result<()> {
                 }
                 // Attach-only: wait for an inbound launch (req #5, deferred).
                 None => {
+                    if launch_mode == "execute" {
+                        warn!(
+                            "[cloud-runtime-agent] --launch-mode execute ignored without --python-path; attaching without an initial launch template"
+                        );
+                    }
                     runtimed::runtime_agent::run_cloud_runtime_agent(
                         config, operator, blob_root, None,
                     )

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -190,6 +190,10 @@ enum Commands {
         /// jobs pass their job id here so the room can fence stale peers.
         #[arg(long)]
         runtime_session_id: Option<String>,
+        /// Whether the initial current-Python launch runs on attach or waits for
+        /// synced execution intent.
+        #[arg(long, value_parser = ["attach", "execute"], default_value = "attach")]
+        launch_mode: Option<String>,
     },
 
     /// Serve this machine as a workstation for a hosted nteract cloud:
@@ -556,6 +560,7 @@ async fn main() -> anyhow::Result<()> {
             workstation_id,
             workstation_display_name,
             runtime_session_id,
+            launch_mode,
         }) => {
             let cli_args = runtimed::workstation::CloudAgentArgs {
                 cloud_url,
@@ -610,6 +615,11 @@ async fn main() -> anyhow::Result<()> {
                         operator,
                         workstation: Some(workstation_metadata),
                     };
+                    let launch_trigger = match launch_mode.as_deref().unwrap_or("attach") {
+                        "execute" => runtimed::runtime_agent::LaunchTrigger::OnFirstExecution,
+                        "attach" => runtimed::runtime_agent::LaunchTrigger::OnAttach,
+                        _ => unreachable!("clap validates launch-mode"),
+                    };
                     runtimed::workstation::allocate_current_python_runtime(
                         target,
                         config.auth,
@@ -618,6 +628,7 @@ async fn main() -> anyhow::Result<()> {
                         launch_working_dir,
                         std::collections::HashMap::new(),
                         blob_root,
+                        launch_trigger,
                     )
                     .await
                 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -64,6 +64,13 @@ fn runtime_agent_response_error(response: &RuntimeAgentResponse) -> Option<&str>
     }
 }
 
+fn should_clear_pending_initial_launch_after_rpc(
+    is_launch_or_restart: bool,
+    response: &RuntimeAgentResponse,
+) -> bool {
+    is_launch_or_restart && runtime_agent_response_error(response).is_none()
+}
+
 /// Minimum interval between reconnect cycles on a recoverable transport,
 /// covering *both* recoverable-failure arms: a clean EOF and a stream framing
 /// error. `reconnect_with_backoff` only delays between *failed* connects, so a
@@ -804,6 +811,12 @@ where
                                         lifecycle_rx = Some(rx.lifecycle_rx);
                                         work_rx = Some(rx.work_rx);
                                     }
+                                    if should_clear_pending_initial_launch_after_rpc(
+                                        is_launch_or_restart,
+                                        &response,
+                                    ) {
+                                        pending_initial_launch = None;
+                                    }
                                     // Update interrupt handle after any request that may change kernel state
                                     interrupt_handle = kernel.as_ref().and_then(|k| k.interrupt_handle());
 
@@ -1170,7 +1183,7 @@ where
                         match classify_stream_error(&transport, &e) {
                             StreamErrorDisposition::TerminalGraceful => {
                                 info!(
-                                    "room closed runtime peer for idle timeout; shutting down cleanly"
+                                    "[runtime-agent] Sync stream closed gracefully by transport; shutting down cleanly"
                                 );
                                 break;
                             }
@@ -3080,6 +3093,35 @@ mod tests {
             ),
             StreamErrorDisposition::TerminalGraceful
         );
+    }
+
+    #[test]
+    fn successful_inbound_launch_or_restart_clears_pending_initial_launch() {
+        let launched = RuntimeAgentResponse::KernelLaunched {
+            env_source: notebook_protocol::connection::EnvSource::Unknown("test".to_string()),
+        };
+        assert!(should_clear_pending_initial_launch_after_rpc(
+            true, &launched
+        ));
+
+        let restarted = RuntimeAgentResponse::KernelRestarted {
+            env_source: notebook_protocol::connection::EnvSource::Unknown("test".to_string()),
+        };
+        assert!(should_clear_pending_initial_launch_after_rpc(
+            true, &restarted
+        ));
+
+        let failed = RuntimeAgentResponse::KernelLaunchFailed {
+            kind: notebook_protocol::protocol::KernelLaunchFailureKind::PortBind,
+            error: "port busy".to_string(),
+        };
+        assert!(!should_clear_pending_initial_launch_after_rpc(
+            true, &failed
+        ));
+        assert!(!should_clear_pending_initial_launch_after_rpc(
+            false,
+            &RuntimeAgentResponse::Ok
+        ));
     }
 
     /// A `FrameTransport` whose `connect` fails the first `fail_before` calls

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1782,6 +1782,7 @@ fn should_apply_initial_launch(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_initial_launch(
     trigger: LaunchTrigger,
     launch: RuntimeAgentRequest,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -408,6 +408,26 @@ fn reassert_live_kernel_projection_if_needed<K: KernelConnection>(
     Ok(true)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamErrorDisposition {
+    Recoverable,
+    TerminalFailed,
+    TerminalGraceful,
+}
+
+fn classify_stream_error<T: FrameTransport>(
+    transport: &T,
+    error: &std::io::Error,
+) -> StreamErrorDisposition {
+    if transport.stream_error_is_recoverable(error) {
+        StreamErrorDisposition::Recoverable
+    } else if transport.stream_error_is_graceful_shutdown(error) {
+        StreamErrorDisposition::TerminalGraceful
+    } else {
+        StreamErrorDisposition::TerminalFailed
+    }
+}
+
 /// Run the runtime agent over an arbitrary [`FrameTransport`].
 ///
 /// The desktop/daemon path ([`run_runtime_agent`]) and the cloud path
@@ -1121,16 +1141,25 @@ where
                         }
                     }
                     Some(Err(e)) => {
-                        if !transport.stream_error_is_recoverable(&e) {
-                            error!(
-                                "[runtime-agent] Non-recoverable sync stream error: {}; \
-                                 shutting down instead of reconnecting",
-                                e
-                            );
-                            terminal_error = Some(anyhow::anyhow!(
-                                "runtime agent sync stream rejected by room: {e}"
-                            ));
-                            break;
+                        match classify_stream_error(&transport, &e) {
+                            StreamErrorDisposition::TerminalGraceful => {
+                                info!(
+                                    "room closed runtime peer for idle timeout; shutting down cleanly"
+                                );
+                                break;
+                            }
+                            StreamErrorDisposition::TerminalFailed => {
+                                error!(
+                                    "[runtime-agent] Non-recoverable sync stream error: {}; \
+                                     shutting down instead of reconnecting",
+                                    e
+                                );
+                                terminal_error = Some(anyhow::anyhow!(
+                                    "runtime agent sync stream rejected by room: {e}"
+                                ));
+                                break;
+                            }
+                            StreamErrorDisposition::Recoverable => {}
                         }
                         // A framing error here means one of two things:
                         //   - the daemon half-closed the sync stream (clean),
@@ -2914,6 +2943,64 @@ mod tests {
         async fn send_frame(&mut self, _: NotebookFrameType, _: &[u8]) -> std::io::Result<()> {
             Ok(())
         }
+    }
+
+    struct ClassifyingTransport {
+        recoverable: bool,
+        graceful: bool,
+    }
+
+    impl FrameTransport for ClassifyingTransport {
+        type Source = NullSource;
+        type Sink = NullSink;
+
+        async fn connect(&self) -> std::io::Result<(Self::Source, Self::Sink)> {
+            Ok((NullSource, NullSink))
+        }
+
+        fn stream_error_is_recoverable(&self, _: &std::io::Error) -> bool {
+            self.recoverable
+        }
+
+        fn stream_error_is_graceful_shutdown(&self, _: &std::io::Error) -> bool {
+            self.graceful
+        }
+    }
+
+    #[test]
+    fn stream_error_classification_has_terminal_graceful_split() {
+        let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "mock");
+
+        assert_eq!(
+            classify_stream_error(
+                &ClassifyingTransport {
+                    recoverable: true,
+                    graceful: false,
+                },
+                &error
+            ),
+            StreamErrorDisposition::Recoverable
+        );
+        assert_eq!(
+            classify_stream_error(
+                &ClassifyingTransport {
+                    recoverable: false,
+                    graceful: false,
+                },
+                &error
+            ),
+            StreamErrorDisposition::TerminalFailed
+        );
+        assert_eq!(
+            classify_stream_error(
+                &ClassifyingTransport {
+                    recoverable: false,
+                    graceful: true,
+                },
+                &error
+            ),
+            StreamErrorDisposition::TerminalGraceful
+        );
     }
 
     /// A `FrameTransport` whose `connect` fails the first `fail_before` calls

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -81,6 +81,21 @@ const RECOVERABLE_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::fr
 /// signal.
 const RUNTIME_ROOM_LINK_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(15);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchTrigger {
+    OnAttach,
+    OnFirstExecution,
+}
+
+impl LaunchTrigger {
+    fn label(self) -> &'static str {
+        match self {
+            LaunchTrigger::OnAttach => "launch-on-attach",
+            LaunchTrigger::OnFirstExecution => "launch-on-execute",
+        }
+    }
+}
+
 /// Runtime-agent-local buffer for live kernel broadcasts. These carry
 /// ephemeral custom widget events such as ipympl PNG frames. Match the
 /// coordinator room broadcast capacity so the runtime-agent bridge can absorb
@@ -230,12 +245,13 @@ pub async fn run_runtime_agent(
 ///   hazard the `runt-cloud-peer` spike documented.
 ///
 /// `initial_launch`, when `Some`, is a [`RuntimeAgentRequest::LaunchKernel`] the
-/// agent applies *once* after the initial RuntimeStateDoc sync, so the
-/// workstation endpoint can *start* a runtime in env X without waiting for an
-/// inbound `LaunchKernel` RPC. Waiting for the RuntimeStateDoc sync keeps the
-/// launch lifecycle write causally after the room checkpoint instead of racing
-/// stale published lifecycle state. `None` keeps the historical attach-only
-/// behavior. Build it with [`crate::workstation::build_current_python_launch`].
+/// agent applies once according to its [`LaunchTrigger`], so the workstation
+/// endpoint can either start a runtime eagerly on attach or lazily after synced
+/// execution intent appears without waiting for an inbound `LaunchKernel` RPC.
+/// Waiting for the RuntimeStateDoc sync keeps the launch lifecycle write
+/// causally after the room checkpoint instead of racing stale published
+/// lifecycle state. `None` keeps the historical attach-only behavior. Build it
+/// with [`crate::workstation::build_current_python_launch`].
 ///
 /// CODE-ONLY (Phase 3c/3b): this builds and unit-tests the spawn path behind the
 /// transport gate; the live cross-machine re-proof (a preview room + the
@@ -245,15 +261,15 @@ pub async fn run_cloud_runtime_agent(
     config: notebook_cloud_transport::CloudWsConfig,
     operator: String,
     blob_root: PathBuf,
-    initial_launch: Option<RuntimeAgentRequest>,
+    initial_launch: Option<(LaunchTrigger, RuntimeAgentRequest)>,
 ) -> anyhow::Result<()> {
     let notebook_id = config.notebook_id.clone();
     info!(
-        "[runtime-agent] Starting cloud runtime_agent notebook_id={} url={} scope={} launch_on_attach={}",
+        "[runtime-agent] Starting cloud runtime_agent notebook_id={} url={} scope={} initial_launch={:?}",
         notebook_id,
         notebook_cloud_transport::build_ws_url(&config.cloud_url, &notebook_id),
         config.scope,
-        initial_launch.is_some(),
+        initial_launch.as_ref().map(|(trigger, _)| *trigger),
     );
 
     let output_blob_publisher = OutputBlobPublisher::cloud(&config);
@@ -451,7 +467,7 @@ async fn run_runtime_agent_on_transport<T, F>(
     blob_root: PathBuf,
     resolve_actor: F,
     output_blob_publisher: OutputBlobPublisher,
-    initial_launch: Option<RuntimeAgentRequest>,
+    initial_launch: Option<(LaunchTrigger, RuntimeAgentRequest)>,
 ) -> anyhow::Result<()>
 where
     T: FrameTransport,
@@ -575,31 +591,43 @@ where
         record_runtime_room_link_seen(&state);
     }
 
-    // -- 3b. Launch-on-attach gate (cloud only) -----------------------------
+    // -- 3b. Initial launch gate (cloud only) -------------------------------
     //
     // The workstation endpoint can hand the agent an initial `LaunchKernel` to
-    // apply after the first RuntimeStateDoc sync, so it *starts* a runtime in env
-    // X without waiting for an inbound RPC. The RuntimeStateDoc sync is
-    // load-bearing: the room may bootstrap from a published checkpoint whose
-    // lifecycle still says AwaitingTrust/Error. If the runtime peer writes
-    // Running before receiving that checkpoint, the writes are concurrent and
-    // Automerge can keep projecting the stale checkpoint value even though the
-    // kernel launched. Gated on `clean_eof_is_recoverable()`, the
-    // recoverable/cloud-transport discriminant: the daemon/UDS path drives launch
-    // via its own RPC and must never launch on attach, so even a (never-passed)
-    // `Some` here is ignored on UDS. The launch runs through the *same*
-    // `handle_runtime_agent_request` path an inbound RPC would, so the kernel
-    // drive, queue release, and command-receiver install are identical — only the
-    // trigger differs.
+    // apply after RuntimeStateDoc sync. `OnAttach` applies after the first sync,
+    // preserving today's eager user-attach behavior. `OnFirstExecution` applies
+    // only after a later sync observes queued execution intent while no kernel
+    // exists. The RuntimeStateDoc sync is load-bearing: the room may bootstrap
+    // from a published checkpoint whose lifecycle still says AwaitingTrust/Error.
+    // If the runtime peer writes Running before receiving that checkpoint, the
+    // writes are concurrent and Automerge can keep projecting the stale checkpoint
+    // value even though the kernel launched. Gated on `clean_eof_is_recoverable()`,
+    // the recoverable/cloud-transport discriminant: the daemon/UDS path drives
+    // launch via its own RPC and must never launch from this template, so even a
+    // (never-passed) `Some` here is ignored on UDS. The launch runs through the
+    // *same* `handle_runtime_agent_request` path an inbound RPC would, so the
+    // kernel drive, queue release, and command-receiver install are identical —
+    // only the trigger differs.
     let mut pending_initial_launch = match initial_launch {
-        Some(launch) if transport.clean_eof_is_recoverable() => {
-            info!("[runtime-agent] Deferring launch-on-attach until initial RuntimeStateDoc sync");
+        Some((trigger, launch)) if transport.clean_eof_is_recoverable() => {
+            match trigger {
+                LaunchTrigger::OnAttach => {
+                    info!(
+                        "[runtime-agent] Deferring launch-on-attach until initial RuntimeStateDoc sync"
+                    );
+                }
+                LaunchTrigger::OnFirstExecution => {
+                    info!(
+                        "[runtime-agent] Deferring launch-on-execute until RuntimeStateDoc sync observes queued execution"
+                    );
+                }
+            }
             let _ = state_kick_tx.send(());
-            Some(launch)
+            Some((trigger, launch))
         }
         Some(_) => {
             warn!(
-                "[runtime-agent] Ignoring launch-on-attach on a non-recoverable transport \
+                "[runtime-agent] Ignoring initial launch on a non-recoverable transport \
                  (daemon-driven launch only)"
             );
             None
@@ -791,6 +819,7 @@ where
                                 let sync_started = std::time::Instant::now();
                                 let mut inbound_queued_count = 0usize;
                                 let mut accepted_queued_count = 0usize;
+                                let mut queued_nonempty = false;
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                                     let sync_result = ctx.state.with_doc(|sd| {
                                         match sd.receive_sync_message_with_changes_recovering(
@@ -817,6 +846,7 @@ where
                                         Ok(Some(queued)) => {
                                             runtime_state_doc_seen = true;
                                             inbound_queued_count = queued.len();
+                                            queued_nonempty = !queued.is_empty();
                                             accepted_queued_count = queue_synced_executions(
                                                 queued,
                                                 &mut seen_execution_ids,
@@ -851,42 +881,38 @@ where
                                                 sync_started.elapsed().as_millis()
                                             );
                                         }
-                                        if let Some(launch) = pending_initial_launch.take() {
-                                            info!(
-                                                "[runtime-agent] Applying launch-on-attach LaunchKernel after RuntimeStateDoc sync startup_elapsed_ms={}",
-                                                agent_started.elapsed().as_millis()
-                                            );
-                                            let launch_apply_started = std::time::Instant::now();
-                                            let (response, new_cmd_rx) =
-                                                handle_runtime_agent_request(
-                                                    launch,
-                                                    &ctx,
-                                                    &mut kernel,
-                                                    &mut kernel_state,
-                                                    &mut seen_execution_ids,
+                                        let should_apply_launch = pending_initial_launch
+                                            .as_ref()
+                                            .map(|(trigger, _)| {
+                                                should_apply_initial_launch(
+                                                    *trigger,
+                                                    runtime_state_doc_seen,
+                                                    kernel.is_some(),
+                                                    queued_nonempty,
                                                 )
-                                                .await;
-                                            if let Some(rx) = new_cmd_rx {
-                                                lifecycle_rx = Some(rx.lifecycle_rx);
-                                                work_rx = Some(rx.work_rx);
-                                            }
-                                            interrupt_handle = kernel
-                                                .as_ref()
-                                                .and_then(|k| k.interrupt_handle());
-                                            if let Some(error) =
-                                                runtime_agent_response_error(&response)
-                                            {
-                                                warn!(
-                                                    "[runtime-agent] Launch-on-attach failed: {}",
-                                                    error
-                                                );
-                                            } else {
-                                                info!(
-                                                    "[runtime-agent-timing] launch-on-attach completed elapsed_ms={} startup_elapsed_ms={}",
-                                                    launch_apply_started.elapsed().as_millis(),
-                                                    agent_started.elapsed().as_millis()
-                                                );
-                                            }
+                                            })
+                                            .unwrap_or(false);
+                                        if should_apply_launch {
+                                            let Some((trigger, launch)) =
+                                                pending_initial_launch.take()
+                                            else {
+                                                unreachable!(
+                                                    "checked pending_initial_launch above"
+                                                )
+                                            };
+                                            apply_initial_launch(
+                                                trigger,
+                                                launch,
+                                                &ctx,
+                                                &mut kernel,
+                                                &mut kernel_state,
+                                                &mut seen_execution_ids,
+                                                &mut lifecycle_rx,
+                                                &mut work_rx,
+                                                &mut interrupt_handle,
+                                                agent_started,
+                                            )
+                                            .await;
                                         }
 
                                         match reassert_live_kernel_projection_if_needed(
@@ -1725,6 +1751,59 @@ async fn queue_synced_executions<K: KernelConnection>(
     }
 
     queued_count
+}
+
+fn should_apply_initial_launch(
+    trigger: LaunchTrigger,
+    runtime_state_doc_seen: bool,
+    kernel_exists: bool,
+    queued_nonempty: bool,
+) -> bool {
+    if !runtime_state_doc_seen {
+        return false;
+    }
+
+    match trigger {
+        LaunchTrigger::OnAttach => true,
+        LaunchTrigger::OnFirstExecution => !kernel_exists && queued_nonempty,
+    }
+}
+
+async fn apply_initial_launch(
+    trigger: LaunchTrigger,
+    launch: RuntimeAgentRequest,
+    ctx: &RuntimeAgentContext,
+    kernel: &mut Option<Kernel>,
+    kernel_state: &mut KernelState,
+    seen_execution_ids: &mut HashSet<String>,
+    lifecycle_rx: &mut Option<mpsc::UnboundedReceiver<LifecycleSignal>>,
+    work_rx: &mut Option<mpsc::Receiver<WorkCommand>>,
+    interrupt_handle: &mut Option<crate::jupyter_kernel::InterruptHandle>,
+    agent_started: std::time::Instant,
+) {
+    info!(
+        "[runtime-agent] Applying {} LaunchKernel after RuntimeStateDoc sync startup_elapsed_ms={}",
+        trigger.label(),
+        agent_started.elapsed().as_millis()
+    );
+    let launch_apply_started = std::time::Instant::now();
+    let (response, new_cmd_rx) =
+        handle_runtime_agent_request(launch, ctx, kernel, kernel_state, seen_execution_ids).await;
+    if let Some(rx) = new_cmd_rx {
+        *lifecycle_rx = Some(rx.lifecycle_rx);
+        *work_rx = Some(rx.work_rx);
+    }
+    *interrupt_handle = kernel.as_ref().and_then(|k| k.interrupt_handle());
+    if let Some(error) = runtime_agent_response_error(&response) {
+        warn!("[runtime-agent] {} failed: {}", trigger.label(), error);
+    } else {
+        info!(
+            "[runtime-agent-timing] {} completed elapsed_ms={} startup_elapsed_ms={}",
+            trigger.label(),
+            launch_apply_started.elapsed().as_millis(),
+            agent_started.elapsed().as_millis()
+        );
+    }
 }
 
 /// Handle a `RuntimeAgentRequest` and return a `RuntimeAgentResponse`.
@@ -3152,6 +3231,60 @@ mod tests {
             !uds_like.clean_eof_is_recoverable(),
             "a non-recoverable (UDS) transport ignores launch-on-attach"
         );
+    }
+
+    #[test]
+    fn initial_launch_trigger_waits_for_runtime_state_doc_sync() {
+        assert!(!should_apply_initial_launch(
+            LaunchTrigger::OnAttach,
+            false,
+            false,
+            true
+        ));
+        assert!(!should_apply_initial_launch(
+            LaunchTrigger::OnFirstExecution,
+            false,
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn launch_on_first_execution_requires_no_kernel_and_queued_work() {
+        assert!(should_apply_initial_launch(
+            LaunchTrigger::OnFirstExecution,
+            true,
+            false,
+            true
+        ));
+        assert!(!should_apply_initial_launch(
+            LaunchTrigger::OnFirstExecution,
+            true,
+            true,
+            true
+        ));
+        assert!(!should_apply_initial_launch(
+            LaunchTrigger::OnFirstExecution,
+            true,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn launch_on_attach_is_ready_after_runtime_state_doc_sync_only() {
+        assert!(should_apply_initial_launch(
+            LaunchTrigger::OnAttach,
+            true,
+            false,
+            false
+        ));
+        assert!(should_apply_initial_launch(
+            LaunchTrigger::OnAttach,
+            true,
+            true,
+            true
+        ));
     }
 
     // -- cloud doc-actor label (Phase 3c) ---------------------------------

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -104,10 +104,16 @@ pub struct AttachJob {
     pub notebook_id: String,
     #[serde(default)]
     pub status: String,
+    #[serde(default = "default_attach_trigger")]
+    pub trigger: String,
     #[serde(default)]
     pub working_directory: Option<String>,
     #[serde(default)]
     pub notebook_path: Option<String>,
+}
+
+fn default_attach_trigger() -> String {
+    "user_attach".into()
 }
 
 /// Filesystem + argv plan for spawning one runtime peer. Pure data so the
@@ -258,7 +264,6 @@ pub fn build_attach_job_spawn_plan(
         .as_deref()
         .map(PathBuf::from)
         .unwrap_or_else(|| opts.working_dir.clone());
-
     let mut args = vec![
         "cloud-runtime-agent".to_string(),
         "--auth-kind".to_string(),
@@ -282,6 +287,10 @@ pub fn build_attach_job_spawn_plan(
         "--workstation-display-name".to_string(),
         opts.display_name.clone(),
     ];
+    if job.trigger == "resume" {
+        args.insert(args.len() - 2, "--launch-mode".to_string());
+        args.insert(args.len() - 2, "execute".to_string());
+    }
     if let Some(notebook_path) = job.notebook_path.as_deref().filter(|path| !path.is_empty()) {
         args.push("--notebook-path".to_string());
         args.push(notebook_path.to_string());
@@ -1731,6 +1740,7 @@ mod tests {
             job_id: job_id.to_string(),
             notebook_id: notebook_id.to_string(),
             status: "pending".to_string(),
+            trigger: "user_attach".to_string(),
             working_directory: None,
             notebook_path: None,
         }
@@ -2106,6 +2116,35 @@ mod tests {
                 "lab2 workstation".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn attach_job_trigger_defaults_to_user_attach() {
+        let job: AttachJob = serde_json::from_value(json!({
+            "job_id": "job-default",
+            "notebook_id": "nb-default",
+        }))
+        .unwrap();
+
+        assert_eq!(job.trigger, "user_attach");
+        let plan = build_attach_job_spawn_plan(&job, &options()).unwrap();
+        assert!(!plan.args.iter().any(|arg| arg == "--launch-mode"));
+    }
+
+    #[test]
+    fn spawn_plan_uses_execute_launch_mode_for_resume_jobs() {
+        let mut resume = job("job-resume", "nb-resume");
+        resume.trigger = "resume".to_string();
+        let plan = build_attach_job_spawn_plan(&resume, &options()).unwrap();
+
+        assert!(plan
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--launch-mode" && pair[1] == "execute"));
+        assert!(plan
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--python-path" && pair[1] == "/opt/k/bin/python"));
     }
 
     #[test]

--- a/crates/runtimed/src/workstation/allocate.rs
+++ b/crates/runtimed/src/workstation/allocate.rs
@@ -98,6 +98,7 @@ pub fn plan_current_python_allocation(
 ///
 /// Deferred (decision 42): the live attach against a real preview room
 /// (staging creds + deployed worker + the `runtime_peer` ACL row).
+#[allow(clippy::too_many_arguments)]
 pub async fn allocate_current_python_runtime(
     target: RoomTarget,
     auth: CloudAuth,

--- a/crates/runtimed/src/workstation/allocate.rs
+++ b/crates/runtimed/src/workstation/allocate.rs
@@ -25,6 +25,7 @@ use notebook_cloud_transport::{CloudAuth, CloudWorkstationMetadata, CloudWsConfi
 use notebook_protocol::protocol::{KernelPorts, RuntimeAgentRequest};
 
 use super::launch_on_attach::{build_current_python_launch, CurrentPythonLaunch};
+use crate::runtime_agent::LaunchTrigger;
 
 /// The cloud room a runtime is being allocated for.
 #[derive(Debug, Clone)]
@@ -105,6 +106,7 @@ pub async fn allocate_current_python_runtime(
     working_dir: Option<PathBuf>,
     env_vars: HashMap<String, String>,
     blob_root: PathBuf,
+    launch_trigger: LaunchTrigger,
 ) -> anyhow::Result<()> {
     let reservation = crate::kernel_ports::reserve_kernel_ports().await?;
     let allocation = plan_current_python_allocation(
@@ -123,7 +125,7 @@ pub async fn allocate_current_python_runtime(
         allocation.config,
         allocation.operator,
         blob_root,
-        Some(allocation.initial_launch),
+        Some((launch_trigger, allocation.initial_launch)),
     )
     .await
 }

--- a/docs/adr/runtime-idle-ttl-lazy-launch.md
+++ b/docs/adr/runtime-idle-ttl-lazy-launch.md
@@ -1,0 +1,160 @@
+# Runtime Idle TTL and Lazy Launch On Execute
+
+**Status:** Accepted, 2026-07-09.
+
+## Context
+
+Hosted notebook rooms can attach a registered workstation as a room-scoped
+`runtime_peer`. The workstation supplies compute and writes accepted runtime
+state, but the room host remains the authority for execution intent, runtime
+peer admission, selected runtime session, and visible notebook state.
+
+Compute should not stay live only because a notebook page is open. Browser tabs,
+editor sockets, viewer sockets, and anonymous public viewers are document
+presence, not execution demand. A hosted runtime that has no active or queued
+execution is idle even when people are still reading the notebook.
+
+Source note: `.context/runtime-idle-ttl-lazy-launch.md`.
+
+The durable source anchors are:
+
+- `apps/notebook-cloud/src/notebook-room.ts`
+- `apps/notebook-cloud/src/storage.ts`
+- `crates/runtimed-wasm/src/lib.rs`
+- `crates/notebook-cloud-transport/src/lib.rs`
+- `crates/runtimed/src/runtime_agent.rs`
+- `crates/runtimed/src/workstation/agent_loop.rs`
+
+## Decision 1: Idleness Is Execution-Only
+
+Hosted runtime idle teardown is based only on runtime execution activity:
+
+- an executing entry in `RuntimeStateDoc`;
+- a `running` execution status;
+- queued execution entries.
+
+Room occupants do not keep compute alive. Owner, editor, viewer, runtime UI,
+and anonymous viewer sockets are excluded from the idle decision. Anonymous
+viewers never defer hosted compute teardown.
+
+When the idle alarm fires, the room host reads the execution activity projection
+from `runtimed-wasm`. If execution is active or queued, teardown is deferred. If
+there is no runtime peer, the room only republishes the compute-session summary.
+If a runtime peer is present and execution is idle, the room reconciles the
+runtime state to an idle terminal projection and then closes runtime-peer
+sockets.
+
+The idle reconcile preserves the workstation attachment's existing `updated_at`.
+Internal room-host rewrites change status and message, but they do not advance
+the timestamp used to reject stale cross-session workstation publishes.
+
+## Decision 2: The Idle TTL Is A Compile-Time Constant
+
+The v1 hosted runtime idle TTL is fixed at 30 minutes:
+
+```text
+RUNTIME_IDLE_TTL_MS = 30 * 60_000
+```
+
+The constant lives in `apps/notebook-cloud/src/notebook-room.ts`. The room arms
+the idle alarm from runtime-peer and execution-state transitions. There is no
+per-notebook, per-workstation, or server-configured TTL policy in v1.
+
+## Decision 3: Launch On Execute Uses Attach-Job Triggers
+
+Workstation attach jobs carry a `trigger` field:
+
+```text
+user_attach
+resume
+```
+
+`user_attach` preserves eager attach behavior. A user explicitly attaches a
+workstation, the workstation agent receives the job, and the spawned
+cloud-runtime-agent applies its initial current-Python `LaunchKernel` template
+after initial `RuntimeStateDoc` sync.
+
+`resume` represents lazy launch-on-execute. Owner execution that finds no
+runtime peer creates or reuses a workstation attach job with trigger `resume`.
+The workstation agent spawns the cloud runtime agent with launch mode
+`execute`. The runtime agent holds the initial current-Python `LaunchKernel`
+template until `RuntimeStateDoc` sync observes queued execution intent while no
+kernel exists. It then applies the same runtime-agent launch path as an inbound
+`LaunchKernel` RPC.
+
+If an explicit `user_attach` request deduplicates onto an active `resume` job
+for the same workstation, the stored job is upgraded to `user_attach` so the
+workstation agent sees the eager intent on the next poll.
+
+Any successful inbound `LaunchKernel` or `RestartKernel` RPC clears a pending
+initial launch template. That prevents an old launch-on-execute template from
+firing after a different environment has already launched.
+
+## Decision 4: Idle Teardown Uses A Graceful Terminal Close Protocol
+
+Idle teardown is a clean terminal shutdown, not a runtime-agent failure.
+
+The room host first commits the idle reconcile in `RuntimeStateDoc`, delivers
+the resulting sync frames to peers, and only then closes runtime-peer sockets.
+This ordering lets viewers and the runtime peer observe the terminal idle state
+before the runtime peer disconnects.
+
+The close reason is cross-language pinned:
+
+```text
+runtime idle timeout
+```
+
+The room sends the terminal close as a cloud room close with that reason. The
+Rust transport mirrors the same literal in
+`RUNTIME_IDLE_TIMEOUT_CLOSE_REASON` and treats only room-authored close errors
+ending in `reason=runtime idle timeout` as graceful shutdown. Frame rejections
+or other permission errors that merely contain the phrase remain terminal
+failures.
+
+The runtime agent treats a graceful terminal close as a clean exit. It does not
+set a terminal runtime-agent error for the job.
+
+## Decision 5: Hosted Resume Is Owner-Only
+
+Hosted execution that can spend remote compute is owner-only in v1. Editors can
+edit notebook content when ACLs allow it, but edit authority is not compute
+authority.
+
+When owner execution needs to resume an idle workstation, the room creates the
+resume attach job under the notebook owner's principal and uses actor label:
+
+```text
+execution resume
+```
+
+Runtime peers remain fenced by selected workstation id and runtime session id.
+The room does not accept a stale runtime peer from an older attach job just
+because it can authenticate as `runtime_peer`.
+
+## Consequences
+
+Open notebook pages no longer imply live hosted compute. A notebook can remain
+readable while its runtime is idle and detached.
+
+The first owner execution after idle teardown may include workstation attach and
+kernel launch latency. The room still records execution intent in
+`RuntimeStateDoc`, so the launch-on-execute runtime agent starts from the same
+queued execution model as eager launch.
+
+The room-host idle reconcile is now a durable state transition. It must commit
+and sync before sockets close. Tests should cover ordering whenever this path
+changes.
+
+The close reason is protocol surface. Changing the string requires coordinated
+updates across the room host, `notebook-cloud-transport`, and runtime-agent
+tests.
+
+The fixed 30-minute TTL is simple and reviewable, but it cannot express
+notebook-specific or workstation-specific cost and latency preferences.
+
+## Future Work
+
+- Add a force-keep-alive pin per notebook for Kyle's hosted workflows.
+- Add per-notebook and per-workstation TTL policy after v1 has usage evidence.
+- File and fix the `uses_fresh_port_retry` lazy-path banner gap as a follow-up.

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -80,6 +80,12 @@ export interface NotebookShellRuntimeTargetProjection {
   runtimeSessionId?: string | null;
   kind: NotebookShellRuntimeTargetKind;
   status: NotebookShellRuntimeTargetStatus;
+  /**
+   * A hosted workstation attachment that is deliberately hibernated. The
+   * RuntimeStateDoc owns this fact; clients use it to label the target and let
+   * Run wake compute without treating the room link as lost.
+   */
+  attachmentIdle?: boolean;
   label: string;
   statusLabel?: string | null;
   detail?: string | null;
@@ -320,6 +326,7 @@ export function projectNotebookRuntimeTargetFromWorkstationAttachment(
     runtimeSessionId: trimToNull(attachment.runtime_session_id),
     kind: options.kind ?? "cloud_workstation",
     status: statusProjection.status,
+    ...(attachment.status === "idle" ? { attachmentIdle: true } : {}),
     label: trimToNull(attachment.display_name) ?? "Attached workstation",
     statusLabel: statusProjection.statusLabel,
     detail: missingRequiredRuntimePeer
@@ -360,6 +367,10 @@ function projectRuntimeRoomLink({
   runtimeLastSeenAt: string | null;
   runtimePeerCount: number | null;
 }): NotebookShellRoomLinkProjection | null {
+  if (attachmentStatus === "idle") {
+    return null;
+  }
+
   if (runtimePeerCount !== null) {
     return {
       status: "connected",
@@ -556,6 +567,7 @@ const NOTEBOOK_SHELL_RUNTIME_TARGET_CACHE_FIELDS = {
   id: (target) => target.id ?? null,
   kind: (target) => target.kind,
   status: (target) => target.status,
+  attachmentIdle: (target) => target.attachmentIdle ?? false,
   label: (target) => target.label,
   statusLabel: (target) => target.statusLabel ?? null,
   detail: (target) => target.detail ?? null,
@@ -857,6 +869,7 @@ function stableNotebookShellRuntimeTarget(
     runtimeSessionId: target.runtimeSessionId ?? null,
     kind: target.kind,
     status: target.status,
+    ...(target.attachmentIdle ? { attachmentIdle: true } : {}),
     label: target.label,
     statusLabel: target.statusLabel ?? null,
     detail: target.detail ?? null,
@@ -965,6 +978,12 @@ function workstationAttachmentStatusProjection(
       return { status: "ready", statusLabel: "Ready", detail: null };
     case "busy":
       return { status: "attached", statusLabel: "Busy", detail: null };
+    case "idle":
+      return {
+        status: "attached",
+        statusLabel: "Idle",
+        detail: "Compute is attached and starts on the next run.",
+      };
     case "connecting":
       return {
         status: "connecting",

--- a/packages/runtimed/src/notebook-workstation-launch.ts
+++ b/packages/runtimed/src/notebook-workstation-launch.ts
@@ -7,6 +7,7 @@ import type {
 
 export type NotebookWorkstationLaunchReadinessState =
   | "ready"
+  | "idle_attached"
   | "attaching"
   | "limited"
   | "needs_registration"
@@ -67,12 +68,14 @@ export function projectNotebookWorkstationLaunchReadiness({
     runtimeTarget?.id ?? null,
     runtimeTarget?.kind ?? null,
     runtimeTarget?.status ?? null,
+    runtimeTarget?.attachmentIdle ?? false,
     runtimeTarget?.statusLabel ?? null,
     runtimeTarget?.label ?? null,
     runtimeTarget?.detail ?? null,
     activeTarget?.id ?? null,
     activeTarget?.kind ?? null,
     activeTarget?.status ?? null,
+    activeTarget?.attachmentIdle ?? false,
     activeTarget?.statusLabel ?? null,
     activeTarget?.label ?? null,
     activeTarget?.detail ?? null,
@@ -87,7 +90,22 @@ export function projectNotebookWorkstationLaunchReadiness({
 
   let projection: NotebookWorkstationLaunchReadinessProjection;
   const runtimeCanExecute = Boolean(capabilities.runtime.executionAvailable);
-  if (runtimeCanExecute && capabilities.canExecute) {
+  if (
+    capabilities.canExecute &&
+    activeTarget?.kind === "cloud_workstation" &&
+    activeTarget.status === "attached" &&
+    activeTarget.attachmentIdle
+  ) {
+    projection = launchProjection({
+      canRun: true,
+      detail: `Runs will start compute on ${activeTarget.label}.`,
+      primaryAction: NO_ACTION,
+      state: "idle_attached",
+      statusLabel: "Idle",
+      targetLabel: activeTarget.label,
+      workstationId: activeTarget.id ?? selection?.activeWorkstationId ?? null,
+    });
+  } else if (runtimeCanExecute && capabilities.canExecute) {
     projection = launchProjection({
       canRun: true,
       detail: null,

--- a/packages/runtimed/src/notebook-workstation-selection.ts
+++ b/packages/runtimed/src/notebook-workstation-selection.ts
@@ -459,6 +459,7 @@ function activeTargetCacheKey(target: NotebookShellRuntimeTargetProjection | nul
     target.id ?? null,
     target.kind,
     target.status,
+    target.attachmentIdle ?? false,
     target.label,
     target.statusLabel ?? null,
     target.detail ?? null,

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -6,6 +6,8 @@ import {
   readOnlyNotebookShellCapabilities,
   resolveNotebookShellRuntimeTarget,
   stabilizeNotebookShellCapabilities,
+  workstationAttachmentCanExecute,
+  workstationAttachmentIsConnected,
   type NotebookShellAccessCapabilities,
   type NotebookShellAuthCapabilities,
   type NotebookShellRuntimeCapabilities,
@@ -523,6 +525,30 @@ describe("projectNotebookRuntimeTargetFromWorkstationAttachment", () => {
         statusLabel: "Lost",
         lastSeenAt: "2026-06-07T21:02:00Z",
       },
+    });
+  });
+
+  it("projects idle workstation attachments as attached wake targets without lost room chrome", () => {
+    const idleAttachment = attachment({
+      status: "idle",
+      status_message: null,
+    });
+    const target = projectNotebookRuntimeTargetFromWorkstationAttachment(idleAttachment, {
+      requireRuntimePeer: true,
+      runtimePeerCount: 0,
+      runtimeLastSeenAt: "2026-06-07T21:02:00Z",
+    });
+
+    expect(workstationAttachmentCanExecute(idleAttachment)).toBe(false);
+    expect(workstationAttachmentIsConnected(idleAttachment)).toBe(false);
+    expect(target).toMatchObject({
+      id: "ws-lab2",
+      status: "attached",
+      attachmentIdle: true,
+      statusLabel: "Idle",
+      detail: "Compute is attached and starts on the next run.",
+      runtimePeerCount: null,
+      roomLink: null,
     });
   });
 });

--- a/packages/runtimed/tests/notebook-workstation-launch.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-launch.test.ts
@@ -6,6 +6,8 @@ import {
   projectNotebookWorkstationSelection,
   type NotebookRegisteredWorkstation,
   type NotebookShellCapabilities,
+  type NotebookShellRuntimeTargetProjection,
+  type NotebookWorkstationSelectionProjection,
 } from "../src";
 
 type LaunchCapabilities = Pick<NotebookShellCapabilities, "canExecute" | "runtime">;
@@ -60,6 +62,25 @@ const lab2Workstation: NotebookRegisteredWorkstation = {
   workingDirectory: "/home/ubuntu/codex/nteract",
 };
 
+function selectionWithActiveTarget(
+  activeTarget: NotebookShellRuntimeTargetProjection,
+): NotebookWorkstationSelectionProjection {
+  return {
+    activeTarget,
+    activeWorkstationId: activeTarget.id ?? null,
+    canRegisterWorkstation: false,
+    canSelectWorkstation: false,
+    canSetDefaultWorkstation: false,
+    defaultWorkstation: null,
+    defaultWorkstationId: null,
+    launchCandidate: null,
+    registeredWorkstations: Object.freeze([]),
+    selectedWorkstation: null,
+    selectedWorkstationId: null,
+    state: "attached",
+  };
+}
+
 beforeEach(() => {
   clearNotebookWorkstationLaunchReadinessProjectionCacheForTests();
   clearNotebookWorkstationSelectionProjectionCacheForTests();
@@ -83,6 +104,89 @@ describe("notebook workstation launch readiness projection", () => {
       statusLabel: "Ready",
       targetLabel: "This machine",
       workstationId: "local-daemon",
+      primaryAction: {
+        kind: "none",
+      },
+    });
+  });
+
+  it("projects idle attached compute as a wake-on-run target", () => {
+    const nonIdleTarget: NotebookShellRuntimeTargetProjection = {
+      id: "ws-lab2",
+      kind: "cloud_workstation",
+      label: "Lab2 workstation",
+      status: "attached",
+      statusLabel: "Idle",
+      detail: "Compute is attached and starts on the next run.",
+    };
+    const idleTarget: NotebookShellRuntimeTargetProjection = {
+      ...nonIdleTarget,
+      attachmentIdle: true,
+    };
+    const nonIdleProjection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: {
+        canExecute: true,
+        runtime: {
+          ...cloudUnavailableCapabilities.runtime,
+          executionAvailable: true,
+          target: nonIdleTarget,
+        },
+      },
+      selection: selectionWithActiveTarget(nonIdleTarget),
+    });
+    const idleProjection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: {
+        canExecute: true,
+        runtime: {
+          ...cloudUnavailableCapabilities.runtime,
+          executionAvailable: true,
+          target: idleTarget,
+        },
+      },
+      selection: selectionWithActiveTarget(idleTarget),
+    });
+
+    expect(nonIdleProjection.state).toBe("ready");
+    expect(idleProjection).not.toBe(nonIdleProjection);
+    expect(idleProjection).toMatchObject({
+      canRun: true,
+      detail: "Runs will start compute on Lab2 workstation.",
+      primaryAction: {
+        kind: "none",
+      },
+      state: "idle_attached",
+      statusLabel: "Idle",
+      targetLabel: "Lab2 workstation",
+      workstationId: "ws-lab2",
+    });
+  });
+
+  it("keeps idle attached compute limited when execution is not allowed", () => {
+    const idleTarget: NotebookShellRuntimeTargetProjection = {
+      id: "ws-lab2",
+      kind: "cloud_workstation",
+      label: "Lab2 workstation",
+      status: "attached",
+      statusLabel: "Idle",
+      detail: "Compute is attached and starts on the next run.",
+      attachmentIdle: true,
+    };
+    const projection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: {
+        canExecute: false,
+        runtime: {
+          ...cloudUnavailableCapabilities.runtime,
+          executionAvailable: true,
+          target: idleTarget,
+        },
+      },
+      selection: selectionWithActiveTarget(idleTarget),
+    });
+
+    expect(projection).toMatchObject({
+      canRun: false,
+      state: "limited",
+      statusLabel: "Idle",
       primaryAction: {
         kind: "none",
       },

--- a/packages/runtimed/tests/notebook-workstation-selection.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-selection.test.ts
@@ -135,6 +135,40 @@ describe("notebook workstation selection projection", () => {
     expect(projection.launchCandidate?.id).toBe("ws-lab2");
   });
 
+  it("keeps idle attachment identity when an offline registry row degrades the target", () => {
+    const projection = projectNotebookWorkstationSelection({
+      activeAttachment: {
+        workstation_id: "ws-lab2",
+        display_name: "Lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "idle",
+      },
+      canSelectWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          ...lab2Workstation,
+          status: "offline",
+          statusMessage: "No heartbeat from this workstation recently.",
+        },
+      ],
+    });
+
+    expect(projection.state).toBe("default");
+    expect(projection.activeWorkstationId).toBe("ws-lab2");
+    expect(projection.activeTarget).toMatchObject({
+      id: "ws-lab2",
+      label: "Lab2 workstation",
+      status: "offline",
+      attachmentIdle: true,
+      detail: "No heartbeat from this workstation recently.",
+    });
+    expect(projection.defaultWorkstation?.isAttached).toBe(false);
+    expect(projection.launchCandidate?.id).toBe("ws-lab2");
+  });
+
   it("directs owners with no registered workstations toward workstation setup", () => {
     const projection = projectNotebookWorkstationSelection({
       canRegisterWorkstation: true,


### PR DESCRIPTION
Implements the runtime idle TTL + lazy launch-on-execute arc: visiting a notebook is never a compute-starting event, idle kernels shut down cleanly after 30 minutes without execution, the attachment stays sticky, and the next Run wakes compute on the same box. Follows the control-plane correctness PR (#3971). The decision record ships as `docs/adr/runtime-idle-ttl-lazy-launch.md` in this PR.

## Decisions

- **Execution-only idleness**: open viewer tabs never hold a kernel alive (WebSocket hibernation keeps tabs cheap). A future force-keep-alive pin per notebook is recorded as ADR future work, not built.
- **TTL = 30 min**, compile-time constant for v1.
- **Lazy launch**: kernels launch on first execution, never on room wake. Eager launch-on-attach survives only for user-initiated attaches (`trigger=user_attach`); resume jobs (`trigger=resume`) spawn with launch-on-execute.
- **Owner-only resume**: hosted execution is owner-only; resume jobs reuse the owner principal. No new ACL surface.
- Fail active attach jobs immediately on lease expiry (registry alarm as the host-independent driver).

## Commits

1. `fix(cloud): ignore stale cross-session workstation-attachment publishes` — the monotonic publish guard deferred from #3971; a raced publish can no longer re-point execution routing at a cancelled job.
2. `fix(cloud): fail active attach jobs on lease expiry` — the host-independent expiry driver deferred from #3971.
3. `fix(cloud): stop idle hosted runtimes and lazily resume execution` — the room-DO idle alarm (third task on the existing single-earliest alarm), execution-activity tracking, teardown via the close path, and the owner-only wake-on-execute resume path.
4. `feat(runtimed): treat runtime idle timeout close as graceful terminal` — a third close category (terminal AND graceful): the host shuts the kernel down cleanly, exits Ok, and the attach job patches `completed` instead of `failed`; the close-reason constant is pinned identical across TS and Rust by test.
5. `feat(runtimed): launch-on-execute trigger for workstation attach jobs` — `trigger` column (guarded ALTER), a one-shot launch template consumed on first execution after `runtime_state_doc_seen`; `user_attach` spawn argv byte-identical to before.
6. `feat(cloud): attached-idle workstation state in rail and Run affordance` — status `idle` renders as "Idle · starts on the next run", Run stays available as the wake affordance (owner connections only), no room-link "lost" chrome for a deliberately hibernated runtime, and stale idle-session peers get a 409 instead of resurrecting reaped compute.
7. `fix(cloud): idle-teardown ordering, close-match anchoring, and review polish` — reconcile frames deliver to peers before sockets close; the idle rewrite preserves `updated_at` and `runtime_session_id` so it can never outrank a later legitimate publish; the graceful-close matcher is anchored to the close-frame format; the lazy-launch template clears on any successful inbound launch RPC; a `user_attach` create that dedups onto an active resume job upgrades the trigger.
8. `docs(adr): runtime idle TTL and lazy launch-on-execute`.
9. `fix(cloud): dedupe active attach jobs before creating the owner unique index at runtime` — from the preview deploy incident (1101s on a DB with pre-#3971 duplicate active jobs); the runtime schema path now runs migration 0008's idempotent dedupe before the index swap.
10. `fix(cloud): peer-gone reconcile never demotes an idle attachment` — from the live preview smoke: a host-initiated socket close racing the idle teardown armed the peer-gone grace alarm, which stamped `error` over the fresh `idle` attachment ("Kernel failed to start" instead of the calm idle state). Guarded in both layers: the WASM peer-gone reconcile skips the attachment rewrite when the current status is `idle`, and the room's grace handler skips + the idle teardown clears any racing watch. Genuine lost-peer cleanup (abort executions, error a live kernel) is preserved.

## Review protocol

Same as #3971: each slice Codex-implemented, adversarially reviewed by an opposing Claude model before the next stacked, then a final gate re-verified the newest fix commit, swept 12 cross-slice invariants with file:line evidence, and ran the full gates (four Rust crates, cloud typecheck + 1392 tests, repo vitest, app build, lint).

The protocol caught two real bugs before they shipped: the s5 review empirically verified checkpoint-ordering and byte-identical argv; the s6 review caught a critical end-to-end break where the idle status flip would have made Run-as-wake reject the frame and demote the attachment to `error` — a notebook dead until manual re-attach.

## Known residuals (filed, not blocking)

- #3973 — when Run hits an `idle` attachment whose workstation is offline, the pre-existing no-peer relabel degrades `idle` to `error`, killing lazy resume until re-attach. Pre-existing shape on main; the fix is a small guard.
- #3974 — an unsuppressed socket-close during idle-teardown delivery can arm the peer-gone grace alarm. Hit live on preview; commit 10 makes the consequence harmless for idle rooms (the spurious alarm fires and skips), so what remains of #3974 is suppressing the pointless arm itself.
- Peer-loss language: "Kernel failed to start" is wrong copy for a running kernel whose peer went away (deploys surface this on every open notebook). Follow-up arc: map peer-gone to a calm Disconnected state with a Retry/Run affordance, keeping genuine launch failures loud.
- The `uses_fresh_port_retry` launch-failure path still skips the error banner (pre-existing #3947 shape), listed in the ADR's future work.

## Deploy note

The `trigger` column lands via the guarded ALTER TABLE pattern in the runtime schema path; no migration-ordering dependency.

The owner-level active-job unique index initially had one: a DB holding duplicate active attach-job groups (the pre-#3971 shape) failed the runtime `CREATE UNIQUE INDEX` with Cloudflare 1101s before migration 0008's cleanup could run — hit live on the preview deploy (see the deploy smoke comment below). Fixed on this branch: the runtime schema path now runs the same idempotent dedupe UPDATE as migration 0008 strictly before the index swap, verified by a test that seeds the duplicate shape and asserts init succeeds, the newest job survives, and the index enforces afterward. Fresh, migrated, and previously-duplicated databases all converge without manual migration ordering.

Binary rollout: ship workstation binaries (nightly, then stable) before the production Worker deploy. New binary + old Worker is fully compatible; old binary + new Worker degrades noisily on idle teardown (reconnect attempts fenced by 409s, jobs `failed` instead of `completed`).
