### PR TITLE
fix(cloud): idle teardown never arms the peer-gone watch

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -271,6 +271,7 @@ export class NotebookRoom {
     { notebookId: string; peer: Peer; closeOptions: PeerCloseOptions }
   >();
   private broadcastDepth = 0;
+  private runtimePeerWatchSuppressionDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
   private readonly selectedRuntimePeerSessions = new Map<
     string,
@@ -1647,6 +1648,23 @@ export class NotebookRoom {
     }
   }
 
+  private withRuntimePeerWatchSuppressed<T>(callback: () => T): T {
+    this.runtimePeerWatchSuppressionDepth += 1;
+    try {
+      return callback();
+    } finally {
+      this.runtimePeerWatchSuppressionDepth -= 1;
+    }
+  }
+
+  private runtimePeerWatchSuppressed(): boolean {
+    return this.runtimePeerWatchSuppressionDepth > 0;
+  }
+
+  private sendFailureCloseOptions(): PeerCloseOptions {
+    return this.runtimePeerWatchSuppressed() ? { suppressRuntimePeerWatch: true } : {};
+  }
+
   private async forwardRequestToActiveRuntimePeer(
     notebookId: string,
     frame: TypedFrame,
@@ -1983,7 +2001,7 @@ export class NotebookRoom {
       if (this.trySendFrame(notebookId, runtimePeer, encoded)) {
         delivered = true;
       } else {
-        this.queuePeerRemoval(notebookId, runtimePeer);
+        this.queuePeerRemoval(notebookId, runtimePeer, this.sendFailureCloseOptions());
       }
     } finally {
       this.broadcastDepth -= 1;
@@ -2199,7 +2217,7 @@ export class NotebookRoom {
     try {
       for (const peer of peers) {
         if (!this.trySendFrame(notebookId, peer, frame)) {
-          this.queuePeerRemoval(notebookId, peer);
+          this.queuePeerRemoval(notebookId, peer, this.sendFailureCloseOptions());
         }
       }
     } finally {
@@ -2221,7 +2239,7 @@ export class NotebookRoom {
         counter: "peer_send_failed",
         counter_delta: 1,
       });
-      this.removePeer(notebookId, peer);
+      this.removePeer(notebookId, peer, this.sendFailureCloseOptions());
     }
   }
 
@@ -2316,7 +2334,11 @@ export class NotebookRoom {
     // A runtime_peer departure is the one failure the daemon can't self-correct
     // (its death IS the trigger). Arm the reconciliation watchdog if it left no
     // runtime_peer behind.
-    if (peer.identity.scope === "runtime_peer" && !closeOptions.suppressRuntimePeerWatch) {
+    if (
+      peer.identity.scope === "runtime_peer" &&
+      !closeOptions.suppressRuntimePeerWatch &&
+      !this.runtimePeerWatchSuppressed()
+    ) {
       this.refreshRuntimePeerWatch(notebookId);
       this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
     }
@@ -2587,17 +2609,28 @@ export class NotebookRoom {
       (async () => {
         try {
           const activity = await this.materializerFor(notebookId).getRuntimeExecutionActivity();
-          if (!this.hasRuntimePeer() || activity.executing || activity.queueDepth > 0) {
+          if (activity.executing || activity.queueDepth > 0) {
             await storage.delete(RUNTIME_IDLE_WATCH_KEY);
             await storage.delete(RUNTIME_IDLE_WATCH_ALARM_AT_KEY);
             await this.rescheduleRoomAlarm();
             return;
           }
+          const nowMs = Date.now();
           const existingAlarmAt = await storage.get<unknown>(RUNTIME_IDLE_WATCH_ALARM_AT_KEY);
-          if (isFiniteTimestamp(existingAlarmAt) && existingAlarmAt > Date.now()) {
+          if (!this.hasRuntimePeer()) {
+            if (isFiniteTimestamp(existingAlarmAt) && existingAlarmAt > nowMs) {
+              await this.rescheduleRoomAlarm();
+              return;
+            }
+            await storage.delete(RUNTIME_IDLE_WATCH_KEY);
+            await storage.delete(RUNTIME_IDLE_WATCH_ALARM_AT_KEY);
+            await this.rescheduleRoomAlarm();
             return;
           }
-          const alarmAt = Date.now() + RUNTIME_IDLE_TTL_MS;
+          if (isFiniteTimestamp(existingAlarmAt) && existingAlarmAt > nowMs) {
+            return;
+          }
+          const alarmAt = nowMs + RUNTIME_IDLE_TTL_MS;
           await storage.put(RUNTIME_IDLE_WATCH_KEY, notebookId);
           await storage.put(RUNTIME_IDLE_WATCH_ALARM_AT_KEY, alarmAt);
           await this.rescheduleRoomAlarm();
@@ -2780,14 +2813,16 @@ export class NotebookRoom {
         updatedAt,
       );
       this.invalidateSelectedRuntimePeerSession(notebookId);
-      if (result.changed) {
-        this.deliverRoomHostFrames(notebookId, result);
-        this.scheduleRoomHostCheckpoint(notebookId, materializer, "runtime_idle_timeout");
-      }
-      this.removeRuntimePeers(notebookId, {
-        code: RUNTIME_IDLE_CLOSE_CODE,
-        reason: RUNTIME_IDLE_CLOSE_REASON,
-        suppressRuntimePeerWatch: true,
+      this.withRuntimePeerWatchSuppressed(() => {
+        if (result.changed) {
+          this.deliverRoomHostFrames(notebookId, result);
+          this.scheduleRoomHostCheckpoint(notebookId, materializer, "runtime_idle_timeout");
+        }
+        this.removeRuntimePeers(notebookId, {
+          code: RUNTIME_IDLE_CLOSE_CODE,
+          reason: RUNTIME_IDLE_CLOSE_REASON,
+          suppressRuntimePeerWatch: true,
+        });
       });
       await this.clearRuntimePeerWatch(notebookId);
       this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3989,6 +3989,69 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     assert.equal(await state.getAlarm(), null);
   });
 
+  it("suppresses peer-gone watch when idle teardown drops a dead runtime socket", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimeSocket = new FakeSocket({ throwOnSend: true });
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    runtimePeer.socket = runtimeSocket.asCloudflareWebSocket();
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    let idleReconciles = 0;
+    let peerGoneReconciles = 0;
+    let peerWatchRefreshes = 0;
+    const peerWatchSpy = room as unknown as {
+      refreshRuntimePeerWatch(notebookId: string): void;
+    };
+    const originalRefreshRuntimePeerWatch = peerWatchSpy.refreshRuntimePeerWatch.bind(room);
+    peerWatchSpy.refreshRuntimePeerWatch = (notebookId: string) => {
+      peerWatchRefreshes += 1;
+      originalRefreshRuntimePeerWatch(notebookId);
+    };
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getRuntimeExecutionActivity: async () => ({ executing: false, queueDepth: 0 }),
+      reconcileRuntimeIdleTimeout: async () => {
+        idleReconciles += 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+          outbound: [
+            {
+              peer_id: "rt",
+              frame_type: FrameType.RUNTIME_STATE_SYNC,
+              payload: new Uint8Array([7, 8, 9]),
+            },
+          ],
+        };
+      },
+      reconcileRuntimePeerGone: async () => {
+        peerGoneReconciles += 1;
+        return noopMaterializedResult();
+      },
+    } as never);
+
+    harness.refreshRuntimeIdleWatch?.("demo");
+    await state.drain();
+
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+
+    assert.equal(idleReconciles, 1);
+    assert.equal(peerWatchRefreshes, 0, "send failure must not arm peer-gone watch");
+    assert.equal(peerGoneReconciles, 0, "no peer-gone reconcile follows idle teardown");
+    assert.equal(harness.peers.has(runtimePeer.id), false);
+    assert.equal(runtimeSocket.closed, true);
+    assert.equal(await state.state.storage.get("runtime_peer_gone_watch"), undefined);
+    assert.equal(await state.state.storage.get("runtime_peer_gone_watch_alarm_at"), undefined);
+    assert.equal(await state.getAlarm(), null);
+  });
+
   it("does not arm idle teardown while execution is active or queued", async () => {
     const state = alarmCapableState();
     const room = new NotebookRoom(state.state, {} as Env);
@@ -4004,6 +4067,46 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     harness.refreshRuntimeIdleWatch?.("demo");
     await state.drain();
 
+    assert.equal(await state.getAlarm(), null);
+  });
+
+  it("preserves a future idle deadline while the runtime peer is transiently absent", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    let idleReconciles = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getRuntimeExecutionActivity: async () => ({ executing: false, queueDepth: 0 }),
+      reconcileRuntimeIdleTimeout: async () => {
+        idleReconciles += 1;
+        return noopMaterializedResult();
+      },
+    } as never);
+    const existingAlarmAt = state.now + RUNTIME_IDLE_TTL_MS / 2;
+    await state.state.storage.put("runtime_idle_watch", "demo");
+    await state.state.storage.put("runtime_idle_watch_alarm_at", existingAlarmAt);
+    await state.state.storage.setAlarm?.(existingAlarmAt);
+
+    harness.refreshRuntimeIdleWatch?.("demo");
+    await state.drain();
+
+    assert.equal(await state.state.storage.get("runtime_idle_watch"), "demo");
+    assert.equal(await state.state.storage.get("runtime_idle_watch_alarm_at"), existingAlarmAt);
+    assert.equal(await state.getAlarm(), existingAlarmAt);
+
+    await state.state.storage.put("runtime_idle_watch_alarm_at", 0);
+    await state.state.storage.setAlarm?.(0);
+    await assert.doesNotReject(async () => {
+      await (room as unknown as { alarm(): Promise<void> }).alarm();
+      await state.drain();
+    });
+
+    assert.equal(idleReconciles, 0, "peerless idle alarm is a no-op");
+    assert.equal(await state.state.storage.get("runtime_idle_watch"), undefined);
+    assert.equal(await state.state.storage.get("runtime_idle_watch_alarm_at"), undefined);
     assert.equal(await state.getAlarm(), null);
   });
 


### PR DESCRIPTION
Idle teardown could re-arm the runtime peer-gone watch it was in the middle of clearing. Delivering final room-host frames or closing runtime peers during teardown can hit a dead socket; the resulting send-failure removal took the normal `removePeer` path and refreshed the watch, so an idle room scheduled a reconciliation alarm for a runtime peer that was intentionally torn down. This PR adds a room-scoped suppression depth around idle teardown so every removal triggered inside it, including queued send-failure removals, skips watch arming. Idle watch refresh also keeps a future stored deadline when the runtime peer is transiently absent instead of resetting the countdown.

## Design decision

Suppression is a re-entrant depth counter on the room rather than threading `suppressRuntimePeerWatch` through every send path. Send failures surface deep inside broadcast and queued-removal code that has no idea a teardown is in progress; the flag would have to ride through `trySendFrame`, `queuePeerRemoval`, and the drain loop. The counter makes the invariant local: any peer removal that happens while `withRuntimePeerWatchSuppressed` is on the stack (or drains from a removal queued during it, via `sendFailureCloseOptions`) inherits the suppression.

## Review protocol

Codex implemented against a written spec; an opposing Claude model reviewed the diff. Verdict: pass, no blocking findings.

Closes #3974.
