### PR TITLE
feat(cloud): peer loss reads as calm Disconnected and resumes on Run

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1549,6 +1549,11 @@ export class NotebookRoom {
     }
   }
 
+  /**
+   * A disconnected selected runtime session is recoverable room state: the
+   * same runtime peer may rejoin with its preserved workstation/session IDs
+   * and publish a ready attachment. Idle remains terminal execution teardown.
+   */
   private async runtimePeerAuthorityError(
     notebookId: string,
     workstation: RuntimePeerWorkstationMetadata | null,
@@ -1558,23 +1563,35 @@ export class NotebookRoom {
       return null;
     }
 
-    if (!runtimePeerSessionStatusAcceptsPeer(selected.status)) {
+    const presentedWorkstationId = runtimePeerWorkstationId(workstation);
+    const presentedSessionId = runtimePeerRuntimeSessionId(workstation);
+    const workstationMatches = presentedWorkstationId === selected.workstationId;
+    const sessionMatches =
+      !selected.runtimeSessionId || presentedSessionId === selected.runtimeSessionId;
+
+    if (selected.status === "disconnected" && workstationMatches && sessionMatches) {
+      return null;
+    }
+
+    if (
+      !runtimePeerSessionStatusAcceptsPeer(selected.status) &&
+      selected.status !== "disconnected"
+    ) {
       return `selected runtime session is ${selected.status}`;
     }
 
-    const presentedWorkstationId = runtimePeerWorkstationId(workstation);
-    if (presentedWorkstationId === selected.workstationId) {
-      if (!selected.runtimeSessionId) {
-        return null;
-      }
-      const presentedSessionId = runtimePeerRuntimeSessionId(workstation);
-      if (presentedSessionId === selected.runtimeSessionId) {
-        return null;
-      }
-      return `runtime peer session ${presentedSessionId ?? "unknown"} does not match selected runtime session ${selected.runtimeSessionId}`;
+    if (!workstationMatches) {
+      return `runtime peer workstation ${presentedWorkstationId} does not match selected workstation ${selected.workstationId}`;
     }
 
-    return `runtime peer workstation ${presentedWorkstationId} does not match selected workstation ${selected.workstationId}`;
+    if (!selected.runtimeSessionId) {
+      return null;
+    }
+    if (sessionMatches) {
+      return null;
+    }
+
+    return `runtime peer session ${presentedSessionId ?? "unknown"} does not match selected runtime session ${selected.runtimeSessionId}`;
   }
 
   private removeRuntimePeers(notebookId: string, closeOptions: PeerCloseOptions): void {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1544,6 +1544,43 @@ describe("NotebookRoom peer lifecycle", () => {
     );
   });
 
+  it("allows only the matching selected runtime session to rejoin after disconnect", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "disconnected",
+        status_message: "compute disconnected: runtime peer left the room",
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/codex/nteract",
+        runtime_session_id: "job-123",
+        updated_at: "2026-06-07T00:00:00.000Z",
+      }),
+      setWorkstationAttachment: async () => noopMaterializedResult(),
+    } as never);
+
+    const matching = await harness.runtimePeerAuthorityError?.("demo", {
+      workstationId: "lab2",
+      runtimeSessionId: "job-123",
+    });
+    const staleSession = await harness.runtimePeerAuthorityError?.("demo", {
+      workstationId: "lab2",
+      runtimeSessionId: "job-456",
+    });
+
+    assert.equal(matching, null);
+    assert.match(String(staleSession), /does not match selected runtime session job-123/);
+  });
+
   it("rejects runtime-peer upgrades for idle selected sessions", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const harness = roomHarness(room);
@@ -3539,6 +3576,93 @@ describe("NotebookRoom materialized sync routing", () => {
     assert.equal(accepted.type, "cloud_frame_accepted");
   });
 
+  it("creates a resume attach job after grace reconciliation disconnects compute", async () => {
+    const db = new ResumeNotebookD1();
+    const state = alarmCapableState();
+    const env = { DB: db } as unknown as Env;
+    const room = new NotebookRoom(state.state, env);
+    const materializer = new RoomMaterializer("demo", state.state, env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", materializer as never);
+    await materializer.setWorkstationAttachment({
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: null,
+      memory_bytes: null,
+      working_directory: "/srv/project",
+      updated_at: "2026-05-22T00:00:00.000Z",
+      runtime_session_id: "job-old",
+    });
+
+    const runtimePeer = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=alice&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.removePeer("demo", runtimePeer);
+    await state.drain();
+    assert.equal(await state.getAlarm(), state.now + 30_000, "watch armed after departure");
+
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+    const disconnectedAttachment = await materializer.getWorkstationAttachment();
+    assert.equal(disconnectedAttachment?.status, "disconnected");
+    assert.equal(
+      disconnectedAttachment?.status_message,
+      "compute disconnected: runtime peer left the room and did not return within the grace window",
+    );
+    assert.equal(disconnectedAttachment?.runtime_session_id, "job-old");
+    assert.equal(disconnectedAttachment?.updated_at, "2026-05-22T00:00:00.000Z");
+
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const ownerPeer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:02.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({
+            id: "request-1",
+            action: "execute_cell",
+            cell_id: initialHostedCellIdForTest("demo"),
+          }),
+        ),
+      ),
+    );
+
+    assert.equal(db.attachJobs.length, 1);
+    assert.equal(db.attachJobs[0]?.trigger, "resume");
+    assert.equal(db.attachJobs[0]?.requested_by_actor_label, "execution resume");
+    const reconnectingAttachment = await materializer.getWorkstationAttachment();
+    assert.equal(reconnectingAttachment?.status, "connecting");
+    assert.equal(reconnectingAttachment?.runtime_session_id, db.attachJobs[0]?.id);
+    const accepted = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(accepted.type, "cloud_frame_accepted");
+  });
+
   it("rejects non-owner execution without creating a resume attach job", async () => {
     const db = new ResumeNotebookD1();
     const room = new NotebookRoom(fakeState(), { DB: db } as unknown as Env);
@@ -3845,8 +3969,8 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       getWorkstationAttachment: async () => attachment,
       reconcileRuntimePeerGone: async () => {
         reconcileCalls += 1;
-        attachment.status = "error";
-        attachment.status_message = "runtime peer disconnected";
+        attachment.status = "disconnected";
+        attachment.status_message = "compute disconnected: runtime peer disconnected";
         return {
           ...noopMaterializedResult(),
           changed: true,
@@ -4293,8 +4417,8 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       getWorkstationAttachment: async () => attachment,
       reconcileRuntimePeerGone: async (reason: string) => {
         repairReason = reason;
-        attachment.status = "error";
-        attachment.status_message = "runtime peer left";
+        attachment.status = "disconnected";
+        attachment.status_message = "compute disconnected: runtime peer left";
         return {
           ...noopMaterializedResult(),
           changed: true,
@@ -4324,7 +4448,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     });
     assert.equal(repairReason, "expired pending attach job");
     assert.equal(checkpointed, 1);
-    assert.equal(attachment.status, "error");
+    assert.equal(attachment.status, "disconnected");
     assert.equal(attachment.runtime_session_id, "expired-job");
   });
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -30,7 +30,9 @@ import {
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
   NotebookWorkstationsPanel,
+  ComputeDisconnectedNotice,
   KernelLaunchErrorBanner,
+  isRuntimePeerDisconnectedErrorDetails,
   projectNotebookCommandRuntimeStatusFromRuntimeState,
   shouldShowKernelLaunchErrorBanner,
   shouldShowNotebookDocumentCommandToolbar,
@@ -1767,6 +1769,20 @@ export function NotebookViewer({
       errorReason: cloudKernelErrorReason,
       runtime: cloudKernelRuntime,
     }) && dismissedLaunchError !== cloudKernelErrorDetails;
+  const shouldRenderComputeDisconnectedNotice =
+    isRuntimePeerDisconnectedErrorDetails(cloudKernelErrorDetails) &&
+    dismissedLaunchError !== cloudKernelErrorDetails;
+  const computeDisconnectedNotice =
+    shouldRenderComputeDisconnectedNotice && cloudKernelErrorDetails ? (
+      <ComputeDisconnectedNotice
+        errorDetails={cloudKernelErrorDetails}
+        onRetry={() => {
+          setDismissedLaunchError(null);
+          handleCloudRestartRuntime();
+        }}
+        onDismiss={() => setDismissedLaunchError(cloudKernelErrorDetails)}
+      />
+    ) : null;
   const kernelLaunchNotice =
     shouldRenderKernelLaunchError && cloudKernelErrorDetails ? (
       <KernelLaunchErrorBanner
@@ -1779,8 +1795,9 @@ export function NotebookViewer({
       />
     ) : null;
   const diagnostics =
-    kernelLaunchNotice || accessRequestNotice ? (
+    computeDisconnectedNotice || kernelLaunchNotice || accessRequestNotice ? (
       <>
+        {computeDisconnectedNotice}
         {kernelLaunchNotice}
         {accessRequestNotice}
       </>

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -55,7 +55,9 @@ import {
   DaemonStatusBanner,
   DebugBanner,
   EnvBuildDecisionDialog,
+  ComputeDisconnectedNotice,
   KernelLaunchErrorBanner,
+  isRuntimePeerDisconnectedErrorDetails,
   NotebookCommentsPanel,
   NotebookConnectionIdentity,
   NotebookDocumentRail,
@@ -1887,6 +1889,17 @@ function AppContent() {
             </button>
           </div>
         )}
+        {isRuntimePeerDisconnectedErrorDetails(errorDetails) &&
+          dismissedLaunchError !== errorDetails && (
+            <ComputeDisconnectedNotice
+              errorDetails={errorDetails as string}
+              onRetry={() => {
+                setDismissedLaunchError(null);
+                tryStartKernel();
+              }}
+              onDismiss={() => setDismissedLaunchError(errorDetails)}
+            />
+          )}
         {shouldShowKernelLaunchErrorBanner({
           lifecycle,
           errorDetails,

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -65,7 +65,9 @@
 //!     default_environment_label: Str
 //!     environment_policy: Str
 //!     status: Str             ("disconnected" | "connecting" | "ready" | "busy" | "idle" | "error")
+//!                             "disconnected" means compute was lost and can resume on execution.
 //!                             "idle" means attached compute is stopped and can resume on execution.
+//!                             "error" means startup or attachment failed and needs attention.
 //!     status_message: Str|null
 //!     cpu_count: Uint|null
 //!     memory_bytes: Uint|null

--- a/crates/runtime-doc/src/policy.rs
+++ b/crates/runtime-doc/src/policy.rs
@@ -789,8 +789,8 @@ mod tests {
         let before = runtime_state_policy_snapshot(&before_doc);
         let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
         let mut next = workstation_attachment();
-        next.status = "error".to_string();
-        next.status_message = Some("runtime peer disconnected".to_string());
+        next.status = "disconnected".to_string();
+        next.status_message = Some("compute disconnected: runtime peer left".to_string());
         after_doc.set_workstation_attachment(Some(&next)).unwrap();
         let after = runtime_state_policy_snapshot(&after_doc);
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1845,7 +1845,11 @@ impl RoomHostHandle {
         let attachment_is_idle = current_attachment
             .as_ref()
             .is_some_and(workstation_attachment_is_idle);
+        let attachment_is_error = current_attachment
+            .as_ref()
+            .is_some_and(workstation_attachment_is_error);
         if !attachment_is_idle
+            && !attachment_is_error
             && (current_attachment.is_some() || self.state_doc.get_heads() != heads_before)
         {
             let next_attachment =
@@ -1996,13 +2000,17 @@ fn runtime_peer_gone_workstation_attachment(
         updated_at: None,
         runtime_session_id: None,
     });
-    attachment.status = "error".to_string();
-    attachment.status_message = Some(format!("runtime peer disconnected: {reason}"));
+    attachment.status = "disconnected".to_string();
+    attachment.status_message = Some(format!("compute disconnected: {reason}"));
     attachment
 }
 
 fn workstation_attachment_is_idle(attachment: &WorkstationAttachmentState) -> bool {
     attachment.status == "idle"
+}
+
+fn workstation_attachment_is_error(attachment: &WorkstationAttachmentState) -> bool {
+    attachment.status == "error"
 }
 
 #[derive(Debug, Serialize)]
@@ -6132,14 +6140,14 @@ mod tests {
         );
         assert_eq!(
             state.workstation.as_ref().map(|ws| ws.status.as_str()),
-            Some("error")
+            Some("disconnected")
         );
         assert_eq!(
             state
                 .workstation
                 .as_ref()
                 .and_then(|ws| ws.status_message.as_deref()),
-            Some("runtime peer disconnected: daemon dropped")
+            Some("compute disconnected: daemon dropped")
         );
         assert_eq!(
             state
@@ -6262,6 +6270,16 @@ mod tests {
             .reconcile_runtime_peer_gone_inner("blip")
             .expect("first reconcile");
         assert!(first.changed);
+        let state = host.state_doc.read_state();
+        let attachment = state
+            .workstation
+            .as_ref()
+            .expect("peer loss writes a disconnected attachment");
+        assert_eq!(attachment.status, "disconnected");
+        assert_eq!(
+            attachment.status_message.as_deref(),
+            Some("compute disconnected: blip")
+        );
 
         // A second alarm (e.g. the grace timer re-firing) is a safe no-op:
         // everything is already terminal, so nothing changes and no frames are
@@ -6302,7 +6320,28 @@ mod tests {
         );
         assert_eq!(
             state.workstation.as_ref().map(|ws| ws.status.as_str()),
-            Some("error")
+            Some("disconnected")
+        );
+        assert_eq!(
+            state
+                .workstation
+                .as_ref()
+                .and_then(|ws| ws.status_message.as_deref()),
+            Some("compute disconnected: late disconnect")
+        );
+        assert_eq!(
+            state
+                .workstation
+                .as_ref()
+                .and_then(|ws| ws.runtime_session_id.as_deref()),
+            Some("job-runtime")
+        );
+        assert_eq!(
+            state
+                .workstation
+                .as_ref()
+                .and_then(|ws| ws.updated_at.as_deref()),
+            Some("2026-06-07T00:00:00.000Z")
         );
     }
 
@@ -6350,6 +6389,50 @@ mod tests {
         assert_eq!(
             attachment.updated_at.as_deref(),
             Some("2026-06-07T00:00:02.000Z")
+        );
+    }
+
+    #[test]
+    fn reconcile_runtime_peer_gone_does_not_demote_error_attachment() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle(&RuntimeLifecycle::Shutdown)
+            .unwrap();
+        let mut attachment = workstation_attachment_fixture();
+        attachment.status = "error".to_string();
+        attachment.status_message =
+            Some("Launch failed while creating the workstation session.".to_string());
+        attachment.runtime_session_id = Some("job-error".to_string());
+        attachment.updated_at = Some("2026-06-07T00:00:03.000Z".to_string());
+        host.set_workstation_attachment_inner(Some(&attachment))
+            .expect("seed error attachment");
+
+        let result = host
+            .reconcile_runtime_peer_gone_inner("late disconnect")
+            .expect("reconcile ok");
+
+        assert!(!result.changed, "error peer-gone reconcile is a no-op");
+        assert!(result.outbound.is_empty());
+        let state = host.state_doc.read_state();
+        assert_ne!(
+            state.kernel.lifecycle,
+            RuntimeLifecycle::Error,
+            "peer-gone reconcile must not write an error kernel state for a terminal lifecycle"
+        );
+        let attachment = state
+            .workstation
+            .as_ref()
+            .expect("error attachment remains");
+        assert_eq!(attachment.status, "error");
+        assert_eq!(
+            attachment.status_message.as_deref(),
+            Some("Launch failed while creating the workstation session.")
+        );
+        assert_eq!(attachment.runtime_session_id.as_deref(), Some("job-error"));
+        assert_eq!(
+            attachment.updated_at.as_deref(),
+            Some("2026-06-07T00:00:03.000Z")
         );
     }
 
@@ -6420,6 +6503,26 @@ mod tests {
         assert_eq!(
             state.kernel.error_details.as_deref(),
             Some("kernel launch failed: missing module")
+        );
+    }
+
+    #[test]
+    fn set_workstation_attachment_keeps_launch_failure_error_status() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut attachment = workstation_attachment_fixture();
+        attachment.status = "error".to_string();
+        attachment.status_message = Some("Failed to launch kernel: missing module".to_string());
+
+        host.set_workstation_attachment_inner(Some(&attachment))
+            .expect("publish launch failure attachment");
+
+        let state = host.state_doc.read_state();
+        let attachment = state.workstation.as_ref().expect("attachment remains");
+        assert_eq!(attachment.status, "error");
+        assert_eq!(
+            attachment.status_message.as_deref(),
+            Some("Failed to launch kernel: missing module")
         );
     }
 

--- a/packages/runtimed/src/notebook-workstation-panel.ts
+++ b/packages/runtimed/src/notebook-workstation-panel.ts
@@ -248,6 +248,7 @@ function isRuntimePeerDisconnectDetail(detail: string): boolean {
   const normalized = detail.trim().toLowerCase();
   return (
     normalized.startsWith("runtime peer disconnected") ||
+    normalized.startsWith("compute disconnected") ||
     normalized.includes("runtime peer left the room") ||
     normalized.startsWith("room link lost")
   );

--- a/packages/runtimed/tests/notebook-compute-session.test.ts
+++ b/packages/runtimed/tests/notebook-compute-session.test.ts
@@ -55,15 +55,20 @@ describe("projectNotebookComputeSessionSummary", () => {
     expect(isNotebookComputeSessionSummary(summary)).toBe(true);
   });
 
-  it("keeps a disconnected ready attachment visible as stale", () => {
+  it("keeps a disconnected attachment visible as stale", () => {
     const summary = projectNotebookComputeSessionSummary({
-      attachment,
+      attachment: {
+        ...attachment,
+        status: "disconnected",
+        status_message: "compute disconnected: runtime peer left the room",
+      },
       notebookId: "topic-viz",
       ownerPrincipal: "user:dev:alice",
       runtimePeerCount: 0,
     });
 
     expect(summary?.status).toBe("stale");
+    expect(summary?.status_message).toBe("compute disconnected: runtime peer left the room");
     expect(summary?.last_runtime_seen_at).toBeNull();
   });
 

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -511,6 +511,32 @@ describe("projectNotebookRuntimeTargetFromWorkstationAttachment", () => {
     });
   });
 
+  it("projects disconnected attachments as offline while error attachments stay attention", () => {
+    const disconnected = projectNotebookRuntimeTargetFromWorkstationAttachment(
+      attachment({
+        status: "disconnected",
+        status_message: "compute disconnected: runtime peer left the room",
+      }),
+    );
+    const failed = projectNotebookRuntimeTargetFromWorkstationAttachment(
+      attachment({
+        status: "error",
+        status_message: "Failed to launch kernel: missing module",
+      }),
+    );
+
+    expect(disconnected).toMatchObject({
+      status: "offline",
+      statusLabel: "Offline",
+      detail: "compute disconnected: runtime peer left the room",
+    });
+    expect(failed).toMatchObject({
+      status: "attention",
+      statusLabel: "Needs attention",
+      detail: "Failed to launch kernel: missing module",
+    });
+  });
+
   it("carries room-link last-seen state for stale hosted attachments", () => {
     const target = projectNotebookRuntimeTargetFromWorkstationAttachment(attachment(), {
       requireRuntimePeer: true,

--- a/packages/runtimed/tests/notebook-workstation-panel.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-panel.test.ts
@@ -266,4 +266,34 @@ describe("projectNotebookWorkstationPanel", () => {
     );
     expect(ownerProjection).not.toBe(viewerProjection);
   });
+
+  it("projects compute-disconnected attachment details as friendly stale copy", () => {
+    const projection = projectNotebookWorkstationPanel(
+      capabilities({
+        accessOverrides: { level: "owner", source: "cloud" },
+        authOverrides: { canUseAuthenticatedIdentity: true },
+        runtimeOverrides: {
+          canWriteRuntimeState: false,
+          connected: false,
+          executionAvailable: false,
+          source: "cloud",
+          target: {
+            id: "ws-lab2",
+            kind: "cloud_workstation",
+            status: "attention",
+            label: "Lab2",
+            statusLabel: "Needs attention",
+            detail: "compute disconnected: expired pending attach job",
+            providerLabel: "Workstation",
+            defaultEnvironmentLabel: "Current Python",
+          },
+        },
+      }),
+    );
+
+    expect(projection.detail).toBe(
+      "Compute from Lab2 is no longer connected to this notebook. Start compute again from an available workstation.",
+    );
+    expect(projection.detail).not.toContain("expired pending attach job");
+  });
 });

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -1,8 +1,23 @@
-import { AlertCircle, Check, Copy, RotateCw } from "lucide-react";
+import { AlertCircle, Check, Copy, RotateCw, WifiOff } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
 import { Button } from "@/components/ui/button";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
+
+const RUNTIME_PEER_DISCONNECTED_ERROR_PREFIX = "runtime peer disconnected:";
+
+export function isRuntimePeerDisconnectedErrorDetails(
+  errorDetails: string | null | undefined,
+): boolean {
+  return errorDetails?.startsWith(RUNTIME_PEER_DISCONNECTED_ERROR_PREFIX) ?? false;
+}
+
+function runtimePeerDisconnectedReason(errorDetails: string | null | undefined): string | null {
+  const details = errorDetails ?? "";
+  if (!isRuntimePeerDisconnectedErrorDetails(details)) return null;
+  const reason = details.slice(RUNTIME_PEER_DISCONNECTED_ERROR_PREFIX.length).trim();
+  return reason.length > 0 ? reason : null;
+}
 
 /**
  * Decide whether the generic kernel-launch banner should render.
@@ -20,6 +35,8 @@ import { NotebookNotice } from "@/components/notebook/NotebookNotice";
  *   toolbar renders targeted prompts that already consume the error message.
  * - Skip `runtime === "deno"`: toolbar renders the Deno
  *   "auto-install failed" prompt that already consumes it.
+ * - Skip room-host peer-loss reconciliation: the kernel is terminalized for
+ *   cleanup, but cloud recovery is a disconnected compute state.
  *
  * Everything else — solver/install errors, stderr tails from generic
  * subprocess crashes, env-build rate limits — falls through to this banner.
@@ -36,6 +53,7 @@ export function shouldShowKernelLaunchErrorBanner(params: {
   if (params.errorReason === KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL) return false;
   if (params.errorReason === KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH) return false;
   if (params.errorReason === KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING) return false;
+  if (isRuntimePeerDisconnectedErrorDetails(params.errorDetails)) return false;
   if (params.runtime === "deno") return false;
   return true;
 }
@@ -107,6 +125,41 @@ export function KernelLaunchErrorBanner({
             Retry
           </Button>
         </>
+      }
+    />
+  );
+}
+
+export interface ComputeDisconnectedNoticeProps {
+  errorDetails: string | null;
+  onRetry: () => void;
+  onDismiss?: () => void;
+}
+
+export function ComputeDisconnectedNotice({
+  errorDetails,
+  onRetry,
+  onDismiss,
+}: ComputeDisconnectedNoticeProps) {
+  const reason = runtimePeerDisconnectedReason(errorDetails);
+
+  return (
+    <NotebookNotice
+      tone="warning"
+      icon={<WifiOff className="size-4" />}
+      title="Compute disconnected"
+      onDismiss={onDismiss}
+      details={
+        <span>
+          Run any cell to wake compute again
+          {reason ? `; last disconnect: ${reason}` : ""}.
+        </span>
+      }
+      actions={
+        <Button size="sm" variant="secondary" className="h-6 px-2 text-xs" onClick={onRetry}>
+          <RotateCw className="size-3 mr-1" />
+          Retry
+        </Button>
       }
     />
   );

--- a/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
+++ b/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
@@ -14,7 +14,9 @@ import userEvent from "@testing-library/user-event";
 import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  ComputeDisconnectedNotice,
   KernelLaunchErrorBanner,
+  isRuntimePeerDisconnectedErrorDetails,
   shouldShowKernelLaunchErrorBanner,
 } from "../KernelLaunchErrorBanner";
 
@@ -23,6 +25,8 @@ const STDERR_TAIL = [
   "stderr tail:",
   "/path/to/python: No module named nteract_kernel_launcher",
 ].join("\n");
+const PEER_DISCONNECTED_DETAILS =
+  "runtime peer disconnected: runtime peer left the room and did not return within the grace window";
 
 describe("KernelLaunchErrorBanner", () => {
   it("shows the failure heading", () => {
@@ -97,6 +101,27 @@ describe("KernelLaunchErrorBanner", () => {
   });
 });
 
+describe("ComputeDisconnectedNotice", () => {
+  it("shows calm disconnected copy with retry and run-as-wake guidance", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <ComputeDisconnectedNotice
+        errorDetails={PEER_DISCONNECTED_DETAILS}
+        onRetry={onRetry}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Compute disconnected")).toBeInTheDocument();
+    expect(screen.getByText(/Run any cell to wake compute again/)).toBeInTheDocument();
+    expect(screen.getByText(/runtime peer left the room/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("shouldShowKernelLaunchErrorBanner", () => {
   const ERROR: RuntimeLifecycle = { lifecycle: "Error" };
   const IDLE: RuntimeLifecycle = { lifecycle: "Running", activity: "Idle" };
@@ -110,6 +135,18 @@ describe("shouldShowKernelLaunchErrorBanner", () => {
         runtime: "python",
       }),
     ).toBe(true);
+  });
+
+  it("hides for runtime peer disconnect cleanup errors", () => {
+    expect(isRuntimePeerDisconnectedErrorDetails(PEER_DISCONNECTED_DETAILS)).toBe(true);
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: PEER_DISCONNECTED_DETAILS,
+        errorReason: null,
+        runtime: "python",
+      }),
+    ).toBe(false);
   });
 
   it("hides when lifecycle is not Error", () => {

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -135,8 +135,11 @@ export {
 } from "./DaemonStatusBanner";
 export { DebugBanner, type DebugBannerProps } from "./DebugBanner";
 export {
+  ComputeDisconnectedNotice,
   KernelLaunchErrorBanner,
+  isRuntimePeerDisconnectedErrorDetails,
   shouldShowKernelLaunchErrorBanner,
+  type ComputeDisconnectedNoticeProps,
   type KernelLaunchErrorBannerProps,
 } from "./KernelLaunchErrorBanner";
 export {


### PR DESCRIPTION
When a cloud runtime peer drops out (grace-window expiry or missing runtime peer at reconcile), the notebook now reads as calmly disconnected instead of broken. Reconcile writes attachment status `disconnected` with a `compute disconnected: <reason>` message rather than `error`, the viewer renders a quiet "Compute disconnected" notice with retry/run-to-wake guidance instead of the red kernel-failure banner, and the next Run admits hosted execution and creates a resume attach job. Genuine launch failures still surface the loud error banner.

## Design decision

Peer loss and launch failure are different states and now carry different vocabulary. `error` stays reserved for real failures, which keeps the resume gate (`runtimeAttachmentCanResumeForExecution` still excludes `error`) and the monotonic publish guard untouched. The viewer discriminates on the `"runtime peer disconnected:"` details prefix, the same discriminator `clear_stale_runtime_peer_gone_error` already keys on, so no new state field was added. `runtime-doc` docs were sharpened to pin down what `disconnected`, `idle`, and `error` each mean.

## Review protocol

Codex implemented; an opposing Claude model reviewed. All blocking findings from that review were fixed and re-verified: WASM tests, notebook-cloud typecheck and tests, full vp suite, notebook build, and lint are green.

Closes #3973.
