### PR TITLE
ci: free runner disk and trim test debuginfo on Linux Rust jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -575,7 +575,23 @@ jobs:
     # run it post-merge or manually when the native smoke signal is needed.
     if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-22.04
+    env:
+      # Shrink test-profile debuginfo to stay under the runner disk ceiling.
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
+      - name: Reclaim runner disk
+        shell: bash
+        run: |
+          echo "Disk before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+          echo "Disk after cleanup:"
+          df -h
+
       - uses: actions/checkout@v6
         with:
           lfs: true
@@ -686,6 +702,19 @@ jobs:
       )
     runs-on: ubuntu-24.04
     steps:
+      - name: Reclaim runner disk
+        shell: bash
+        run: |
+          echo "Disk before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+          echo "Disk after cleanup:"
+          df -h
+
       - uses: actions/checkout@v6
         with:
           lfs: true
@@ -726,7 +755,23 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'ci:rust')
       )
     runs-on: ubuntu-24.04
+    env:
+      # Shrink test-profile debuginfo to stay under the runner disk ceiling.
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
+      - name: Reclaim runner disk
+        shell: bash
+        run: |
+          echo "Disk before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+          echo "Disk after cleanup:"
+          df -h
+
       - uses: actions/checkout@v6
         with:
           lfs: true
@@ -768,6 +813,19 @@ jobs:
       )
     runs-on: ubuntu-24.04
     steps:
+      - name: Reclaim runner disk
+        shell: bash
+        run: |
+          echo "Disk before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+          echo "Disk after cleanup:"
+          df -h
+
       - uses: actions/checkout@v6
         with:
           lfs: true


### PR DESCRIPTION
Linux Rust jobs keep running out of runner disk. This adds a top-of-job reclaim step to `build-linux`, `linux-rust-clippy`, `linux-rust-tests`, and `linux-runtimed-node` that deletes preinstalled toolchains we never use (Android, .NET, GHC, CodeQL), with `df -h` before and after so the reclaimed headroom is visible in logs. It also sets `CARGO_PROFILE_TEST_DEBUG: "0"` on the two jobs that run `cargo test` (`build-linux`, `linux-rust-tests`) to trim test-profile debuginfo, which is a large share of target-dir growth.

Design decision: debuginfo trimming is scoped to the test profile and only on jobs that compile tests. Release artifacts are untouched, so shipped binaries and symbolication are unaffected; the only cost is worse backtraces in CI test failures, which we can revisit if it bites.

Implemented by Codex; reviewed by an opposing Claude pass (verdict: pass, no blocking findings). YAML validated, `actionlint` clean.

Closes #3981.
