### PR TITLE
fix(cloud): align workstation registration values

### DIFF
--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1039,7 +1039,7 @@ export async function registerWorkstation(
        created_at,
        updated_at,
        last_seen_at
-     ) VALUES (?, ?, ?, ?, ?, 'online', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ) VALUES (?, ?, ?, ?, ?, 'online', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(owner_principal, workstation_id) DO UPDATE SET
        display_name = excluded.display_name,
        provider = excluded.provider,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -9411,6 +9411,9 @@ class FakeD1Statement implements D1PreparedStatement {
 
   async run<T = unknown>(): Promise<D1Result<T>> {
     this.db.executedStatements.push(this.query);
+    if (this.query.includes("INSERT INTO workstations")) {
+      assertInsertValuesArity(this.query, "workstations");
+    }
     const alterMatch = this.query.match(/ALTER TABLE\s+(\w+)\s+ADD COLUMN\s+(\w+)/i);
     if (alterMatch) {
       const [, table, column] = alterMatch;
@@ -10876,6 +10879,27 @@ function scopeRank(scope: NotebookAclRow["scope"]): number {
     case "viewer":
       return 1;
   }
+}
+
+function assertInsertValuesArity(query: string, table: string): void {
+  const normalized = query.replace(/\s+/g, " ");
+  const match = normalized.match(
+    new RegExp(`INSERT INTO ${table}\\s*\\((.*?)\\)\\s*VALUES\\s*\\((.*?)\\)`, "i"),
+  );
+  assert.ok(match, `expected ${table} insert statement`);
+  const [, columnsSql = "", valuesSql = ""] = match;
+  assert.equal(
+    splitSqlList(valuesSql).length,
+    splitSqlList(columnsSql).length,
+    `${table} insert must provide one value expression per column`,
+  );
+}
+
+function splitSqlList(list: string): string[] {
+  return list
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function workstationKey(ownerPrincipal: string, workstationId: string): string {


### PR DESCRIPTION
## Summary
- add the missing value expression in the workstation registration INSERT so D1 receives one value per column
- add a FakeD1 regression guard so the worker route tests catch future insert column/value arity mismatches

## Why
Preview workstation heartbeats were throwing Worker 1101s with `D1_ERROR: 17 values for 18 columns: SQLITE_ERROR` after the workstation build metadata columns landed. The deployed hotfix restored live registration; this gets the fix onto GitHub/main.

## Tests
- `node --import tsx --test test/worker-routes.test.ts --test-name-pattern "Workstation pairing"`
- `cargo xtask lint --fix`