### PR TITLE
fix(settings): font picker UX improvements — alignment, custom mode, fixed height

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -107,36 +107,40 @@ export function FontFamilyPicker({
 }) {
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
+  const customInputRef = useRef<HTMLInputElement>(null);
   const inputId = `editor-${label.toLowerCase().replace(/\s+/g, "-")}`;
   const listId = `${inputId}-list`;
 
-  const options = useMemo(() => {
-    const currentSingleFamily = singleFontFamilyFromCssValue(value);
-    return uniqueSortedFontFamilies([
-      ...fontFamilies,
-      ...(currentSingleFamily ? [currentSingleFamily] : []),
-    ]);
-  }, [fontFamilies, value]);
+  const options = useMemo(
+    () => uniqueSortedFontFamilies([...fontFamilies]),
+    [fontFamilies],
+  );
+
+  const currentSingleFamily = singleFontFamilyFromCssValue(value);
+  const isKnownFont =
+    currentSingleFamily != null &&
+    options.some((f) => f.toLocaleLowerCase() === currentSingleFamily.toLocaleLowerCase());
+
+  const [customMode, setCustomMode] = useState(() => value !== "" && !isKnownFont);
+
+  useEffect(() => {
+    if (customMode) customInputRef.current?.focus();
+  }, [customMode]);
 
   const normalizedSearchValue = searchValue.trim().toLocaleLowerCase();
   const visibleOptions = useMemo(() => {
     if (!normalizedSearchValue) return options;
-    return options.filter((fontFamily) =>
-      fontFamily.toLocaleLowerCase().includes(normalizedSearchValue),
-    );
+    return options.filter((f) => f.toLocaleLowerCase().includes(normalizedSearchValue));
   }, [normalizedSearchValue, options]);
 
-  const currentSingleFamily = singleFontFamilyFromCssValue(value);
-  const exactSearchMatch = options.some(
-    (fontFamily) => fontFamily.toLocaleLowerCase() === normalizedSearchValue,
-  );
-  const customCandidate = searchValue.trim();
-  const showCustomCandidate = customCandidate.length > 0 && !exactSearchMatch;
-  const displayValue = currentSingleFamily || value || placeholder;
+  const displayValue = customMode
+    ? value || "Custom…"
+    : currentSingleFamily || value || placeholder;
 
   const clear = useCallback(() => {
-    if (value !== "") onChange("");
-  }, [onChange, value]);
+    onChange("");
+    setCustomMode(false);
+  }, [onChange]);
 
   const selectValue = useCallback(
     (next: string) => {
@@ -149,10 +153,23 @@ export function FontFamilyPicker({
 
   const selectFontFamily = useCallback(
     (fontFamily: string) => {
+      setCustomMode(false);
       selectValue(fontFamilyNameToCssValue(fontFamily));
     },
     [selectValue],
   );
+
+  const selectDefault = useCallback(() => {
+    setCustomMode(false);
+    selectValue("");
+  }, [selectValue]);
+
+  const selectCustomMode = useCallback(() => {
+    if (!customMode) onChange("");
+    setCustomMode(true);
+    setSearchValue("");
+    setOpen(false);
+  }, [customMode, onChange]);
 
   return (
     <div className="space-y-1.5">
@@ -177,7 +194,7 @@ export function FontFamilyPicker({
                 aria-expanded={open}
                 className={cn(
                   "flex h-8 min-w-0 flex-1 items-center justify-between rounded-md border border-input bg-background px-3 py-1 text-left text-xs shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                  value ? "text-foreground" : "text-muted-foreground",
+                  value || customMode ? "text-foreground" : "text-muted-foreground",
                 )}
               >
                 <span className="min-w-0 truncate font-mono">{displayValue}</span>
@@ -189,13 +206,16 @@ export function FontFamilyPicker({
                 <CommandInput
                   value={searchValue}
                   onValueChange={setSearchValue}
-                  placeholder="Search fonts or enter a CSS stack"
+                  placeholder="Search fonts"
                 />
                 <CommandList className="max-h-72">
                   <CommandGroup>
-                    <CommandItem value="__default__" onSelect={() => selectValue("")}>
+                    <CommandItem value="__default__" onSelect={selectDefault}>
                       <Check
-                        className={cn("size-3.5", value === "" ? "opacity-100" : "opacity-0")}
+                        className={cn(
+                          "size-3.5",
+                          !customMode && value === "" ? "opacity-100" : "opacity-0",
+                        )}
                       />
                       <div className="min-w-0">
                         <div className="truncate text-sm">Theme default</div>
@@ -204,25 +224,22 @@ export function FontFamilyPicker({
                         </div>
                       </div>
                     </CommandItem>
-                    {showCustomCandidate ? (
-                      <CommandItem
-                        value={customCandidate}
-                        onSelect={() => selectValue(customCandidate)}
-                      >
-                        <Check className="size-3.5 opacity-0" />
-                        <div className="min-w-0">
-                          <div className="truncate text-sm">Use custom value</div>
-                          <div className="truncate font-mono text-[10px] text-muted-foreground">
-                            {customCandidate}
-                          </div>
+                    <CommandItem value="__custom__" onSelect={selectCustomMode}>
+                      <Check
+                        className={cn("size-3.5", customMode ? "opacity-100" : "opacity-0")}
+                      />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm">Custom</div>
+                        <div className="truncate text-[10px] text-muted-foreground">
+                          Enter a CSS font stack
                         </div>
-                      </CommandItem>
-                    ) : null}
+                      </div>
+                    </CommandItem>
                   </CommandGroup>
                   {visibleOptions.length > 0 ? (
                     <CommandGroup heading="System fonts">
                       {visibleOptions.map((fontFamily) => {
-                        const selected = currentSingleFamily === fontFamily;
+                        const selected = !customMode && currentSingleFamily === fontFamily;
                         const cssValue = fontFamilyNameToCssValue(fontFamily);
                         return (
                           <CommandItem
@@ -252,14 +269,14 @@ export function FontFamilyPicker({
                         );
                       })}
                     </CommandGroup>
-                  ) : !showCustomCandidate ? (
+                  ) : (
                     <CommandEmpty>No fonts found.</CommandEmpty>
-                  ) : null}
+                  )}
                 </CommandList>
               </Command>
             </PopoverContent>
           </Popover>
-          {value ? (
+          {value || customMode ? (
             <button
               type="button"
               aria-label={`Clear ${label.toLowerCase()}`}
@@ -272,6 +289,18 @@ export function FontFamilyPicker({
           ) : null}
         </div>
       </div>
+      {customMode ? (
+        <div className="pl-[5.5rem]">
+          <input
+            ref={customInputRef}
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder='e.g. Helvetica, Arial, sans-serif'
+            className="w-full h-7 rounded-md border border-input bg-background px-2 font-mono text-xs text-foreground placeholder:text-muted-foreground shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          />
+        </div>
+      ) : null}
       <p className="pl-[5.5rem] text-[10px] text-muted-foreground/70">{description}</p>
     </div>
   );

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -111,10 +111,7 @@ export function FontFamilyPicker({
   const inputId = `editor-${label.toLowerCase().replace(/\s+/g, "-")}`;
   const listId = `${inputId}-list`;
 
-  const options = useMemo(
-    () => uniqueSortedFontFamilies([...fontFamilies]),
-    [fontFamilies],
-  );
+  const options = useMemo(() => uniqueSortedFontFamilies([...fontFamilies]), [fontFamilies]);
 
   const currentSingleFamily = singleFontFamilyFromCssValue(value);
   const isKnownFont =
@@ -133,9 +130,7 @@ export function FontFamilyPicker({
     return options.filter((f) => f.toLocaleLowerCase().includes(normalizedSearchValue));
   }, [normalizedSearchValue, options]);
 
-  const displayValue = customMode
-    ? value || "Custom…"
-    : currentSingleFamily || value || placeholder;
+  const displayValue = customMode ? "Custom…" : currentSingleFamily || value || placeholder;
 
   const clear = useCallback(() => {
     onChange("");
@@ -225,9 +220,7 @@ export function FontFamilyPicker({
                       </div>
                     </CommandItem>
                     <CommandItem value="__custom__" onSelect={selectCustomMode}>
-                      <Check
-                        className={cn("size-3.5", customMode ? "opacity-100" : "opacity-0")}
-                      />
+                      <Check className={cn("size-3.5", customMode ? "opacity-100" : "opacity-0")} />
                       <div className="min-w-0">
                         <div className="truncate text-sm">Custom</div>
                         <div className="truncate text-[10px] text-muted-foreground">
@@ -296,7 +289,7 @@ export function FontFamilyPicker({
             type="text"
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder='e.g. Helvetica, Arial, sans-serif'
+            placeholder="e.g. Helvetica, Arial, sans-serif"
             className="w-full h-7 rounded-md border border-input bg-background px-2 font-mono text-xs text-foreground placeholder:text-muted-foreground shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           />
         </div>

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -174,7 +174,7 @@ export function FontFamilyPicker({
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between gap-3">
-        <label className="text-sm text-muted-foreground" htmlFor={inputId}>
+        <label className="text-sm text-foreground" htmlFor={inputId}>
           {label}
         </label>
         <div className="flex min-w-0 flex-1 items-center gap-1.5">

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -120,10 +120,10 @@ export function FontFamilyPicker({
 
   const normalizedSearchValue = searchValue.trim().toLocaleLowerCase();
   const visibleOptions = useMemo(() => {
-    if (!normalizedSearchValue) return options.slice(0, 200);
-    return options
-      .filter((fontFamily) => fontFamily.toLocaleLowerCase().includes(normalizedSearchValue))
-      .slice(0, 200);
+    if (!normalizedSearchValue) return options;
+    return options.filter((fontFamily) =>
+      fontFamily.toLocaleLowerCase().includes(normalizedSearchValue),
+    );
   }, [normalizedSearchValue, options]);
 
   const currentSingleFamily = singleFontFamilyFromCssValue(value);

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -167,12 +167,12 @@ export function FontFamilyPicker({
   }, [customMode, onChange]);
 
   return (
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between gap-3">
-        <label className="text-sm text-foreground" htmlFor={inputId}>
-          {label}
-        </label>
-        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+    <div className="contents">
+      <label className="text-sm text-foreground self-center" htmlFor={inputId}>
+        {label}
+      </label>
+      <div className="space-y-1.5 min-w-0">
+        <div className="flex min-w-0 items-center gap-1.5">
           <Popover
             open={open}
             onOpenChange={(nextOpen) => {
@@ -281,9 +281,7 @@ export function FontFamilyPicker({
             </button>
           ) : null}
         </div>
-      </div>
-      {customMode ? (
-        <div className="pl-[5.5rem]">
+        {customMode ? (
           <input
             ref={customInputRef}
             type="text"
@@ -292,9 +290,9 @@ export function FontFamilyPicker({
             placeholder="e.g. Helvetica, Arial, sans-serif"
             className="w-full h-7 rounded-md border border-input bg-background px-2 font-mono text-xs text-foreground placeholder:text-muted-foreground shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           />
-        </div>
-      ) : null}
-      <p className="pl-[5.5rem] text-[10px] text-muted-foreground/70">{description}</p>
+        ) : null}
+        <p className="text-[10px] text-muted-foreground/70">{description}</p>
+      </div>
     </div>
   );
 }
@@ -440,22 +438,24 @@ function EditorSection({
       </div>
 
       <div className="space-y-3">
-        <FontFamilyPicker
-          label="Code font"
-          value={codeFontFamily}
-          onChange={onCodeFontFamilyChange}
-          placeholder='ui-monospace, "SF Mono", monospace'
-          description="Code cells, raw cells, inline code, and code blocks"
-          fontFamilies={fontFamilies}
-        />
-        <FontFamilyPicker
-          label="Markdown font"
-          value={markdownFontFamily}
-          onChange={onMarkdownFontFamilyChange}
-          placeholder="system-ui, sans-serif"
-          description="Rendered Markdown and Markdown input"
-          fontFamilies={fontFamilies}
-        />
+        <div className="grid gap-x-3 gap-y-3" style={{ gridTemplateColumns: "auto 1fr" }}>
+          <FontFamilyPicker
+            label="Code font"
+            value={codeFontFamily}
+            onChange={onCodeFontFamilyChange}
+            placeholder='ui-monospace, "SF Mono", monospace'
+            description="Code cells, raw cells, inline code, and code blocks"
+            fontFamilies={fontFamilies}
+          />
+          <FontFamilyPicker
+            label="Markdown font"
+            value={markdownFontFamily}
+            onChange={onMarkdownFontFamilyChange}
+            placeholder="system-ui, sans-serif"
+            description="Rendered Markdown and Markdown input"
+            fontFamilies={fontFamilies}
+          />
+        </div>
         <div className="flex items-center justify-between gap-3">
           <div className="space-y-0.5">
             <span className="text-sm text-foreground">Line numbers</span>

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -168,7 +168,9 @@ export function FontFamilyPicker({
 
   return (
     <div className="contents">
-      <span className="text-sm text-muted-foreground whitespace-nowrap self-center">{label}</span>
+      <span className="text-sm text-muted-foreground whitespace-nowrap self-start pt-1.5">
+        {label}
+      </span>
       <div className="space-y-1.5 min-w-0">
         <div className="flex min-w-0 items-center gap-1.5">
           <Popover

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -168,7 +168,7 @@ export function FontFamilyPicker({
 
   return (
     <div className="contents">
-      <span className="text-sm text-muted-foreground whitespace-nowrap self-start pt-1.5">
+      <span className="text-sm text-muted-foreground whitespace-nowrap self-start pt-1.5 text-right">
         {label}
       </span>
       <div className="space-y-1.5 min-w-0">

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -203,7 +203,7 @@ export function FontFamilyPicker({
                   onValueChange={setSearchValue}
                   placeholder="Search fonts"
                 />
-                <CommandList className="max-h-72">
+                <CommandList className="h-72 max-h-72">
                   <CommandGroup>
                     <CommandItem value="__default__" onSelect={selectDefault}>
                       <Check

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -185,6 +185,7 @@ export function FontFamilyPicker({
                 id={inputId}
                 type="button"
                 role="combobox"
+                aria-label={label}
                 aria-controls={listId}
                 aria-expanded={open}
                 className={cn(
@@ -262,7 +263,7 @@ export function FontFamilyPicker({
                         );
                       })}
                     </CommandGroup>
-                  ) : (
+                  ) : searchValue.trim() ? null : (
                     <CommandEmpty>No fonts found.</CommandEmpty>
                   )}
                 </CommandList>

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -192,7 +192,7 @@ export function FontFamilyPicker({
                   placeholder="Search fonts or enter a CSS stack"
                 />
                 <CommandList className="max-h-72">
-                  <CommandGroup heading="Fonts">
+                  <CommandGroup>
                     <CommandItem value="__default__" onSelect={() => selectValue("")}>
                       <Check
                         className={cn("size-3.5", value === "" ? "opacity-100" : "opacity-0")}
@@ -204,36 +204,6 @@ export function FontFamilyPicker({
                         </div>
                       </div>
                     </CommandItem>
-                    {visibleOptions.map((fontFamily) => {
-                      const selected = currentSingleFamily === fontFamily;
-                      const cssValue = fontFamilyNameToCssValue(fontFamily);
-                      return (
-                        <CommandItem
-                          key={fontFamily}
-                          value={fontFamily}
-                          onSelect={() => selectFontFamily(fontFamily)}
-                          className="items-start"
-                        >
-                          <Check
-                            className={cn(
-                              "mt-0.5 size-3.5",
-                              selected ? "opacity-100" : "opacity-0",
-                            )}
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-sm" style={{ fontFamily: cssValue }}>
-                              {fontFamily}
-                            </div>
-                            <div
-                              className="truncate text-[11px] text-muted-foreground"
-                              style={{ fontFamily: cssValue }}
-                            >
-                              Aa The quick brown fox 0123
-                            </div>
-                          </div>
-                        </CommandItem>
-                      );
-                    })}
                     {showCustomCandidate ? (
                       <CommandItem
                         value={customCandidate}
@@ -249,7 +219,40 @@ export function FontFamilyPicker({
                       </CommandItem>
                     ) : null}
                   </CommandGroup>
-                  {visibleOptions.length === 0 && !showCustomCandidate ? (
+                  {visibleOptions.length > 0 ? (
+                    <CommandGroup heading="Fonts">
+                      {visibleOptions.map((fontFamily) => {
+                        const selected = currentSingleFamily === fontFamily;
+                        const cssValue = fontFamilyNameToCssValue(fontFamily);
+                        return (
+                          <CommandItem
+                            key={fontFamily}
+                            value={fontFamily}
+                            onSelect={() => selectFontFamily(fontFamily)}
+                            className="items-start"
+                          >
+                            <Check
+                              className={cn(
+                                "mt-0.5 size-3.5",
+                                selected ? "opacity-100" : "opacity-0",
+                              )}
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-sm" style={{ fontFamily: cssValue }}>
+                                {fontFamily}
+                              </div>
+                              <div
+                                className="truncate text-[11px] text-muted-foreground"
+                                style={{ fontFamily: cssValue }}
+                              >
+                                Aa The quick brown fox 0123
+                              </div>
+                            </div>
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  ) : !showCustomCandidate ? (
                     <CommandEmpty>No fonts found.</CommandEmpty>
                   ) : null}
                 </CommandList>

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -168,9 +168,7 @@ export function FontFamilyPicker({
 
   return (
     <div className="contents">
-      <label className="text-sm text-foreground self-center" htmlFor={inputId}>
-        {label}
-      </label>
+      <span className="text-sm text-muted-foreground whitespace-nowrap self-center">{label}</span>
       <div className="space-y-1.5 min-w-0">
         <div className="flex min-w-0 items-center gap-1.5">
           <Popover

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -220,7 +220,7 @@ export function FontFamilyPicker({
                     ) : null}
                   </CommandGroup>
                   {visibleOptions.length > 0 ? (
-                    <CommandGroup heading="Fonts">
+                    <CommandGroup heading="System fonts">
                       {visibleOptions.map((fontFamily) => {
                         const selected = currentSingleFamily === fontFamily;
                         const cssValue = fontFamilyNameToCssValue(fontFamily);

--- a/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
+++ b/apps/notebook/src/__tests__/settings-font-family-picker.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { fontFamilyNameToCssValue, uniqueSortedFontFamilies } from "@nteract/notebook-host";
+import { useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { FontFamilyPicker } from "../../settings/App";
 
@@ -20,16 +21,23 @@ beforeAll(() => {
 });
 
 function renderPicker(value = "", onChange = vi.fn()) {
-  render(
-    <FontFamilyPicker
-      label="Markdown font"
-      value={value}
-      onChange={onChange}
-      placeholder="system-ui, sans-serif"
-      description="Rendered Markdown and Markdown input"
-      fontFamilies={fontFamilies}
-    />,
-  );
+  function Harness() {
+    const [currentValue, setCurrentValue] = useState(value);
+    return (
+      <FontFamilyPicker
+        label="Markdown font"
+        value={currentValue}
+        onChange={(next) => {
+          onChange(next);
+          setCurrentValue(next);
+        }}
+        placeholder="system-ui, sans-serif"
+        description="Rendered Markdown and Markdown input"
+        fontFamilies={fontFamilies}
+      />
+    );
+  }
+  render(<Harness />);
   return { onChange };
 }
 
@@ -39,7 +47,7 @@ describe("FontFamilyPicker", () => {
     const { onChange } = renderPicker();
 
     await user.click(screen.getByRole("combobox", { name: "Markdown font" }));
-    await user.type(screen.getByPlaceholderText("Search fonts or enter a CSS stack"), "frau");
+    await user.type(screen.getByPlaceholderText("Search fonts"), "frau");
     await user.click(screen.getByText("Fraunces"));
 
     expect(onChange).toHaveBeenCalledWith("Fraunces");
@@ -50,24 +58,26 @@ describe("FontFamilyPicker", () => {
     const { onChange } = renderPicker();
 
     await user.click(screen.getByRole("combobox", { name: "Markdown font" }));
-    await user.type(screen.getByPlaceholderText("Search fonts or enter a CSS stack"), "sf mono");
+    await user.type(screen.getByPlaceholderText("Search fonts"), "sf mono");
     await user.click(screen.getByText("SF Mono"));
 
     expect(onChange).toHaveBeenCalledWith('"SF Mono"');
   });
 
-  it("allows a custom CSS font stack", async () => {
+  it("allows a custom CSS font stack via Custom mode", async () => {
     const user = userEvent.setup();
     const { onChange } = renderPicker();
 
     await user.click(screen.getByRole("combobox", { name: "Markdown font" }));
+    await user.type(screen.getByPlaceholderText("Search fonts"), "Fraunces, Georgia, serif");
+    expect(screen.queryByText("Use custom value")).not.toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText("Search fonts"));
+    await user.click(screen.getByText("Custom"));
     await user.type(
-      screen.getByPlaceholderText("Search fonts or enter a CSS stack"),
+      screen.getByPlaceholderText("e.g. Helvetica, Arial, sans-serif"),
       "Fraunces, Georgia, serif",
     );
-    const option = screen.getByText("Use custom value").closest("[cmdk-item]");
-    expect(option).not.toBeNull();
-    await user.click(within(option!).getByText("Use custom value"));
 
     expect(onChange).toHaveBeenCalledWith("Fraunces, Georgia, serif");
   });

--- a/packages/notebook-host/src/font-families.ts
+++ b/packages/notebook-host/src/font-families.ts
@@ -32,7 +32,9 @@ export function uniqueSortedFontFamilies(fontFamilies: readonly string[]): strin
   const byKey = new Map<string, string>();
   for (const fontFamily of fontFamilies) {
     const trimmed = fontFamily.trim();
-    if (!trimmed || trimmed.startsWith(".") || /[^\x00-\x7F]/.test(trimmed)) continue;
+    if (!trimmed) continue;
+    if (trimmed.startsWith(".")) continue;
+    if (/[^\u0020-\u024F]/.test(trimmed)) continue;
     if (/^Noto (?:Sans|Serif|Mono) \S/.test(trimmed)) continue;
     const key = trimmed.toLocaleLowerCase();
     if (!byKey.has(key)) byKey.set(key, trimmed);

--- a/packages/notebook-host/src/font-families.ts
+++ b/packages/notebook-host/src/font-families.ts
@@ -33,6 +33,7 @@ export function uniqueSortedFontFamilies(fontFamilies: readonly string[]): strin
   for (const fontFamily of fontFamilies) {
     const trimmed = fontFamily.trim();
     if (!trimmed || trimmed.startsWith(".") || /[^\x00-\x7F]/.test(trimmed)) continue;
+    if (/^Noto (?:Sans|Serif|Mono) \S/.test(trimmed)) continue;
     const key = trimmed.toLocaleLowerCase();
     if (!byKey.has(key)) byKey.set(key, trimmed);
   }

--- a/packages/notebook-host/src/font-families.ts
+++ b/packages/notebook-host/src/font-families.ts
@@ -32,7 +32,7 @@ export function uniqueSortedFontFamilies(fontFamilies: readonly string[]): strin
   const byKey = new Map<string, string>();
   for (const fontFamily of fontFamilies) {
     const trimmed = fontFamily.trim();
-    if (!trimmed || trimmed.startsWith(".")) continue;
+    if (!trimmed || trimmed.startsWith(".") || /[^\x00-\x7F]/.test(trimmed)) continue;
     const key = trimmed.toLocaleLowerCase();
     if (!byKey.has(key)) byKey.set(key, trimmed);
   }

--- a/packages/notebook-host/src/font-families.ts
+++ b/packages/notebook-host/src/font-families.ts
@@ -32,6 +32,20 @@ export function uniqueSortedFontFamilies(fontFamilies: readonly string[]): strin
   const byKey = new Map<string, string>();
   for (const fontFamily of fontFamilies) {
     const trimmed = fontFamily.trim();
+    // The system font list contains a lot of noise. We reduce it three primary ways,
+    // and may add more filters here as new noise sources are identified:
+    //
+    // - Dot-prefix fonts: skip names starting with "." (e.g. ".SF NS Text"),
+    //   which are private macOS system internals not meant for user selection.
+    //
+    // - Non-Latin names: skip names containing characters outside U+0020–U+024F
+    //   (ASCII plus diacritic Latin like "Naïve"). Fonts named in Arabic, Thai,
+    //   CJK, Indic, etc. are hard for most users to identify in a picker UI.
+    //
+    // - Noto script-variant fonts: skip "Noto Sans <Script>", "Noto Serif <Script>",
+    //   and "Noto Mono <Script>" (e.g. "Noto Sans Arabic"). These are Google's
+    //   per-script coverage fonts and flood the list with dozens of near-identical
+    //   entries. The base "Noto Sans", "Noto Serif", and "Noto Mono" are kept.
     if (!trimmed) continue;
     if (trimmed.startsWith(".")) continue;
     if (/[^\u0020-\u024F]/.test(trimmed)) continue;

--- a/packages/notebook-host/src/font-families.ts
+++ b/packages/notebook-host/src/font-families.ts
@@ -32,7 +32,7 @@ export function uniqueSortedFontFamilies(fontFamilies: readonly string[]): strin
   const byKey = new Map<string, string>();
   for (const fontFamily of fontFamilies) {
     const trimmed = fontFamily.trim();
-    if (!trimmed) continue;
+    if (!trimmed || trimmed.startsWith(".")) continue;
     const key = trimmed.toLocaleLowerCase();
     if (!byKey.has(key)) byKey.set(key, trimmed);
   }

--- a/src/components/editor/__tests__/editor-settings-store.test.ts
+++ b/src/components/editor/__tests__/editor-settings-store.test.ts
@@ -19,10 +19,24 @@ describe("editor-settings-store", () => {
         line_numbers: true,
       }),
     ).toEqual({
-      codeFontFamily: '"Hack", monospace',
+      codeFontFamily: ' "Hack", monospace',
       markdownFontFamily: "Georgia, serif",
       lineNumbers: true,
     });
+  });
+
+  it("preserves spaces while typing a custom font stack", () => {
+    setNotebookEditorSettings({ codeFontFamily: "Fraunces, " });
+    expect(setNotebookEditorSettings({ codeFontFamily: "Fraunces, " }).codeFontFamily).toBe(
+      "Fraunces, ",
+    );
+    expect(
+      setNotebookEditorSettings({ codeFontFamily: "Fraunces, Georgia, serif" }).codeFontFamily,
+    ).toBe("Fraunces, Georgia, serif");
+  });
+
+  it("treats whitespace-only font families as empty", () => {
+    expect(setNotebookEditorSettings({ codeFontFamily: "   " }).codeFontFamily).toBe("");
   });
 
   it("applies font settings as notebook typography variables", () => {

--- a/src/components/editor/editor-settings-store.ts
+++ b/src/components/editor/editor-settings-store.ts
@@ -32,7 +32,10 @@ function normalizeFontFamily(value: unknown, fallback = ""): string {
     })
     .join("");
   const [firstDeclaration] = withoutControlChars.split(/[;{}]/);
-  return (firstDeclaration ?? "").trim().slice(0, MAX_FONT_FAMILY_LENGTH);
+  // Keep internal/trailing spaces so live typing of stacks like "Foo, Bar" works.
+  // Collapse whitespace-only values to empty so clear/default still behaves.
+  const cleaned = (firstDeclaration ?? "").slice(0, MAX_FONT_FAMILY_LENGTH);
+  return cleaned.trim().length === 0 ? "" : cleaned;
 }
 
 function normalizeEditorSettings(


### PR DESCRIPTION
## Summary

Less noisy font list - removing "." fonts, non-ascii names, and "Noto" font noise (A Google font):

https://github.com/user-attachments/assets/e41b9108-9523-4a6c-a927-141e80c13778

Better alignment
<img width="690" height="323" alt="Screenshot 2026-07-09 at 5 02 43 PM" src="https://github.com/user-attachments/assets/335add32-4d0d-4040-8487-080b2af59d47" />

Font grouping
<img width="684" height="550" alt="Screenshot 2026-07-09 at 5 02 48 PM" src="https://github.com/user-attachments/assets/8d5eeae0-4612-4173-8f58-057adafe9c2a" />

Better custom font UX - instead of typing into the combo-box, we show a separate text field:
<img width="640" height="256" alt="Screenshot 2026-07-09 at 5 03 03 PM" src="https://github.com/user-attachments/assets/43c0a3be-f346-46cc-a46a-deb89dc84520" />

Prevent layout from jumping

https://github.com/user-attachments/assets/2c3eea7b-4990-437a-919c-50aa54a1eea8

- Removes the font list cap that was cutting off fonts past \"L\".
- Filters dot-prefixed private system fonts, non-ASCII-named fonts, and Noto script-variant fonts (e.g. `Noto Sans Psalter Pahlavi`) from the font picker — keeping only `Noto Sans`, `Noto Serif`, and `Noto Mono`.
- Renames the fonts group heading to \"System fonts\" and moves the theme default/custom value above it.
- Replaces the inline custom font entry with an explicit \"Custom\" mode: selecting it shows a free-text CSS font stack input below the dropdown; the trigger always shows \"Custom…\" while in custom mode, regardless of what is typed.
- Refactors \`FontFamilyPicker\` to use \`display: contents\` so labels and controls participate in the parent grid, aligning \"Code font\" and \"Markdown font\" labels/controls with each other (matching the Environment/Data Stack layout).
- Labels are now \`<span>\` elements with \`text-sm text-muted-foreground text-right\` styling — clicking them no longer opens the dropdown.
- Locks the dropdown list to a fixed \`h-72\` height so it doesn't shrink as search results narrow.

## Test plan

- [ ] Open Settings → Editor. Verify the font list is complete (fonts past \"L\" appear).
- [ ] Confirm dot-prefixed fonts (e.g. \`.AppleSystemUIFont\`), non-ASCII-named fonts, and \`Noto Sans <Script>\` variants do not appear; \`Noto Sans\`, \`Noto Serif\`, \`Noto Mono\` do appear.
- [ ] Verify \"System fonts\" group heading and that the theme default/custom value appears above it.
- [ ] Verify \"Code font\" and \"Markdown font\" labels are right-aligned and their controls are left-aligned with each other (matching Environment/Data Stack layout).
- [ ] Confirm clicking a label does not open the dropdown.
- [ ] Select \"Custom\" from the dropdown, type a CSS stack (e.g. \`Georgia, serif\`) — trigger should remain \"Custom…\" and the text input should show the typed value.
- [ ] Verify the dropdown list stays the same height while typing in the search box.
- [ ] Clear button dismisses custom mode and resets the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)