### PR TITLE
docs(adr): refresh workstation and publish status

### DIFF
--- a/docs/adr/identity-and-trust.md
+++ b/docs/adr/identity-and-trust.md
@@ -475,7 +475,8 @@ be carried across publish if every change is signed by its claimed author.
 
 - **Publish-time re-authoring:** Implement the fresh-document flow in
   `runt-publish` before relying on cross-space attribution closure (see threat
-  table row).
+  table row). Tracked as implementation and security work in
+  [#3900](https://github.com/nteract/nteract/issues/3900).
 
 ## Limitations
 
@@ -513,7 +514,7 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 6. **`runtime_peer` connection topology.** The hosted prototype now supports direct `runtime_peer` `RuntimeStateDoc` ingress into the room. Still open: whether the production kernel sidecar connects to the room directly with its own `runtime_peer` scope credential, or whether a separate runtime-coordination protocol relays writes. Tied to the future remote-runtime work.
 7. **Deployment topology.** How clients reach rooms (browser-direct WebSocket, local-daemon proxy, native client), where kernels run, TLS/CORS, credential keyring placement. Drafted in `docs/adr/deployment-topology.md`.
 8. **ACL mechanics beyond the Cloudflare v1 shape.** The hosted prototype covers flat D1 rows, public-read rows, and owner-only row mutation. Still open: owner transfer UX, group/org expansion, inherited ACLs, audit event retention, Zanzibar/Authzed-style evaluation, and product policy for anonymous public presence.
-9. **Signed-change authorship across publish.** When Automerge gains signed changes (keyhive direction), publish flows could carry historical authorship across identity spaces with cryptographic verification. Until then, publish produces a fresh document in the destination space (see Decision 6).
+9. **Signed-change authorship across publish.** When Automerge gains signed changes (keyhive direction), publish flows could carry historical authorship across identity spaces with cryptographic verification. This remains a possible future alternative. Current publish behavior and the accepted fresh-document target are recorded separately in Decision 6.
 10. **Bearer-token replay mitigation.** DPoP / proof-of-possession tokens, mTLS for system-to-system, short token lifetimes. v1 inherits the bearer-token threat model; tightening it is future work.
 11. **Lower-cost actor-label validator.** Replace the v1 clone-preview validator with parsing of `automerge::sync::Message.changes` chunks (V1 and V2) before merge to reject changes whose actor's principal doesn't match the connection's authenticated principal. Deferred until we land a patch on our Automerge fork as part of the room-host crate extraction. Drafted in `docs/memos/automerge-fork-patches.md`. Pairs with the filters work above for full attribution integrity once both are in.
 
@@ -542,7 +543,10 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 - Anaconda validates, returns principal `user:anaconda:550e...` (same as quill), scope `editor` (as the ACL permits).
 - Claude's actor is `user:anaconda:550e.../agent:claude:s1`. Same principal as quill's desktop session, different operator. Attribution shows both clearly; the trust gate sees them as the same principal and authorizes both.
 
-### Publishing a local notebook to Anaconda
+### Target: publishing a local notebook to Anaconda
+
+Current publish still uploads the source Automerge document bytes. The target
+flow is:
 
 - quill triggers "publish to Anaconda" from desktop.
 - Desktop captures the current rendered state of the local `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc`: cells, metadata, outputs, widget state, blob references.

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -1,7 +1,9 @@
 # Remote Workstation Doc Agents
 
-**Status:** In progress, 2026-06-04. Core CRDT and validator paths landed;
-workstation UI and lifecycle surfaces remain open. Trimmed 2026-06-29.
+**Status:** Accepted, 2026-07-10. The provider-neutral registration and
+room-scoped `runtime_peer` foundation tracked in
+[#3381](https://github.com/nteract/nteract/issues/3381) is shipped; focused
+follow-ups remain.
 
 This ADR records the hosted workstation architecture. Earlier API sketches,
 prototype UI notes, and landed implementation ledgers were removed to keep the
@@ -99,15 +101,19 @@ models must stay distinct.
 
 ## Current Implementation Shape
 
-The current hosted path has:
+The core objective in
+[#3381](https://github.com/nteract/nteract/issues/3381) is present on `main`:
+provider-neutral workstation records, pairing and registration, attach jobs, a
+Rust workstation connector, and per-job cloud runtime agents that join selected
+rooms with explicit `runtime_peer` authority. Runtime session ids are projected
+through `RuntimeStateDoc.workstation`; the room host fences stale peers and
+retains authority over execution intent and accepted runtime/output state.
 
-- D1-backed workstation registration, defaults, and attach-job records;
-- a Rust `runtimed workstation-agent` connector;
-- hosted attach-job APIs and event/poll wakeups;
-- `runtimed cloud-runtime-agent` spawned per accepted job;
-- runtime session ids mirrored into `RuntimeStateDoc.workstation`;
-- room-host fencing for stale runtime peers;
-- owner-authorized execution and runtime-agent command forwarding.
+Liveness and idle handling, version reporting, structured CPU, memory, and
+accelerator capability projection, and owner-authorized execution and runtime
+command forwarding are also shipped. These establish the shared control-plane
+foundation without making provider setup, credentials, environments, or update
+lifecycle part of the room protocol.
 
 Implementation details live in source and tests, especially the hosted cloud
 app, `notebook-cloud-transport`, `runtime-doc`, `runtimed-wasm`, and
@@ -115,9 +121,21 @@ app, `notebook-cloud-transport`, `runtime-doc`, `runtimed-wasm`, and
 
 ## Open Boundaries
 
-- Provider-specific packaging and install flows should stay outside the room
-  protocol.
-- Workstation catalogs may feed host-owned rails, but shared notebook components
-  should consume normalized host facts.
+- Notebook-first setup, recovery, compute-source selection, and accelerator UX
+  belong to host-owned notebook chrome; shared notebook components should
+  consume normalized host facts
+  ([#3990](https://github.com/nteract/nteract/issues/3990)).
+- Persistent pairing remains the registration bootstrap. Short-lived,
+  room- and session-scoped attachment credentials are focused security work and
+  do not change room-mediated runtime authority
+  ([#3991](https://github.com/nteract/nteract/issues/3991)).
+- Provider-specific packaging, environment selection, and validation stay
+  outside the room protocol. The Outerbounds current-Python smoke is tracked in
+  [#3992](https://github.com/nteract/nteract/issues/3992); the JupyterHub
+  kernelspec and working-directory adapter remains in
+  [#3608](https://github.com/nteract/nteract/issues/3608).
+- Compatibility notices and safe idle self-update remain connector lifecycle
+  work and must not interrupt active execution
+  ([#3975](https://github.com/nteract/nteract/issues/3975)).
 - Public sharing does not imply compute access.
 - Runtime peer attachment does not imply notebook edit authority.


### PR DESCRIPTION
## Summary

- mark the provider-neutral workstation registration and room-scoped `runtime_peer` foundation as shipped, matching completed issue #3381
- keep the accepted workstation boundaries intact while routing focused product, security, provider, verification, and update work to their current issues
- clarify that publish currently preserves source Automerge history while fresh destination-space re-authoring remains the accepted target tracked by #3900

## Current behavior and target behavior

Current publish uploads the saved source Automerge documents, so source actor history remains in the hosted revision. The target is to create fresh documents in the destination identity space under a verified publisher actor; #3900 remains the implementation and security follow-up.

The provider-neutral workstation control-plane foundation tracked by #3381 is already on `main`. The remaining workstation issues refine setup and recovery UX, attachment credentials, provider smokes and adapters, and update lifecycle without reopening the accepted room/runtime authority model.

## Verification

- `python3 scripts/ci/check-docs-guidance.py docs/adr/identity-and-trust.md docs/adr/remote-workstation-doc-agents.md`
- `cargo xtask lint --fix`

Related to #3381 and #3900.
