### PR TITLE
chore(mcp): refresh generated tool caches

### DIFF
--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -706,5 +706,137 @@
       "type": "object"
     },
     "name": "replace_regex"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "description": "Create a comment thread anchored to a cell or the notebook.",
+    "inputSchema": {
+      "$defs": {
+        "AnchorParam": {
+          "anyOf": [
+            {
+              "properties": {
+                "cell_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cell_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "notebook": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "notebook"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "anchor": {
+          "$ref": "#/$defs/AnchorParam",
+          "description": "Anchor: either { \"cell_id\": \"...\" } for cell comment, or { \"notebook\": true } for notebook comment."
+        },
+        "body": {
+          "description": "Comment text (markdown supported).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "anchor",
+        "body"
+      ],
+      "title": "CreateCommentParams",
+      "type": "object"
+    },
+    "name": "create_comment"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "description": "Reply to an existing comment thread.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "description": "Reply text (markdown supported).",
+          "type": "string"
+        },
+        "thread_id": {
+          "description": "Thread ID to reply to.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "thread_id",
+        "body"
+      ],
+      "title": "ReplyCommentParams",
+      "type": "object"
+    },
+    "name": "reply_comment"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
+    "description": "Mark a comment thread as resolved.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "thread_id": {
+          "description": "Thread ID to resolve.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "thread_id"
+      ],
+      "title": "ResolveCommentParams",
+      "type": "object"
+    },
+    "name": "resolve_comment"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
+    "description": "Reopen a resolved comment thread.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "thread_id": {
+          "description": "Thread ID to reopen.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "thread_id"
+      ],
+      "title": "ReopenCommentParams",
+      "type": "object"
+    },
+    "name": "reopen_comment"
   }
 ]

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -135,6 +135,22 @@
     {
       "description": "Replace a regex match in a cell (fancy-regex). Fails if 0 or >1 matches. Replacement is literal text.",
       "name": "replace_regex"
+    },
+    {
+      "description": "Create a comment thread anchored to a cell or the notebook.",
+      "name": "create_comment"
+    },
+    {
+      "description": "Reply to an existing comment thread.",
+      "name": "reply_comment"
+    },
+    {
+      "description": "Mark a comment thread as resolved.",
+      "name": "resolve_comment"
+    },
+    {
+      "description": "Reopen a resolved comment thread.",
+      "name": "reopen_comment"
     }
   ],
   "tools_generated": false,

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -135,6 +135,22 @@
     {
       "description": "Replace a regex match in a cell (fancy-regex). Fails if 0 or >1 matches. Replacement is literal text.",
       "name": "replace_regex"
+    },
+    {
+      "description": "Create a comment thread anchored to a cell or the notebook.",
+      "name": "create_comment"
+    },
+    {
+      "description": "Reply to an existing comment thread.",
+      "name": "reply_comment"
+    },
+    {
+      "description": "Mark a comment thread as resolved.",
+      "name": "resolve_comment"
+    },
+    {
+      "description": "Reopen a resolved comment thread.",
+      "name": "reopen_comment"
     }
   ],
   "tools_generated": false,


### PR DESCRIPTION
## Summary

- Refresh the generated MCP tool cache for the current 23-tool surface.
- Add the four comment tools to the nightly and stable MCP bundle manifests.

## CI failure

Addresses the stale-cache failure in [Actions run 29121166676](https://github.com/nteract/nteract/actions/runs/29121166676), specifically the [Linux release artifacts job 86456955975](https://github.com/nteract/nteract/actions/runs/29121166676/job/86456955975).

## Generated files

- `crates/runt-mcp-proxy/tool-cache.json`
- `mcpb/manifest.nightly.json`
- `mcpb/manifest.stable.json`

The repository-supported generator adds `create_comment`, `reply_comment`, `resolve_comment`, and `reopen_comment`. No product code or unrelated formatting is included.

## Verification

- `cargo xtask sync-tool-cache --check`
  - Before generation: reproduced all three stale-file reports.
  - After generation and lint: passed with 23 tools and 1,452 of 1,500 description bytes.
- `cargo xtask lint --fix`
- `git diff --check origin/main...HEAD`
- Confirmed the cache and both manifest tool-name projections are identical.
