### PR TITLE
test(ci): fix cross-platform build failures

### DIFF
--- a/crates/runtimed/src/workstation/accelerators.rs
+++ b/crates/runtimed/src/workstation/accelerators.rs
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn detects_usable_nvidia_a100_with_per_device_memory() {
         let temp = tempfile::TempDir::new().unwrap();
-        add_pci_device(temp.path(), "0000:01:00.0", "0x030200", "0x10de");
+        add_pci_device(temp.path(), "0000-01-00.0", "0x030200", "0x10de");
 
         let devices = scan_linux_gpu_devices(temp.path()).unwrap();
         let accelerators = project_linux_accelerators(
@@ -364,8 +364,8 @@ mod tests {
     #[test]
     fn groups_identical_nvidia_gpus() {
         let temp = tempfile::TempDir::new().unwrap();
-        add_pci_device(temp.path(), "0000:01:00.0", "0x030200", "0x10de");
-        add_pci_device(temp.path(), "0000:02:00.0", "0x030200", "0x10de");
+        add_pci_device(temp.path(), "0000-01-00.0", "0x030200", "0x10de");
+        add_pci_device(temp.path(), "0000-02-00.0", "0x030200", "0x10de");
 
         let devices = scan_linux_gpu_devices(temp.path()).unwrap();
         let accelerators = project_linux_accelerators(
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn detected_nvidia_probe_failure_is_not_ready_with_actionable_diagnostic() {
         let temp = tempfile::TempDir::new().unwrap();
-        add_pci_device(temp.path(), "0000:01:00.0", "0x030200", "0x10de");
+        add_pci_device(temp.path(), "0000-01-00.0", "0x030200", "0x10de");
 
         let devices = scan_linux_gpu_devices(temp.path()).unwrap();
         let accelerators = project_linux_accelerators(&devices, NvidiaProbe::Failed);
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn successful_linux_scan_without_gpu_is_known_none() {
         let temp = tempfile::TempDir::new().unwrap();
-        add_pci_device(temp.path(), "0000:00:1f.6", "0x020000", "0x8086");
+        add_pci_device(temp.path(), "0000-00-1f.6", "0x020000", "0x8086");
 
         let devices = scan_linux_gpu_devices(temp.path()).unwrap();
 
@@ -416,7 +416,7 @@ mod tests {
             None
         );
 
-        let unreadable_device = temp.path().join("0000:01:00.0");
+        let unreadable_device = temp.path().join("0000-01-00.0");
         std::fs::create_dir_all(unreadable_device).unwrap();
         assert_eq!(scan_linux_gpu_devices(temp.path()), None);
     }
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn non_nvidia_gpu_stays_structured_with_unknown_readiness() {
         let temp = tempfile::TempDir::new().unwrap();
-        add_pci_device(temp.path(), "0000:03:00.0", "0x030000", "0x1002");
+        add_pci_device(temp.path(), "0000-03-00.0", "0x030000", "0x1002");
 
         let devices = scan_linux_gpu_devices(temp.path()).unwrap();
         let accelerators = project_linux_accelerators(&devices, NvidiaProbe::NotRun);

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2312,7 +2312,7 @@ class TestWidgetRuntimeState:
 
     async def test_private_widget_snapshot_reads_runtime_state_comms(self, session):
         """ipywidgets comm_open state lands in RuntimeStateDoc for Python inspection."""
-        await async_start_kernel_with_retry(session)
+        await async_use_auto_kernel_or_start(session)
 
         cell_id = await session.create_cell(
             "from IPython.display import display\n"


### PR DESCRIPTION
## Summary

- make Linux PCI fixture directory names valid on Windows so accelerator tests exercise the scanner instead of failing during setup
- avoid racing the notebook's auto-launched kernel with a second explicit launch in the widget runtime-state integration test

## Root causes

The latest `main` Build failure ([run 29089224209](https://github.com/nteract/nteract/actions/runs/29089224209)) exposed two independent test issues:

1. Six accelerator tests used Linux PCI BDF strings containing `:` as temporary directory names. Windows rejects those path components before the test logic runs.
2. The widget runtime-state integration test explicitly launched a kernel even though notebook creation already auto-launches one. The duplicate launch request stalled until pytest's 600-second timeout; the test never reached widget execution.

The stale MCP tool-cache failure from the same run was already fixed independently by #3996 and is present on current `main`.

## Verification

- `cargo test -p runtimed --lib workstation::accelerators::tests` — 9 passed
- targeted widget integration test in CI mode — 1 passed in 17.56s
- `cargo xtask sync-tool-cache --check` — 23 tools, caches current
- `cargo xtask lint --fix` — all checks passed
- `git diff --check` — passed
