### PR TITLE
fix(notebook-cloud): route sidecar assets through Workers

### DIFF
--- a/apps/notebook-cloud/src/renderer-assets-worker.ts
+++ b/apps/notebook-cloud/src/renderer-assets-worker.ts
@@ -30,7 +30,12 @@ const rendererAssetsWorker: ExportedHandler<RendererAssetsEnv> = {
 
     const assetUrl = new URL(request.url);
     assetUrl.pathname = assetPathname;
-    const response = await env.ASSETS.fetch(new Request(assetUrl, request));
+    let response: Response;
+    try {
+      response = await env.ASSETS.fetch(new Request(assetUrl, request));
+    } catch {
+      return fallThroughToOrigin(request, json({ error: "renderer assets are unavailable" }, 503));
+    }
     const assetResponse = withRendererAssetCors(new Response(response.body, response), {
       assetPathname,
     });

--- a/apps/notebook-cloud/src/renderer-assets-worker.ts
+++ b/apps/notebook-cloud/src/renderer-assets-worker.ts
@@ -22,13 +22,22 @@ const rendererAssetsWorker: ExportedHandler<RendererAssetsEnv> = {
       return json({ error: "not found" }, 404);
     }
     if (!env.ASSETS) {
-      return json({ error: "renderer assets are not configured" }, 503);
+      return fallThroughToOrigin(
+        request,
+        json({ error: "renderer assets are not configured" }, 503),
+      );
     }
 
     const assetUrl = new URL(request.url);
     assetUrl.pathname = assetPathname;
     const response = await env.ASSETS.fetch(new Request(assetUrl, request));
-    return withRendererAssetCors(new Response(response.body, response), { assetPathname });
+    const assetResponse = withRendererAssetCors(new Response(response.body, response), {
+      assetPathname,
+    });
+    if (response.status >= 400) {
+      return fallThroughToOrigin(request, assetResponse);
+    }
+    return assetResponse;
   },
 };
 
@@ -57,6 +66,19 @@ function rendererAssetPathname(rawName: string): string | null {
   }
 
   return `/${name}`;
+}
+
+async function fallThroughToOrigin(request: Request, fallback: Response): Promise<Response> {
+  try {
+    // A path Route can continue to the Worker on the matching Custom Domain by
+    // fetching the untouched incoming request. Keep the main Worker's bundled
+    // renderer assets available while the two Workers roll out independently.
+    return await fetch(request);
+  } catch {
+    // Standalone workers.dev and local deployments have no downstream Custom
+    // Domain Worker. Preserve the renderer Worker's original error there.
+    return fallback;
+  }
 }
 
 function json(value: unknown, status = 200): Response {

--- a/apps/notebook-cloud/test/deploy-config.test.mjs
+++ b/apps/notebook-cloud/test/deploy-config.test.mjs
@@ -3,6 +3,16 @@ import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 
 const CONFIG_URL = new URL("../wrangler.toml", import.meta.url);
+const ASSET_WORKER_CONFIGS = [
+  {
+    name: "renderer assets Worker",
+    url: new URL("../wrangler.renderer-assets.toml", import.meta.url),
+  },
+  {
+    name: "output document Worker",
+    url: new URL("../wrangler.output-document.toml", import.meta.url),
+  },
+];
 
 async function readVarsBlock() {
   const config = await readFile(CONFIG_URL, "utf8");
@@ -42,5 +52,18 @@ describe("notebook cloud deploy config", () => {
 
     assert.equal(apiKeyUserinfo.origin, oidcIssuer.origin);
     assert.equal(apiKeyUserinfo.pathname, "/api/auth/sessions/whoami");
+  });
+
+  it("runs asset requests through each sidecar Worker before serving static files", async () => {
+    for (const { name, url } of ASSET_WORKER_CONFIGS) {
+      const config = await readFile(url, "utf8");
+      const assetsBlock = config.match(/^\[assets\]\s*$([\s\S]*?)(?=^\[|(?![\s\S]))/m)?.[1] ?? "";
+
+      assert.match(
+        assetsBlock,
+        /^run_worker_first\s*=\s*true\s*$/m,
+        `${name} must run first so its response headers cannot be bypassed`,
+      );
+    }
   });
 });

--- a/apps/notebook-cloud/test/renderer-assets-worker.test.ts
+++ b/apps/notebook-cloud/test/renderer-assets-worker.test.ts
@@ -278,6 +278,44 @@ describe("renderer assets Worker", () => {
     assert.equal(originFetch.mock.callCount(), 1);
   });
 
+  it("falls through when the sidecar assets binding rejects", async (t) => {
+    let originCallCount = 0;
+    const originFetch = t.mock.method(globalThis, "fetch", async () => {
+      originCallCount += 1;
+      if (originCallCount === 1) {
+        return new Response("main-worker-asset", {
+          headers: { "X-Renderer-Asset-Source": "main-worker" },
+        });
+      }
+      throw new Error("no downstream Custom Domain Worker");
+    });
+    const env = fakeEnv({
+      ASSETS: {
+        fetch: async () => {
+          throw new Error("asset binding unavailable");
+        },
+      },
+    });
+
+    const originResponse = await rendererAssetsWorker.fetch(
+      new Request("https://cloud.test/renderer-assets/sift_wasm.wasm"),
+      env,
+      fakeContext(),
+    );
+    const standaloneResponse = await rendererAssetsWorker.fetch(
+      new Request("https://assets.test/renderer-assets/sift_wasm.wasm"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(originResponse.status, 200);
+    assert.equal(originResponse.headers.get("X-Renderer-Asset-Source"), "main-worker");
+    assert.equal(standaloneResponse.status, 503);
+    assert.equal(standaloneResponse.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.deepEqual(await standaloneResponse.json(), { error: "renderer assets are unavailable" });
+    assert.equal(originFetch.mock.callCount(), 2);
+  });
+
   it("keeps cache-validation responses in the sidecar Worker", async (t) => {
     const originFetch = t.mock.method(globalThis, "fetch", async () => {
       throw new Error("origin fallback should not run");

--- a/apps/notebook-cloud/test/renderer-assets-worker.test.ts
+++ b/apps/notebook-cloud/test/renderer-assets-worker.test.ts
@@ -193,6 +193,131 @@ describe("renderer assets Worker", () => {
     assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
     assert.equal(response.headers.get("Content-Type"), "application/wasm");
   });
+
+  it("falls through to the Custom Domain Worker when the sidecar asset is unavailable", async (t) => {
+    const assetRequests: Array<{ method: string; url: string }> = [];
+    const originRequests: Array<{ method: string; url: string; etag: string | null }> = [];
+    const assetStatuses = [404, 503];
+    const originFetch = t.mock.method(
+      globalThis,
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init);
+        originRequests.push({
+          method: request.method,
+          url: request.url,
+          etag: request.headers.get("If-None-Match"),
+        });
+        return new Response("main-worker-asset", {
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "X-Renderer-Asset-Source": "main-worker",
+          },
+        });
+      },
+    );
+
+    for (const status of assetStatuses) {
+      const response = await rendererAssetsWorker.fetch(
+        new Request("https://cloud.test/renderer-assets/sift_wasm.wasm?v=build", {
+          headers: { "If-None-Match": '"previous"' },
+        }),
+        fakeEnv({
+          ASSETS: {
+            fetch: async (request: Request) => {
+              assetRequests.push({ method: request.method, url: request.url });
+              return new Response("sidecar miss", { status });
+            },
+          },
+        }),
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("X-Renderer-Asset-Source"), "main-worker");
+      assert.equal(await response.text(), "main-worker-asset");
+    }
+
+    assert.deepEqual(assetRequests, [
+      { method: "GET", url: "https://cloud.test/sift_wasm.wasm?v=build" },
+      { method: "GET", url: "https://cloud.test/sift_wasm.wasm?v=build" },
+    ]);
+    assert.deepEqual(originRequests, [
+      {
+        method: "GET",
+        url: "https://cloud.test/renderer-assets/sift_wasm.wasm?v=build",
+        etag: '"previous"',
+      },
+      {
+        method: "GET",
+        url: "https://cloud.test/renderer-assets/sift_wasm.wasm?v=build",
+        etag: '"previous"',
+      },
+    ]);
+    assert.equal(originFetch.mock.callCount(), assetStatuses.length);
+  });
+
+  it("falls through when the sidecar assets binding is absent", async (t) => {
+    const originFetch = t.mock.method(
+      globalThis,
+      "fetch",
+      async () =>
+        new Response("main-worker-asset", {
+          headers: { "X-Renderer-Asset-Source": "main-worker" },
+        }),
+    );
+
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://cloud.test/renderer-assets/sift_wasm.wasm"),
+      fakeEnv(),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("X-Renderer-Asset-Source"), "main-worker");
+    assert.equal(originFetch.mock.callCount(), 1);
+  });
+
+  it("keeps cache-validation responses in the sidecar Worker", async (t) => {
+    const originFetch = t.mock.method(globalThis, "fetch", async () => {
+      throw new Error("origin fallback should not run");
+    });
+
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://cloud.test/renderer-assets/sift_wasm.wasm"),
+      fakeEnv({
+        ASSETS: {
+          fetch: async () => new Response(null, { status: 304 }),
+        },
+      }),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 304);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(originFetch.mock.callCount(), 0);
+  });
+
+  it("returns the sidecar error when no downstream origin is available", async (t) => {
+    const originFetch = t.mock.method(globalThis, "fetch", async () => {
+      throw new Error("no downstream Custom Domain Worker");
+    });
+
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://assets.test/renderer-assets/missing.wasm"),
+      fakeEnv({
+        ASSETS: {
+          fetch: async () => new Response("sidecar miss", { status: 404 }),
+        },
+      }),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(await response.text(), "sidecar miss");
+    assert.equal(originFetch.mock.callCount(), 1);
+  });
 });
 
 function fakeEnv(overrides: Partial<Env> = {}): Pick<Env, "ASSETS"> {

--- a/apps/notebook-cloud/wrangler.output-document.toml
+++ b/apps/notebook-cloud/wrangler.output-document.toml
@@ -7,3 +7,4 @@ routes = [{ pattern = "preview.runtusercontent.com", custom_domain = true }]
 [assets]
 directory = "./dist-output-document"
 binding = "ASSETS"
+run_worker_first = true

--- a/apps/notebook-cloud/wrangler.renderer-assets.toml
+++ b/apps/notebook-cloud/wrangler.renderer-assets.toml
@@ -6,6 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 [assets]
 directory = "./dist/plugins"
 binding = "ASSETS"
+run_worker_first = true
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

- run the renderer-assets and isolated output-document Workers before Cloudflare serves their static assets
- preserve the main Custom Domain Worker's bundled renderer assets as a fallback when the renderer sidecar misses or is unavailable
- protect the sidecar routing and origin-fallback contracts with focused deployment and handler tests

## Why

Cloudflare's asset-first routing can serve matching files without invoking the Worker handler. These handlers attach CORS, security, and cache headers while enforcing their route and method boundaries, so requests must enter the Worker first.

The hosted renderer Worker can also run as a path Route in front of the main app's Custom Domain. On an absent binding, a rejected asset lookup, or an asset response with status 400 or higher, it now calls `fetch(request)` with the untouched incoming request. Cloudflare can then continue to the main Worker, retaining the bundled renderer asset during rolling deploys. Successful responses and cache-validation responses such as 304 stay in the renderer Worker. If no downstream origin exists or its subrequest throws, the renderer Worker returns its original CORS-decorated error.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run build:artifacts`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/deploy-config.test.mjs test/renderer-assets-worker.test.ts test/output-document-worker.test.ts`
- `pnpm --dir apps/notebook-cloud exec wrangler deploy -c wrangler.renderer-assets.toml --dry-run`
- `git diff --check origin/main...HEAD`
