### PR TITLE
feat(runtimed): add recovery journal and causal file checkpoint primitives

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -97,6 +97,11 @@
 //!       head_revision: Uint
 //!       checkpoint: Map|null (blob-backed full document checkpoint)
 //!       patch_tail: List[Map] (bounded blob-backed transactions after checkpoint)
+//!   file_checkpoint/       Map (additive; absent in frozen schema v2 genesis)
+//!     exported_heads: List[Str] (NotebookDoc Automerge heads in hex)
+//!     save_sequence: Uint|null  (monotonic committed file replacement sequence)
+//!     source_issue_kind: Str    ("" | "conflict" | "degraded")
+//!     source_issue_reason: Str  (human-readable diagnostic; "" when clear)
 //!   runtime_state_doc_id: Str|null
 //!   last_saved: Str|null   (ISO timestamp of last save)
 //! ```
@@ -409,6 +414,49 @@ pub struct WorkstationAttachmentState {
     pub runtime_session_id: Option<String>,
 }
 
+/// Why the file-backed source cannot currently be treated as healthy.
+///
+/// A conflict means both the journal-backed live document and an externally
+/// changed `.ipynb` must be preserved for explicit reconciliation. Degraded
+/// covers other durability failures where the room remains resident and must
+/// not claim a successful checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FileSourceIssue {
+    Conflict { reason: String },
+    Degraded { reason: String },
+}
+
+impl FileSourceIssue {
+    fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Conflict { .. } => "conflict",
+            Self::Degraded { .. } => "degraded",
+        }
+    }
+
+    fn reason(&self) -> &str {
+        match self {
+            Self::Conflict { reason } | Self::Degraded { reason } => reason,
+        }
+    }
+}
+
+/// Causal file state projected to RuntimeStateDoc readers.
+///
+/// This map is additive and intentionally absent from the frozen v2 genesis.
+/// Missing data therefore reads as no committed checkpoint and no source
+/// issue, keeping older RuntimeStateDoc snapshots backward-compatible.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileCheckpointState {
+    #[serde(default)]
+    pub exported_heads: Vec<String>,
+    #[serde(default)]
+    pub save_sequence: Option<u64>,
+    #[serde(default)]
+    pub source_issue: Option<FileSourceIssue>,
+}
+
 /// Full runtime state snapshot.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeState {
@@ -421,6 +469,10 @@ pub struct RuntimeState {
     pub env: EnvState,
     pub trust: TrustRuntimeState,
     pub last_saved: Option<String>,
+    /// Last causally committed `.ipynb` checkpoint and current source health.
+    /// Missing fields in older RuntimeStateDocs project to the default state.
+    #[serde(default)]
+    pub file_checkpoint: FileCheckpointState,
     /// Path to the notebook's `.ipynb` on the daemon's disk.
     /// `None` for untitled notebooks; daemon writes this on save / save-as.
     pub path: Option<String>,
@@ -2532,6 +2584,118 @@ impl RuntimeStateDoc {
         Ok(())
     }
 
+    /// Read the last causally committed file checkpoint and source health.
+    ///
+    /// Frozen v2 genesis documents and older persisted snapshots do not have
+    /// this additive map, so absence projects to [`FileCheckpointState::default`].
+    pub fn file_checkpoint(&self) -> FileCheckpointState {
+        let Some(checkpoint) = self.get_map("file_checkpoint") else {
+            return FileCheckpointState::default();
+        };
+        let source_issue = match self.read_str(&checkpoint, "source_issue_kind").as_str() {
+            "conflict" => Some(FileSourceIssue::Conflict {
+                reason: self.read_str(&checkpoint, "source_issue_reason"),
+            }),
+            "degraded" => Some(FileSourceIssue::Degraded {
+                reason: self.read_str(&checkpoint, "source_issue_reason"),
+            }),
+            _ => None,
+        };
+        FileCheckpointState {
+            exported_heads: self.read_str_list(&checkpoint, "exported_heads"),
+            save_sequence: self.read_opt_u64(&checkpoint, "save_sequence"),
+            source_issue,
+        }
+    }
+
+    /// Publish a committed `.ipynb` checkpoint at exact NotebookDoc heads.
+    ///
+    /// Callers must invoke this only after durable file replacement succeeds.
+    /// Source health is intentionally left unchanged; reconciliation owns that
+    /// independent axis.
+    pub fn set_file_checkpoint(
+        &mut self,
+        exported_heads: &[String],
+        save_sequence: u64,
+    ) -> Result<bool, RuntimeStateError> {
+        let current = self.file_checkpoint();
+        if current
+            .save_sequence
+            .is_some_and(|current_sequence| current_sequence >= save_sequence)
+        {
+            // Async save completion can arrive after a newer checkpoint has
+            // already committed. RuntimeStateDoc is a causal projection, so a
+            // stale completion must not regress exported heads (or let its
+            // caller regress last_saved metadata).
+            return Ok(false);
+        }
+
+        let checkpoint = self.get_or_create_root_map("file_checkpoint")?;
+        let heads = match self.doc.get(&checkpoint, "exported_heads").ok().flatten() {
+            Some((Value::Object(ObjType::List), heads)) => heads,
+            _ => self
+                .doc
+                .put_object(&checkpoint, "exported_heads", ObjType::List)?,
+        };
+        for index in (0..self.doc.length(&heads)).rev() {
+            self.doc.delete(&heads, index)?;
+        }
+        for (index, head) in exported_heads.iter().enumerate() {
+            self.doc.insert(&heads, index, head.as_str())?;
+        }
+        self.doc.put(
+            &checkpoint,
+            "save_sequence",
+            ScalarValue::Uint(save_sequence),
+        )?;
+        Ok(true)
+    }
+
+    /// Clear committed checkpoint metadata without changing source health.
+    pub fn clear_file_checkpoint(&mut self) -> Result<(), RuntimeStateError> {
+        let current = self.file_checkpoint();
+        if current.exported_heads.is_empty() && current.save_sequence.is_none() {
+            return Ok(());
+        }
+
+        let checkpoint = self.get_or_create_root_map("file_checkpoint")?;
+        if let Some((Value::Object(ObjType::List), heads)) =
+            self.doc.get(&checkpoint, "exported_heads").ok().flatten()
+        {
+            for index in (0..self.doc.length(&heads)).rev() {
+                self.doc.delete(&heads, index)?;
+            }
+        }
+        self.doc
+            .put(&checkpoint, "save_sequence", ScalarValue::Null)?;
+        Ok(())
+    }
+
+    /// Publish or clear a source conflict/degradation diagnostic.
+    pub fn set_file_source_issue(
+        &mut self,
+        issue: Option<&FileSourceIssue>,
+    ) -> Result<(), RuntimeStateError> {
+        if self.file_checkpoint().source_issue.as_ref() == issue {
+            return Ok(());
+        }
+
+        let checkpoint = self.get_or_create_root_map("file_checkpoint")?;
+        match issue {
+            Some(issue) => {
+                self.doc
+                    .put(&checkpoint, "source_issue_kind", issue.kind_str())?;
+                self.doc
+                    .put(&checkpoint, "source_issue_reason", issue.reason())?;
+            }
+            None => {
+                self.doc.put(&checkpoint, "source_issue_kind", "")?;
+                self.doc.put(&checkpoint, "source_issue_reason", "")?;
+            }
+        }
+        Ok(())
+    }
+
     /// Set the `last_saved` timestamp.
     pub fn set_last_saved(&mut self, timestamp: Option<&str>) -> Result<(), RuntimeStateError> {
         self.set_optional_str("last_saved", timestamp)
@@ -3304,6 +3468,7 @@ impl RuntimeStateDoc {
             .unwrap_or_default();
 
         let last_saved = self.read_opt_str(&ROOT, "last_saved");
+        let file_checkpoint = self.file_checkpoint();
         let path = self.read_opt_str(&ROOT, "path");
         let runtime_state_doc_id = self.runtime_state_doc_id();
         let workstation = self.workstation_attachment();
@@ -3333,6 +3498,7 @@ impl RuntimeStateDoc {
             env: env_state,
             trust: trust_state,
             last_saved,
+            file_checkpoint,
             path,
             executions,
             comms,
@@ -4430,6 +4596,106 @@ mod tests {
 
         doc.set_last_saved(None).unwrap();
         assert_eq!(doc.read_state().last_saved, None);
+    }
+
+    #[test]
+    fn file_checkpoint_defaults_for_frozen_v2_genesis() {
+        let doc = RuntimeStateDoc::new();
+
+        assert_eq!(doc.file_checkpoint(), FileCheckpointState::default());
+        assert_eq!(
+            doc.read_state().file_checkpoint,
+            FileCheckpointState::default()
+        );
+        assert!(doc.doc().get(ROOT, "file_checkpoint").unwrap().is_none());
+    }
+
+    #[test]
+    fn file_checkpoint_and_source_issue_round_trip_independently() {
+        let mut doc = RuntimeStateDoc::new();
+        let exported_heads = vec!["aa11".to_string(), "bb22".to_string()];
+
+        doc.set_file_checkpoint(&exported_heads, 7).unwrap();
+        assert_eq!(
+            doc.read_state().file_checkpoint,
+            FileCheckpointState {
+                exported_heads: exported_heads.clone(),
+                save_sequence: Some(7),
+                source_issue: None,
+            }
+        );
+
+        let conflict = FileSourceIssue::Conflict {
+            reason: "disk fingerprint changed while journal heads were unsaved".to_string(),
+        };
+        doc.set_file_source_issue(Some(&conflict)).unwrap();
+        assert_eq!(
+            doc.read_state().file_checkpoint.source_issue,
+            Some(conflict)
+        );
+
+        let degraded = FileSourceIssue::Degraded {
+            reason: "recovery journal flush failed".to_string(),
+        };
+        doc.set_file_source_issue(Some(&degraded)).unwrap();
+        doc.clear_file_checkpoint().unwrap();
+        assert_eq!(
+            doc.read_state().file_checkpoint,
+            FileCheckpointState {
+                exported_heads: Vec::new(),
+                save_sequence: None,
+                source_issue: Some(degraded),
+            }
+        );
+
+        doc.set_file_source_issue(None).unwrap();
+        assert_eq!(
+            doc.read_state().file_checkpoint,
+            FileCheckpointState::default()
+        );
+    }
+
+    #[test]
+    fn file_checkpoint_rejects_stale_async_completion() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(doc
+            .set_file_checkpoint(&["new-head".to_string()], 9)
+            .unwrap());
+        assert!(!doc
+            .set_file_checkpoint(&["old-head".to_string()], 8)
+            .unwrap());
+        assert_eq!(
+            doc.file_checkpoint(),
+            FileCheckpointState {
+                exported_heads: vec!["new-head".to_string()],
+                save_sequence: Some(9),
+                source_issue: None,
+            }
+        );
+    }
+
+    #[test]
+    fn file_checkpoint_serializes_to_the_client_runtime_state_shape() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_file_checkpoint(&["cafebabe".to_string()], 12)
+            .unwrap();
+        doc.set_file_source_issue(Some(&FileSourceIssue::Conflict {
+            reason: "source and journal diverged".to_string(),
+        }))
+        .unwrap();
+
+        let value = serde_json::to_value(doc.read_state()).unwrap();
+        assert_eq!(
+            value.get("file_checkpoint"),
+            Some(&serde_json::json!({
+                "exported_heads": ["cafebabe"],
+                "save_sequence": 12,
+                "source_issue": {
+                    "kind": "conflict",
+                    "reason": "source and journal diverged",
+                },
+            }))
+        );
     }
 
     #[test]

--- a/crates/runtime-doc/src/policy.rs
+++ b/crates/runtime-doc/src/policy.rs
@@ -222,6 +222,13 @@ fn validate_runtime_peer_room_host_owned_delta(
             "room-host/daemon-owned",
         ));
     }
+    if before.state.file_checkpoint != after.state.file_checkpoint {
+        return Err(runtime_state_policy_error(
+            scope,
+            "file_checkpoint",
+            "room-host/daemon-owned",
+        ));
+    }
     if before.state.path != after.state.path {
         return Err(runtime_state_policy_error(
             scope,
@@ -697,8 +704,8 @@ fn runtime_state_policy_error(
 mod tests {
     use super::*;
     use crate::{
-        BokehSessionCheckpoint, BokehSessionPatchRef, KernelActivity, ProjectContext, QueueEntry,
-        RuntimeLifecycle, WorkstationAttachmentState,
+        BokehSessionCheckpoint, BokehSessionPatchRef, FileSourceIssue, KernelActivity,
+        ProjectContext, QueueEntry, RuntimeLifecycle, WorkstationAttachmentState,
     };
     use automerge::transaction::Transactable;
     use serde_json::json;
@@ -1285,6 +1292,32 @@ mod tests {
         assert!(
             err.to_string().contains("workstation"),
             "error should identify workstation writes: {err}"
+        );
+    }
+
+    #[test]
+    fn runtime_peer_policy_rejects_file_checkpoint_changes() {
+        let mut before_doc = RuntimeStateDoc::new();
+        before_doc
+            .set_file_checkpoint(&["head-1".to_string()], 1)
+            .unwrap();
+        let before = runtime_state_policy_snapshot(&before_doc);
+
+        let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
+        after_doc
+            .set_file_source_issue(Some(&FileSourceIssue::Degraded {
+                reason: "forged journal failure".to_string(),
+            }))
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err =
+            validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::RuntimePeer)
+                .unwrap_err();
+
+        assert!(
+            err.to_string().contains("file_checkpoint"),
+            "error should identify daemon-owned file checkpoint writes: {err}"
         );
     }
 

--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -1,0 +1,1950 @@
+//! Room-wide durability coordination for NotebookDoc history.
+//!
+//! One coordinator serializes source, peer, daemon, and file-checkpoint
+//! records for a room. Callers that mutate the live NotebookDoc commit its
+//! resulting snapshot here before releasing the document lock or publishing
+//! an acknowledgement/broadcast. The append-only journal is authoritative;
+//! the watch state makes durable-head barriers and degradation observable.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use automerge::{AutoCommit, Change, ChangeHash};
+use tokio::sync::watch;
+use uuid::Uuid;
+
+use super::recovery::{
+    PendingFileCheckpoint, RecoveredJournalRecord, RecoveryJournal, RecoveryJournalError,
+    RecoveryManifest, RecoverySourcePhase, RecoveryUnavailableReason, SourceFingerprint,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RoomDurabilityStatus {
+    pub(crate) has_durable_record: bool,
+    pub(crate) journal_sequence: u64,
+    pub(crate) durable_heads: Vec<String>,
+    pub(crate) exported_heads: Vec<String>,
+    pub(crate) source_generation: u64,
+    pub(crate) source_phase: RecoverySourcePhase,
+    pub(crate) source_fingerprint: SourceFingerprint,
+    pub(crate) has_peer_changes: bool,
+    pub(crate) degraded_reason: Option<String>,
+}
+
+impl RoomDurabilityStatus {
+    pub(crate) fn is_degraded(&self) -> bool {
+        self.degraded_reason.is_some()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DurableMutation {
+    Source {
+        generation: u64,
+        fingerprint: SourceFingerprint,
+        staged_change_hashes: Vec<[u8; 32]>,
+    },
+    Peer {
+        change_hashes: Vec<[u8; 32]>,
+    },
+    SourceReady {
+        generation: u64,
+    },
+    Daemon,
+    FileCheckpoint {
+        canonical_path: PathBuf,
+        file_fingerprint: SourceFingerprint,
+        exported_heads: Vec<[u8; 32]>,
+        save_sequence: u64,
+        /// Explicit source reconciliation advances the room generation in
+        /// the same journal record as the selected file checkpoint. Ordinary
+        /// saves leave source-task identity unchanged.
+        source_generation: Option<u64>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DurableCommitOutcome {
+    Committed(RoomDurabilityStatus),
+    AlreadyDurable(RoomDurabilityStatus),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ReconciledSourceCommit {
+    pub(crate) status: RoomDurabilityStatus,
+    pub(crate) archived_directory: PathBuf,
+    pub(crate) archive_durability_warning: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RoomDurabilityError {
+    #[error("room recovery journal failed: {0}")]
+    Journal(#[from] RecoveryJournalError),
+    #[error("durable Automerge snapshot is invalid: {0}")]
+    InvalidSnapshot(String),
+    #[error("invalid durable Automerge head {head}: {reason}")]
+    InvalidHead { head: String, reason: String },
+    #[error("timed out waiting for durable Automerge heads")]
+    TimedOut,
+    #[error("room durability is degraded: {0}")]
+    Degraded(String),
+    #[error("room durability commits are frozen for clean shutdown")]
+    ShutdownInProgress,
+    #[error("room journal sequence is exhausted")]
+    SequenceExhausted,
+    #[error("file checkpoint heads are not contained in the durable recovery snapshot")]
+    FileCheckpointHeadsNotDurable,
+    #[error(
+        "external source changed while journal heads were not exported (journal source {journal_source:?}, observed source {observed_source:?})"
+    )]
+    SourceConflict {
+        journal_source: SourceFingerprint,
+        observed_source: SourceFingerprint,
+    },
+    #[error("room does not have an active recovery journal")]
+    JournalUnavailable,
+    #[error("active recovery journal could not be archived: {0:?}")]
+    ArchiveUnavailable(RecoveryUnavailableReason),
+    #[error(
+        "recovery journal was archived at {archive:?}, but the reconciled source record failed: {source}"
+    )]
+    ReconciledSourceAfterArchive {
+        archive: PathBuf,
+        #[source]
+        source: Box<RecoveryJournalError>,
+    },
+}
+
+/// Run one synchronous document serialization/journal boundary without
+/// starving unrelated tasks on runtimed's multi-thread executor.
+///
+/// The operation deliberately stays on the current task so callers can retain
+/// a borrowed NotebookDoc guard across the causal durability boundary. Tokio
+/// replaces the occupied worker while the closure performs blocking disk I/O.
+/// Current-thread test runtimes execute inline because `block_in_place` is not
+/// available there.
+pub(crate) fn run_blocking_durability_boundary<T>(operation: impl FnOnce() -> T) -> T {
+    let multi_thread_runtime = tokio::runtime::Handle::try_current()
+        .map(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+        .unwrap_or(false);
+    if multi_thread_runtime {
+        tokio::task::block_in_place(operation)
+    } else {
+        operation()
+    }
+}
+
+struct DurabilityState {
+    manifest: RecoveryManifest,
+    durable_snapshot: Arc<[u8]>,
+    has_durable_record: bool,
+    degraded_reason: Option<String>,
+}
+
+/// Single serialization point for all durable NotebookDoc history in a room.
+pub(crate) struct RoomDurability {
+    journal: Mutex<Option<RecoveryJournal>>,
+    state: Mutex<DurabilityState>,
+    status_tx: watch::Sender<RoomDurabilityStatus>,
+    accepting_commits: AtomicBool,
+}
+
+impl RoomDurability {
+    /// Create a journal-backed coordinator before source publication.
+    pub(crate) fn journaled(
+        journal: RecoveryJournal,
+        notebook_id: Uuid,
+        canonical_path: Option<PathBuf>,
+        source_fingerprint: SourceFingerprint,
+        source_generation: u64,
+        genesis_snapshot: Vec<u8>,
+    ) -> Self {
+        let manifest = RecoveryManifest::new(
+            0,
+            notebook_id,
+            canonical_path,
+            notebook_doc::SCHEMA_VERSION,
+            source_fingerprint,
+            source_generation,
+        );
+        Self::from_state(Some(journal), manifest, genesis_snapshot, false, None)
+    }
+
+    /// Restore the exact latest complete record selected by recovery scanning.
+    pub(crate) fn recovered(journal: RecoveryJournal, recovered: RecoveredJournalRecord) -> Self {
+        let degraded_reason = recovered
+            .ignored_tail
+            .as_ref()
+            .filter(|tail| !tail.is_repairable_torn_suffix())
+            .map(|tail| format!("recovery journal has preserved corrupt data: {tail:?}"));
+        Self::from_state(
+            Some(journal),
+            recovered.record.manifest,
+            recovered.record.automerge_snapshot,
+            true,
+            degraded_reason,
+        )
+    }
+
+    /// Explicitly ephemeral rooms expose an in-memory satisfied barrier. All
+    /// persistent rooms, including untitled rooms, are journal-backed before
+    /// they can acknowledge changes.
+    pub(crate) fn volatile(notebook_id: Uuid, snapshot: Vec<u8>, heads: Vec<[u8; 32]>) -> Self {
+        let mut manifest = RecoveryManifest::new(
+            0,
+            notebook_id,
+            None,
+            notebook_doc::SCHEMA_VERSION,
+            super::recovery::source_fingerprint(&[]),
+            0,
+        );
+        manifest.durable_heads = heads;
+        Self::from_state(None, manifest, snapshot, true, None)
+    }
+
+    fn from_state(
+        journal: Option<RecoveryJournal>,
+        manifest: RecoveryManifest,
+        durable_snapshot: Vec<u8>,
+        has_durable_record: bool,
+        degraded_reason: Option<String>,
+    ) -> Self {
+        let state = DurabilityState {
+            manifest,
+            durable_snapshot: durable_snapshot.into(),
+            has_durable_record,
+            degraded_reason,
+        };
+        let status = status_from_state(&state);
+        let (status_tx, _) = watch::channel(status);
+        Self {
+            journal: Mutex::new(journal),
+            state: Mutex::new(state),
+            status_tx,
+            accepting_commits: AtomicBool::new(true),
+        }
+    }
+
+    fn ensure_accepting_commits(&self) -> Result<(), RoomDurabilityError> {
+        if self.accepting_commits.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            Err(RoomDurabilityError::ShutdownInProgress)
+        }
+    }
+
+    /// Close the room's journal commit point after a final snapshot was
+    /// committed while holding the live NotebookDoc lock.
+    pub(crate) fn freeze_commits(&self) {
+        self.accepting_commits.store(false, Ordering::Release);
+    }
+
+    pub(crate) fn thaw_commits(&self) {
+        self.accepting_commits.store(true, Ordering::Release);
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, DurabilityState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    pub(crate) fn journal(&self) -> Option<RecoveryJournal> {
+        self.journal
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Durably attach the recovery journal when an untitled room becomes
+    /// file-backed.
+    ///
+    /// The causal file checkpoint is already present in the in-memory
+    /// manifest when this is called. The first journal record therefore binds
+    /// the exact saved heads, file fingerprint, and current recovery union in
+    /// one durable marker before the room starts acknowledging later edits as
+    /// a file-backed session.
+    pub(crate) fn promote_to_journal(
+        &self,
+        journal: RecoveryJournal,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut state = self.lock_state();
+        let mut active = self
+            .journal
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(current) = active.as_ref() {
+            if current.path() == journal.path() {
+                return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                    &state,
+                )));
+            }
+            return Err(RoomDurabilityError::InvalidSnapshot(format!(
+                "room recovery journal is already bound to {}",
+                current.path().display()
+            )));
+        }
+
+        if state.manifest.canonical_path.is_none() || state.manifest.file_save_sequence.is_none() {
+            return Err(RoomDurabilityError::InvalidSnapshot(
+                "a room must have a committed file checkpoint before journal promotion".to_string(),
+            ));
+        }
+        let mut promoted_manifest = state.manifest.clone();
+        if promoted_manifest.source_phase == RecoverySourcePhase::Pending {
+            let mut durable = AutoCommit::load(&state.durable_snapshot)
+                .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+            promoted_manifest.sequence = promoted_manifest
+                .sequence
+                .checked_add(1)
+                .ok_or(RoomDurabilityError::SequenceExhausted)?;
+            promoted_manifest.source_generation = promoted_manifest
+                .source_generation
+                .checked_add(1)
+                .ok_or(RoomDurabilityError::SequenceExhausted)?;
+            promoted_manifest.source_phase = RecoverySourcePhase::Ready;
+            promoted_manifest.staged_change_hashes = durable
+                .get_changes(&[])
+                .iter()
+                .map(|change| change.hash().0)
+                .collect();
+        }
+
+        if let Err(error) = journal.append(&promoted_manifest, &state.durable_snapshot) {
+            let reason = error.to_string();
+            state.degraded_reason = Some(reason.clone());
+            self.status_tx.send_replace(status_from_state(&state));
+            return Err(RoomDurabilityError::Journal(error));
+        }
+        *active = Some(journal);
+        state.manifest = promoted_manifest;
+        state.has_durable_record = true;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    pub(crate) fn status(&self) -> RoomDurabilityStatus {
+        self.status_tx.borrow().clone()
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<RoomDurabilityStatus> {
+        self.status_tx.subscribe()
+    }
+
+    pub(crate) fn durable_snapshot(&self) -> Arc<[u8]> {
+        Arc::clone(&self.lock_state().durable_snapshot)
+    }
+
+    pub(crate) fn manifest(&self) -> RecoveryManifest {
+        self.lock_state().manifest.clone()
+    }
+
+    /// Commit a complete NotebookDoc snapshot and its exact causal heads.
+    ///
+    /// This method is synchronous by design so a caller may hold the live
+    /// document write lock through journal fsync without carrying an async
+    /// mutex guard across `.await`. The room stays unavailable to other
+    /// document readers until the durable marker has landed.
+    pub(crate) fn commit_snapshot(
+        &self,
+        snapshot: &[u8],
+        durable_heads: Vec<[u8; 32]>,
+        mutation: DurableMutation,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut candidate = AutoCommit::load(snapshot)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+
+        let mut state = self.lock_state();
+        let (committed_snapshot, durable_heads) =
+            if state.has_durable_record && matches!(&mutation, DurableMutation::Daemon) {
+                // Reaper and shutdown snapshots are captured before their
+                // blocking journal write. A peer batch may commit in between.
+                // Merge the already-durable union into the candidate so an
+                // older daemon snapshot can never regress acknowledged heads.
+                let mut durable = AutoCommit::load(&state.durable_snapshot)
+                    .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+                let missing = durable
+                    .get_changes(&[])
+                    .into_iter()
+                    .filter(|change| candidate.get_change_by_hash(&change.hash()).is_none())
+                    .collect::<Vec<_>>();
+                candidate
+                    .apply_changes(missing)
+                    .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+                let heads = candidate.get_heads().iter().map(|head| head.0).collect();
+                (candidate.save(), heads)
+            } else {
+                (snapshot.to_vec(), durable_heads)
+            };
+        if state.has_durable_record
+            && state.manifest.durable_heads == durable_heads
+            && mutation_is_already_reflected(&state.manifest, &mutation)
+        {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        }
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        manifest.durable_heads = durable_heads.clone();
+        if matches!(&mutation, DurableMutation::Source { .. }) {
+            // An imported source snapshot is already represented by the exact
+            // bytes on disk, so it is a causal clean baseline even though no
+            // user-initiated save event occurred.
+            manifest.exported_heads = durable_heads;
+            manifest.file_save_sequence = Some(0);
+        }
+        apply_mutation_to_manifest(&mut manifest, mutation);
+
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &committed_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+
+        state.manifest = manifest;
+        state.durable_snapshot = committed_snapshot.into();
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    /// Commit a generation-owned staged source without replacing peer changes
+    /// that were accepted while preparation was in flight.
+    ///
+    /// The source snapshot and peer snapshot are forks of the same canonical
+    /// genesis. Merge the exact staged changes into the current durable union,
+    /// retain peer-authored hashes, and keep `exported_heads` pinned to the
+    /// staged source revision represented by the bytes already on disk.
+    pub(crate) fn commit_staged_source(
+        &self,
+        staged_snapshot: &[u8],
+        staged_heads: Vec<[u8; 32]>,
+        generation: u64,
+        fingerprint: SourceFingerprint,
+        staged_change_hashes: Vec<[u8; 32]>,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let required_heads = staged_heads
+            .iter()
+            .copied()
+            .map(ChangeHash)
+            .collect::<Vec<_>>();
+        let mut staged = AutoCommit::load(staged_snapshot)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        if !required_heads
+            .iter()
+            .all(|head| staged.get_change_by_hash(head).is_some())
+        {
+            return Err(RoomDurabilityError::InvalidSnapshot(
+                "staged source snapshot does not contain its declared heads".to_string(),
+            ));
+        }
+
+        let mutation = DurableMutation::Source {
+            generation,
+            fingerprint,
+            staged_change_hashes,
+        };
+        let mut state = self.lock_state();
+        if state.has_durable_record
+            && mutation_is_already_reflected(&state.manifest, &mutation)
+            && state.manifest.exported_heads == staged_heads
+            && snapshot_contains_heads(&state.durable_snapshot, &required_heads)?
+        {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        }
+
+        let mut durable = AutoCommit::load(&state.durable_snapshot)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let missing = staged
+            .get_changes(&[])
+            .into_iter()
+            .filter(|change| durable.get_change_by_hash(&change.hash()).is_none())
+            .collect::<Vec<_>>();
+        durable
+            .apply_changes(missing)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let durable_heads = durable.get_heads().iter().map(|head| head.0).collect();
+        let durable_snapshot = durable.save();
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        manifest.durable_heads = durable_heads;
+        manifest.exported_heads = staged_heads;
+        manifest.file_save_sequence = Some(0);
+        apply_mutation_to_manifest(&mut manifest, mutation);
+
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &durable_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+
+        state.manifest = manifest;
+        state.durable_snapshot = durable_snapshot.into();
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    /// Mark a durably staged generation fully reconstructed and publishable.
+    ///
+    /// This is a separate journal record from staging so a crash between the
+    /// NotebookDoc commit and runtime-sidecar reconstruction restarts in
+    /// `DurablyStaged` and resumes the same generation instead of reporting a
+    /// false Ready state.
+    pub(crate) fn commit_source_ready(
+        &self,
+        generation: u64,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut state = self.lock_state();
+        if state.manifest.source_generation != generation {
+            return Err(RoomDurabilityError::InvalidSnapshot(format!(
+                "source generation {} cannot complete durable generation {}",
+                generation, state.manifest.source_generation
+            )));
+        }
+        let mutation = DurableMutation::SourceReady { generation };
+        if state.has_durable_record && mutation_is_already_reflected(&state.manifest, &mutation) {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        }
+        if state.manifest.source_phase != RecoverySourcePhase::DurablyStaged {
+            return Err(RoomDurabilityError::InvalidSnapshot(format!(
+                "source generation {generation} is not durably staged"
+            )));
+        }
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        apply_mutation_to_manifest(&mut manifest, mutation);
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+
+        state.manifest = manifest;
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    /// Append a causal file checkpoint without replacing the recovery union.
+    ///
+    /// The durable snapshot may contain peer changes newer than the captured
+    /// heads exported to `.ipynb`. Verify those heads are ancestors of the
+    /// recovery snapshot, then advance only manifest checkpoint metadata.
+    pub(crate) fn prepare_file_checkpoint(
+        &self,
+        canonical_path: PathBuf,
+        file_fingerprint: SourceFingerprint,
+        exported_heads: Vec<[u8; 32]>,
+        save_sequence: u64,
+        source_generation: Option<u64>,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let required_heads = exported_heads
+            .iter()
+            .copied()
+            .map(ChangeHash)
+            .collect::<Vec<_>>();
+        let mut state = self.lock_state();
+        if !snapshot_contains_heads(&state.durable_snapshot, &required_heads)? {
+            return Err(RoomDurabilityError::FileCheckpointHeadsNotDurable);
+        }
+        let pending = PendingFileCheckpoint {
+            canonical_path,
+            file_fingerprint,
+            exported_heads,
+            save_sequence,
+            source_generation,
+        };
+        if state.manifest.pending_file_checkpoint.as_ref() == Some(&pending) {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        }
+        if let Some(existing) = &state.manifest.pending_file_checkpoint {
+            return Err(RoomDurabilityError::InvalidSnapshot(format!(
+                "file checkpoint {} is still pending before sequence {} can prepare",
+                existing.save_sequence, save_sequence
+            )));
+        }
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        manifest.pending_file_checkpoint = Some(pending);
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+        state.manifest = manifest;
+        state.has_durable_record = true;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    /// Clear a prepared checkpoint after atomic replacement definitively did
+    /// not occur. A crash before this marker is harmless: restart observes
+    /// the old source fingerprint and appends the same abort transition.
+    pub(crate) fn abort_file_checkpoint(
+        &self,
+        save_sequence: u64,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut state = self.lock_state();
+        let Some(pending) = state.manifest.pending_file_checkpoint.as_ref() else {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        };
+        if pending.save_sequence != save_sequence {
+            return Err(RoomDurabilityError::InvalidSnapshot(format!(
+                "cannot abort checkpoint sequence {save_sequence}; sequence {} is pending",
+                pending.save_sequence
+            )));
+        }
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        manifest.pending_file_checkpoint = None;
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+        state.manifest = manifest;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    /// Resolve a checkpoint intent discovered during restart. Disk matching
+    /// the intended bytes proves replacement happened; matching the previous
+    /// source proves it did not. Any third fingerprint remains a real source
+    /// conflict and is never selected silently.
+    pub(crate) fn resolve_recovered_file_checkpoint(
+        &self,
+        current_source_fingerprint: SourceFingerprint,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut state = self.lock_state();
+        let Some(pending) = state.manifest.pending_file_checkpoint.clone() else {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        };
+        let mut manifest = state.manifest.clone();
+        if current_source_fingerprint == pending.file_fingerprint {
+            apply_mutation_to_manifest(
+                &mut manifest,
+                DurableMutation::FileCheckpoint {
+                    canonical_path: pending.canonical_path,
+                    file_fingerprint: pending.file_fingerprint,
+                    exported_heads: pending.exported_heads,
+                    save_sequence: pending.save_sequence,
+                    source_generation: pending.source_generation,
+                },
+            );
+        } else if current_source_fingerprint == manifest.source_fingerprint {
+            manifest.pending_file_checkpoint = None;
+        } else {
+            return Err(RoomDurabilityError::SourceConflict {
+                journal_source: manifest.source_fingerprint,
+                observed_source: current_source_fingerprint,
+            });
+        }
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+        state.manifest = manifest;
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    pub(crate) fn commit_file_checkpoint(
+        &self,
+        canonical_path: PathBuf,
+        file_fingerprint: SourceFingerprint,
+        exported_heads: Vec<[u8; 32]>,
+        save_sequence: u64,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.commit_file_checkpoint_with_generation(
+            canonical_path,
+            file_fingerprint,
+            exported_heads,
+            save_sequence,
+            None,
+        )
+    }
+
+    /// Commit the file checkpoint selected by an explicit source
+    /// reconciliation and advance its generation atomically in the same
+    /// journal record. The caller restores interactive capabilities only
+    /// after this returns successfully.
+    pub(crate) fn commit_reconciled_file_checkpoint(
+        &self,
+        canonical_path: PathBuf,
+        file_fingerprint: SourceFingerprint,
+        exported_heads: Vec<[u8; 32]>,
+        save_sequence: u64,
+        source_generation: u64,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.commit_file_checkpoint_with_generation(
+            canonical_path,
+            file_fingerprint,
+            exported_heads,
+            save_sequence,
+            Some(source_generation),
+        )
+    }
+
+    fn commit_file_checkpoint_with_generation(
+        &self,
+        canonical_path: PathBuf,
+        file_fingerprint: SourceFingerprint,
+        exported_heads: Vec<[u8; 32]>,
+        save_sequence: u64,
+        source_generation: Option<u64>,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let required_heads = exported_heads
+            .iter()
+            .copied()
+            .map(ChangeHash)
+            .collect::<Vec<_>>();
+        let mut state = self.lock_state();
+        if !snapshot_contains_heads(&state.durable_snapshot, &required_heads)? {
+            return Err(RoomDurabilityError::FileCheckpointHeadsNotDurable);
+        }
+
+        let expected_pending = PendingFileCheckpoint {
+            canonical_path: canonical_path.clone(),
+            file_fingerprint,
+            exported_heads: exported_heads.clone(),
+            save_sequence,
+            source_generation,
+        };
+        let mutation = DurableMutation::FileCheckpoint {
+            canonical_path,
+            file_fingerprint,
+            exported_heads,
+            save_sequence,
+            source_generation,
+        };
+        if let Some(pending) = &state.manifest.pending_file_checkpoint {
+            if pending != &expected_pending {
+                return Err(RoomDurabilityError::InvalidSnapshot(format!(
+                    "file checkpoint sequence {save_sequence} does not match prepared intent {}",
+                    pending.save_sequence
+                )));
+            }
+        }
+        if state.has_durable_record && mutation_is_already_reflected(&state.manifest, &mutation) {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        }
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        apply_mutation_to_manifest(&mut manifest, mutation);
+
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+
+        state.manifest = manifest;
+        state.has_durable_record = true;
+        // A file checkpoint does not reconcile a pre-existing source conflict
+        // or journal degradation. Explicit reconciliation owns that transition.
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    /// Retire the active recovery history and commit a deliberate disk-source
+    /// replacement as the first record in a new active journal.
+    ///
+    /// The supplied snapshot is the live recovered document plus a causal
+    /// delete/recreate change authored by the reconciliation operation. It
+    /// therefore retains knowledge of the archived history for convergence
+    /// with already-connected peers while making the selected disk cells and
+    /// metadata the visible winners. This method owns the durability mutex
+    /// from archive through append so peer/source/checkpoint commits cannot
+    /// land between those two commit points.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn archive_and_commit_reconciled_source(
+        &self,
+        snapshot: &[u8],
+        durable_heads: Vec<[u8; 32]>,
+        canonical_path: PathBuf,
+        source_fingerprint: SourceFingerprint,
+        source_generation: u64,
+        replacement_change_hashes: Vec<[u8; 32]>,
+        save_sequence: u64,
+    ) -> Result<ReconciledSourceCommit, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut candidate = AutoCommit::load(snapshot)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let mut actual_heads = candidate
+            .get_heads()
+            .iter()
+            .map(|head| head.0)
+            .collect::<Vec<_>>();
+        let mut declared_heads = durable_heads.clone();
+        actual_heads.sort_unstable();
+        declared_heads.sort_unstable();
+        if actual_heads != declared_heads {
+            return Err(RoomDurabilityError::InvalidSnapshot(
+                "reconciled source snapshot heads do not match the declared heads".to_string(),
+            ));
+        }
+
+        let mut state = self.lock_state();
+        let journal = self
+            .journal()
+            .ok_or(RoomDurabilityError::JournalUnavailable)?;
+        let sequence = state
+            .manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        let mut manifest = RecoveryManifest::new(
+            sequence,
+            state.manifest.notebook_id,
+            Some(canonical_path),
+            notebook_doc::SCHEMA_VERSION,
+            source_fingerprint,
+            source_generation,
+        );
+        manifest.source_phase = RecoverySourcePhase::DurablyStaged;
+        manifest.staged_change_hashes = replacement_change_hashes;
+        manifest.durable_heads = durable_heads.clone();
+        manifest.exported_heads = durable_heads;
+        manifest.file_save_sequence = Some(save_sequence);
+
+        let replacement = journal.archive_and_replace(&manifest, snapshot)?;
+
+        state.manifest = manifest;
+        state.durable_snapshot = Arc::from(snapshot);
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(ReconciledSourceCommit {
+            status,
+            archived_directory: replacement.archive.directory,
+            archive_durability_warning: replacement.durability_warning,
+        })
+    }
+
+    /// Merge peer-authored changes into the durable recovery union.
+    ///
+    /// During source publication the live room may intentionally expose only
+    /// a prefix of the staged source history. The durable snapshot already
+    /// contains the complete staged generation, so peer changes are applied
+    /// to that snapshot rather than replacing it with the live prefix. A
+    /// restart can therefore resume the same staged hashes while preserving
+    /// every acknowledged peer change.
+    pub(crate) fn commit_peer_changes(
+        &self,
+        changes: Vec<Change>,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.commit_changes(changes)
+    }
+
+    /// Commit one fully prepared external file revision as a new immutable
+    /// source generation and causal disk checkpoint.
+    ///
+    /// Callers hold the live NotebookDoc lock from authoring through this
+    /// synchronous append. The precondition is checked under the durability
+    /// lock, so peer changes prepared concurrently either land first and force
+    /// a conflict or land afterward and remain causally dirty.
+    pub(crate) fn commit_external_source_revision(
+        &self,
+        changes: Vec<Change>,
+        observed_source: SourceFingerprint,
+        canonical_path: PathBuf,
+        save_sequence: u64,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        let mut state = self.lock_state();
+        if state.has_durable_record
+            && state.manifest.durable_heads != state.manifest.exported_heads
+            && state.manifest.source_fingerprint != observed_source
+        {
+            return Err(RoomDurabilityError::SourceConflict {
+                journal_source: state.manifest.source_fingerprint,
+                observed_source,
+            });
+        }
+
+        let mut durable = AutoCommit::load(&state.durable_snapshot)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let source_hashes = changes
+            .iter()
+            .map(|change| change.hash().0)
+            .collect::<Vec<_>>();
+        let missing = changes
+            .into_iter()
+            .filter(|change| durable.get_change_by_hash(&change.hash()).is_none())
+            .collect::<Vec<_>>();
+        durable
+            .apply_changes(missing)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let durable_heads = durable
+            .get_heads()
+            .iter()
+            .map(|head| head.0)
+            .collect::<Vec<_>>();
+        let snapshot = durable.save();
+        let generation = state
+            .manifest
+            .source_generation
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        manifest.source_generation = generation;
+        manifest.source_phase = RecoverySourcePhase::DurablyStaged;
+        manifest.source_fingerprint = observed_source;
+        manifest.staged_change_hashes = source_hashes;
+        manifest.durable_heads = durable_heads.clone();
+        manifest.exported_heads = durable_heads;
+        manifest.canonical_path = Some(canonical_path);
+        manifest.file_save_sequence = Some(save_sequence);
+
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason.clone());
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+        state.manifest = manifest;
+        state.durable_snapshot = snapshot.into();
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    fn commit_changes(
+        &self,
+        changes: Vec<Change>,
+    ) -> Result<DurableCommitOutcome, RoomDurabilityError> {
+        self.ensure_accepting_commits()?;
+        if changes.is_empty() {
+            return Ok(DurableCommitOutcome::AlreadyDurable(self.status()));
+        }
+
+        let mut state = self.lock_state();
+        let mut durable = AutoCommit::load(&state.durable_snapshot)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let peer_hashes = changes
+            .iter()
+            .map(|change| change.hash().0)
+            .collect::<Vec<_>>();
+        let missing = changes
+            .into_iter()
+            .filter(|change| durable.get_change_by_hash(&change.hash()).is_none())
+            .collect::<Vec<_>>();
+        if missing.is_empty()
+            && peer_hashes
+                .iter()
+                .all(|hash| state.manifest.peer_change_hashes.contains(hash))
+        {
+            return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
+                &state,
+            )));
+        }
+        durable
+            .apply_changes(missing)
+            .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+        let durable_heads = durable.get_heads().iter().map(|head| head.0).collect();
+        let snapshot = durable.save();
+
+        let mut manifest = state.manifest.clone();
+        manifest.sequence = manifest
+            .sequence
+            .checked_add(1)
+            .ok_or(RoomDurabilityError::SequenceExhausted)?;
+        manifest.durable_heads = durable_heads;
+        apply_mutation_to_manifest(
+            &mut manifest,
+            DurableMutation::Peer {
+                change_hashes: peer_hashes,
+            },
+        );
+        if let Some(journal) = self.journal() {
+            if let Err(error) = journal.append(&manifest, &snapshot) {
+                let reason = error.to_string();
+                state.degraded_reason = Some(reason);
+                self.status_tx.send_replace(status_from_state(&state));
+                return Err(RoomDurabilityError::Journal(error));
+            }
+        }
+
+        state.manifest = manifest;
+        state.durable_snapshot = snapshot.into();
+        state.has_durable_record = true;
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        Ok(DurableCommitOutcome::Committed(status))
+    }
+
+    pub(crate) fn mark_degraded(&self, reason: impl Into<String>) -> RoomDurabilityStatus {
+        let mut state = self.lock_state();
+        state.degraded_reason = Some(reason.into());
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        status
+    }
+
+    pub(crate) fn clear_degraded(&self) -> RoomDurabilityStatus {
+        let mut state = self.lock_state();
+        state.degraded_reason = None;
+        let status = status_from_state(&state);
+        self.status_tx.send_replace(status.clone());
+        status
+    }
+
+    /// Wait until the latest durable snapshot contains every required change.
+    /// A degraded journal returns immediately instead of masquerading as a
+    /// timeout, and the wait always has a caller-supplied bound.
+    pub(crate) async fn await_durable(
+        &self,
+        required_heads: &[String],
+        timeout: Duration,
+    ) -> Result<RoomDurabilityStatus, RoomDurabilityError> {
+        let parsed = parse_heads(required_heads)?;
+        let mut receiver = self.subscribe();
+        let wait = async {
+            loop {
+                let status = receiver.borrow().clone();
+                if let Some(reason) = &status.degraded_reason {
+                    return Err(RoomDurabilityError::Degraded(reason.clone()));
+                }
+                let snapshot = self.durable_snapshot();
+                if status.has_durable_record && snapshot_contains_heads(&snapshot, &parsed)? {
+                    return Ok(status);
+                }
+                if receiver.changed().await.is_err() {
+                    let current = self.status();
+                    if let Some(reason) = current.degraded_reason {
+                        return Err(RoomDurabilityError::Degraded(reason));
+                    }
+                    return Err(RoomDurabilityError::TimedOut);
+                }
+            }
+        };
+        tokio::time::timeout(timeout, wait)
+            .await
+            .map_err(|_| RoomDurabilityError::TimedOut)?
+    }
+}
+
+fn status_from_state(state: &DurabilityState) -> RoomDurabilityStatus {
+    RoomDurabilityStatus {
+        has_durable_record: state.has_durable_record,
+        journal_sequence: state.manifest.sequence,
+        durable_heads: state
+            .manifest
+            .durable_heads
+            .iter()
+            .map(hex::encode)
+            .collect(),
+        exported_heads: state
+            .manifest
+            .exported_heads
+            .iter()
+            .map(hex::encode)
+            .collect(),
+        source_generation: state.manifest.source_generation,
+        source_phase: state.manifest.source_phase,
+        source_fingerprint: state.manifest.source_fingerprint,
+        has_peer_changes: !state.manifest.peer_change_hashes.is_empty(),
+        degraded_reason: state.degraded_reason.clone(),
+    }
+}
+
+fn apply_mutation_to_manifest(manifest: &mut RecoveryManifest, mutation: DurableMutation) {
+    match mutation {
+        DurableMutation::Source {
+            generation,
+            fingerprint,
+            staged_change_hashes,
+        } => {
+            manifest.source_generation = generation;
+            manifest.source_fingerprint = fingerprint;
+            manifest.source_phase = RecoverySourcePhase::DurablyStaged;
+            manifest.staged_change_hashes = staged_change_hashes;
+        }
+        DurableMutation::Peer { change_hashes } => {
+            let mut seen = manifest
+                .peer_change_hashes
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>();
+            for hash in change_hashes {
+                if seen.insert(hash) {
+                    manifest.peer_change_hashes.push(hash);
+                }
+            }
+        }
+        DurableMutation::SourceReady { generation } => {
+            manifest.source_generation = generation;
+            manifest.source_phase = RecoverySourcePhase::Ready;
+        }
+        DurableMutation::Daemon => {}
+        DurableMutation::FileCheckpoint {
+            canonical_path,
+            file_fingerprint,
+            exported_heads,
+            save_sequence,
+            source_generation,
+        } => {
+            manifest.canonical_path = Some(canonical_path);
+            manifest.source_fingerprint = file_fingerprint;
+            manifest.exported_heads = exported_heads;
+            manifest.file_save_sequence = Some(save_sequence);
+            if let Some(source_generation) = source_generation {
+                manifest.source_generation = source_generation;
+                manifest.source_phase = RecoverySourcePhase::DurablyStaged;
+            }
+            manifest.pending_file_checkpoint = None;
+        }
+    }
+}
+
+fn mutation_is_already_reflected(manifest: &RecoveryManifest, mutation: &DurableMutation) -> bool {
+    match mutation {
+        DurableMutation::Source {
+            generation,
+            fingerprint,
+            staged_change_hashes,
+        } => {
+            manifest.source_generation == *generation
+                && manifest.source_fingerprint == *fingerprint
+                && manifest.staged_change_hashes == *staged_change_hashes
+        }
+        DurableMutation::Peer { change_hashes } => change_hashes
+            .iter()
+            .all(|hash| manifest.peer_change_hashes.contains(hash)),
+        DurableMutation::SourceReady { generation } => {
+            manifest.source_generation == *generation
+                && manifest.source_phase == RecoverySourcePhase::Ready
+        }
+        DurableMutation::Daemon => true,
+        DurableMutation::FileCheckpoint {
+            canonical_path,
+            file_fingerprint,
+            exported_heads,
+            save_sequence,
+            source_generation,
+        } => {
+            manifest.canonical_path.as_ref() == Some(canonical_path)
+                && manifest.source_fingerprint == *file_fingerprint
+                && manifest.exported_heads == *exported_heads
+                && manifest.file_save_sequence == Some(*save_sequence)
+                && source_generation
+                    .is_none_or(|generation| manifest.source_generation == generation)
+                && manifest.pending_file_checkpoint.is_none()
+        }
+    }
+}
+
+fn parse_heads(heads: &[String]) -> Result<Vec<ChangeHash>, RoomDurabilityError> {
+    heads
+        .iter()
+        .map(|head| {
+            ChangeHash::from_str(head).map_err(|error| RoomDurabilityError::InvalidHead {
+                head: head.clone(),
+                reason: error.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn snapshot_contains_heads(
+    snapshot: &[u8],
+    required_heads: &[ChangeHash],
+) -> Result<bool, RoomDurabilityError> {
+    if required_heads.is_empty() {
+        return Ok(true);
+    }
+    let mut doc = AutoCommit::load(snapshot)
+        .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
+    Ok(required_heads
+        .iter()
+        .all(|head| doc.get_change_by_hash(head).is_some()))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use automerge::{transaction::Transactable, ReadDoc, ROOT};
+
+    use super::*;
+    use crate::notebook_sync_server::recovery::{source_fingerprint, RecoveryLoadOutcome};
+
+    #[tokio::test]
+    async fn blocking_boundary_runs_on_current_thread_test_runtime() {
+        assert_eq!(run_blocking_durability_boundary(|| 42), 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_boundary_runs_on_multithread_runtime() {
+        assert_eq!(run_blocking_durability_boundary(|| 42), 42);
+    }
+
+    fn snapshot_with_change(value: i64) -> (Vec<u8>, Vec<[u8; 32]>, Vec<String>, [u8; 32]) {
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "value", value).unwrap();
+        let heads = doc.get_heads();
+        let raw_heads = heads.iter().map(|head| head.0).collect::<Vec<_>>();
+        let encoded_heads = heads.iter().map(ToString::to_string).collect::<Vec<_>>();
+        let change_hash = doc.get_changes(&[])[0].hash().0;
+        (doc.save(), raw_heads, encoded_heads, change_hash)
+    }
+
+    #[tokio::test]
+    async fn peer_commit_is_durable_before_barrier_and_survives_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let source = source_fingerprint(b"source");
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            source,
+            1,
+            genesis,
+        );
+        let (snapshot, heads, encoded_heads, change_hash) = snapshot_with_change(7);
+
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads,
+                DurableMutation::Peer {
+                    change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        let status = durability
+            .await_durable(&encoded_heads, Duration::from_millis(50))
+            .await
+            .unwrap();
+        assert!(status.has_peer_changes);
+
+        let recovered = match journal.load(source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        assert_eq!(
+            recovered.record.manifest.peer_change_hashes,
+            vec![change_hash]
+        );
+        assert_eq!(recovered.record.automerge_snapshot, snapshot);
+    }
+
+    #[tokio::test]
+    async fn degraded_barrier_fails_without_waiting_for_timeout() {
+        let (snapshot, heads, encoded_heads, _) = snapshot_with_change(1);
+        let durability = RoomDurability::volatile(Uuid::nil(), snapshot, heads);
+        durability.mark_degraded("disk full");
+
+        let error = durability
+            .await_durable(&encoded_heads, Duration::from_secs(10))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RoomDurabilityError::Degraded(reason) if reason == "disk full"));
+    }
+
+    #[test]
+    fn shutdown_freeze_rejects_later_commits_until_transaction_is_thawed() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let source = source_fingerprint(b"source");
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(journal, Uuid::nil(), None, source, 0, genesis);
+        let initial_manifest = durability.manifest();
+        let (snapshot, heads, _, _) = snapshot_with_change(11);
+
+        durability.freeze_commits();
+        assert!(matches!(
+            durability.commit_snapshot(&snapshot, heads.clone(), DurableMutation::Daemon),
+            Err(RoomDurabilityError::ShutdownInProgress)
+        ));
+        assert_eq!(
+            durability.manifest(),
+            initial_manifest,
+            "a post-barrier mutation must not advance acknowledged recovery heads"
+        );
+
+        durability.thaw_commits();
+        durability
+            .commit_snapshot(&snapshot, heads.clone(), DurableMutation::Daemon)
+            .unwrap();
+        assert_eq!(durability.manifest().durable_heads, heads);
+    }
+
+    #[test]
+    fn older_durable_snapshot_satisfies_ancestor_head_barrier() {
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "first", 1).unwrap();
+        let required = doc.get_heads();
+        doc.put(ROOT, "second", 2).unwrap();
+        let snapshot = doc.save();
+
+        assert!(snapshot_contains_heads(&snapshot, &required).unwrap());
+    }
+
+    #[test]
+    fn stale_daemon_snapshot_cannot_regress_a_newer_peer_commit() {
+        let mut older = AutoCommit::new();
+        older.put(ROOT, "source", 1).unwrap();
+        let older_heads = older.get_heads();
+        let older_snapshot = older.save();
+        let durability = RoomDurability::volatile(
+            Uuid::nil(),
+            older_snapshot.clone(),
+            older_heads.iter().map(|head| head.0).collect(),
+        );
+
+        let mut peer = AutoCommit::load(&older_snapshot).unwrap();
+        let peer_baseline = peer.get_heads();
+        peer.put(ROOT, "peer", 2).unwrap();
+        durability
+            .commit_peer_changes(peer.get_changes(&peer_baseline))
+            .unwrap();
+        let after_peer = durability.status();
+
+        durability
+            .commit_snapshot(
+                &older_snapshot,
+                older_heads.iter().map(|head| head.0).collect(),
+                DurableMutation::Daemon,
+            )
+            .unwrap();
+
+        let recovered = AutoCommit::load(&durability.durable_snapshot()).unwrap();
+        assert_eq!(
+            recovered.get(ROOT, "peer").unwrap().unwrap().0.to_i64(),
+            Some(2)
+        );
+        assert_eq!(durability.status().durable_heads, after_peer.durable_heads);
+    }
+
+    #[test]
+    fn file_checkpoint_advances_manifest_without_regressing_newer_durable_snapshot() {
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "exported", 1).unwrap();
+        let exported_heads = doc.get_heads();
+        doc.put(ROOT, "peer", 2).unwrap();
+        let durable_heads = doc.get_heads();
+        let durable_snapshot = doc.save();
+        let durability = RoomDurability::volatile(
+            Uuid::nil(),
+            durable_snapshot.clone(),
+            durable_heads.iter().map(|head| head.0).collect(),
+        );
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let fingerprint = source_fingerprint(b"checkpoint");
+
+        durability
+            .commit_file_checkpoint(
+                path.clone(),
+                fingerprint,
+                exported_heads.iter().map(|head| head.0).collect(),
+                9,
+            )
+            .unwrap();
+
+        let manifest = durability.manifest();
+        assert_eq!(manifest.canonical_path, Some(path));
+        assert_eq!(manifest.exported_heads, vec![exported_heads[0].0]);
+        assert_eq!(manifest.durable_heads, vec![durable_heads[0].0]);
+        assert_eq!(manifest.file_save_sequence, Some(9));
+        assert_eq!(durability.durable_snapshot().as_ref(), durable_snapshot);
+    }
+
+    #[test]
+    fn file_checkpoint_rejects_heads_absent_from_recovery_union() {
+        let (snapshot, heads, _, _) = snapshot_with_change(1);
+        let durability = RoomDurability::volatile(Uuid::nil(), snapshot, heads);
+
+        let error = durability
+            .commit_file_checkpoint(
+                PathBuf::from("/tmp/notebook.ipynb"),
+                source_fingerprint(b"checkpoint"),
+                vec![[0xff; 32]],
+                1,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RoomDurabilityError::FileCheckpointHeadsNotDurable
+        ));
+        assert!(durability.manifest().exported_heads.is_empty());
+    }
+
+    #[test]
+    fn restart_finalizes_file_replacement_from_durable_intent() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let old_source = source_fingerprint(b"old source");
+        let new_source = source_fingerprint(b"new source");
+        let (snapshot, heads, _, change_hash) = snapshot_with_change(1);
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            old_source,
+            1,
+            snapshot.clone(),
+        );
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads.clone(),
+                DurableMutation::Source {
+                    generation: 1,
+                    fingerprint: old_source,
+                    staged_change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        durability.commit_source_ready(1).unwrap();
+        durability
+            .prepare_file_checkpoint(
+                PathBuf::from("/tmp/notebook.ipynb"),
+                new_source,
+                heads.clone(),
+                2,
+                None,
+            )
+            .unwrap();
+        drop(durability);
+
+        let recovered = match journal.load(new_source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("pending replacement should be recoverable, got {other:?}"),
+        };
+        assert!(recovered.record.manifest.pending_file_checkpoint.is_some());
+        let restarted = RoomDurability::recovered(journal.clone(), recovered);
+        restarted
+            .resolve_recovered_file_checkpoint(new_source)
+            .unwrap();
+
+        let manifest = restarted.manifest();
+        assert_eq!(manifest.source_fingerprint, new_source);
+        assert_eq!(manifest.exported_heads, heads);
+        assert_eq!(manifest.file_save_sequence, Some(2));
+        assert!(manifest.pending_file_checkpoint.is_none());
+        let latest = match journal.load(new_source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("finalized checkpoint should match disk, got {other:?}"),
+        };
+        assert!(latest.record.manifest.pending_file_checkpoint.is_none());
+    }
+
+    #[test]
+    fn restart_aborts_checkpoint_intent_when_old_file_remains() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let old_source = source_fingerprint(b"old source");
+        let new_source = source_fingerprint(b"new source");
+        let (snapshot, heads, _, change_hash) = snapshot_with_change(1);
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            old_source,
+            1,
+            snapshot.clone(),
+        );
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads.clone(),
+                DurableMutation::Source {
+                    generation: 1,
+                    fingerprint: old_source,
+                    staged_change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        durability
+            .prepare_file_checkpoint(
+                PathBuf::from("/tmp/notebook.ipynb"),
+                new_source,
+                heads,
+                2,
+                None,
+            )
+            .unwrap();
+        drop(durability);
+
+        let recovered = match journal.load(old_source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("old source should prove replacement did not occur, got {other:?}"),
+        };
+        let restarted = RoomDurability::recovered(journal.clone(), recovered);
+        restarted
+            .resolve_recovered_file_checkpoint(old_source)
+            .unwrap();
+        let manifest = restarted.manifest();
+        assert_eq!(manifest.source_fingerprint, old_source);
+        assert!(manifest.pending_file_checkpoint.is_none());
+    }
+
+    #[test]
+    fn staged_source_merges_peer_changes_accepted_during_preparation() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let source_fingerprint = source_fingerprint(b"source");
+        let mut genesis = AutoCommit::new();
+        genesis.put(ROOT, "genesis", 1).unwrap();
+        let genesis_snapshot = genesis.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            source_fingerprint,
+            1,
+            genesis_snapshot.clone(),
+        );
+
+        let mut peer = AutoCommit::load(&genesis_snapshot).unwrap();
+        let peer_heads = peer.get_heads();
+        peer.put(ROOT, "peer", 2).unwrap();
+        let peer_changes = peer.get_changes(&peer_heads);
+        durability.commit_peer_changes(peer_changes).unwrap();
+
+        let mut staged = AutoCommit::load(&genesis_snapshot).unwrap();
+        staged.put(ROOT, "source", 3).unwrap();
+        let staged_heads = staged.get_heads();
+        let staged_hashes = staged
+            .get_changes(&genesis.get_heads())
+            .iter()
+            .map(|change| change.hash().0)
+            .collect::<Vec<_>>();
+        let staged_snapshot = staged.save();
+        durability
+            .commit_staged_source(
+                &staged_snapshot,
+                staged_heads.iter().map(|head| head.0).collect(),
+                1,
+                source_fingerprint,
+                staged_hashes,
+            )
+            .unwrap();
+
+        let recovered = match journal.load(source_fingerprint).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        let recovered_doc = AutoCommit::load(&recovered.record.automerge_snapshot).unwrap();
+        assert_eq!(
+            recovered_doc
+                .get(ROOT, "source")
+                .unwrap()
+                .unwrap()
+                .0
+                .to_i64(),
+            Some(3)
+        );
+        assert_eq!(
+            recovered_doc.get(ROOT, "peer").unwrap().unwrap().0.to_i64(),
+            Some(2)
+        );
+        assert_eq!(
+            recovered.record.manifest.exported_heads,
+            staged_heads.iter().map(|head| head.0).collect::<Vec<_>>()
+        );
+        assert_ne!(
+            recovered.record.manifest.durable_heads,
+            recovered.record.manifest.exported_heads
+        );
+    }
+
+    #[test]
+    fn observed_source_commit_rechecks_unsaved_heads_after_async_preparation() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let disk_source = source_fingerprint(b"original disk source");
+        let mut genesis = AutoCommit::new();
+        let genesis_snapshot = genesis.save();
+        let durability = RoomDurability::journaled(
+            journal,
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            disk_source,
+            1,
+            genesis_snapshot,
+        );
+
+        let mut source = AutoCommit::new();
+        source.put(ROOT, "source", 1).unwrap();
+        let source_heads = source.get_heads();
+        let source_hashes = source
+            .get_changes(&[])
+            .iter()
+            .map(|change| change.hash().0)
+            .collect();
+        durability
+            .commit_snapshot(
+                &source.save(),
+                source_heads.iter().map(|head| head.0).collect(),
+                DurableMutation::Source {
+                    generation: 1,
+                    fingerprint: disk_source,
+                    staged_change_hashes: source_hashes,
+                },
+            )
+            .unwrap();
+
+        // Simulate a peer batch landing after the watcher preflight but before
+        // its prepared source changes acquire the document lock.
+        let mut peer = AutoCommit::load(&durability.durable_snapshot()).unwrap();
+        let before_peer = peer.get_heads();
+        peer.put(ROOT, "peer", 2).unwrap();
+        durability
+            .commit_peer_changes(peer.get_changes(&before_peer))
+            .unwrap();
+        let before_observed = durability.status();
+
+        let mut observed = AutoCommit::load(&durability.durable_snapshot()).unwrap();
+        let before_disk = observed.get_heads();
+        observed.put(ROOT, "external", 3).unwrap();
+        let observed_fingerprint = source_fingerprint(b"new external source");
+        let error = durability
+            .commit_external_source_revision(
+                observed.get_changes(&before_disk),
+                observed_fingerprint,
+                PathBuf::from("/tmp/notebook.ipynb"),
+                2,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RoomDurabilityError::SourceConflict {
+                journal_source,
+                observed_source,
+            } if journal_source == disk_source && observed_source == observed_fingerprint
+        ));
+        let after = durability.status();
+        assert_eq!(after.journal_sequence, before_observed.journal_sequence);
+        assert_eq!(after.durable_heads, before_observed.durable_heads);
+        assert_eq!(after.source_fingerprint, disk_source);
+    }
+
+    #[test]
+    fn sequential_clean_external_revisions_advance_the_causal_file_checkpoint() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let original_source = source_fingerprint(b"original source");
+        let mut genesis = AutoCommit::new();
+        let genesis_snapshot = genesis.save();
+        let durability = RoomDurability::journaled(
+            journal,
+            Uuid::nil(),
+            Some(path.clone()),
+            original_source,
+            1,
+            genesis_snapshot,
+        );
+
+        let mut initial = AutoCommit::new();
+        let initial_heads = initial.get_heads();
+        initial.put(ROOT, "source", 0).unwrap();
+        durability
+            .commit_staged_source(
+                &initial.save(),
+                initial.get_heads().iter().map(|head| head.0).collect(),
+                1,
+                original_source,
+                initial
+                    .get_changes(&initial_heads)
+                    .iter()
+                    .map(|change| change.hash().0)
+                    .collect(),
+            )
+            .unwrap();
+        durability.commit_source_ready(1).unwrap();
+
+        for (value, bytes, save_sequence) in [
+            (1, b"revision one".as_slice(), 2),
+            (2, b"revision two".as_slice(), 3),
+        ] {
+            let mut external = AutoCommit::load(&durability.durable_snapshot()).unwrap();
+            let before = external.get_heads();
+            external.put(ROOT, "source", value).unwrap();
+            let fingerprint = source_fingerprint(bytes);
+            let status = match durability
+                .commit_external_source_revision(
+                    external.get_changes(&before),
+                    fingerprint,
+                    path.clone(),
+                    save_sequence,
+                )
+                .unwrap()
+            {
+                DurableCommitOutcome::Committed(status)
+                | DurableCommitOutcome::AlreadyDurable(status) => status,
+            };
+            assert_eq!(status.durable_heads, status.exported_heads);
+            assert_eq!(status.source_fingerprint, fingerprint);
+            assert_eq!(status.source_phase, RecoverySourcePhase::DurablyStaged);
+            durability
+                .commit_source_ready(status.source_generation)
+                .unwrap();
+        }
+
+        let mut peer = AutoCommit::load(&durability.durable_snapshot()).unwrap();
+        let before_peer = peer.get_heads();
+        peer.put(ROOT, "peer", true).unwrap();
+        durability
+            .commit_peer_changes(peer.get_changes(&before_peer))
+            .unwrap();
+        let before_conflict = durability.status();
+
+        let mut external = AutoCommit::load(&durability.durable_snapshot()).unwrap();
+        let before_external = external.get_heads();
+        external.put(ROOT, "source", 3).unwrap();
+        let observed_source = source_fingerprint(b"revision three");
+        let error = durability
+            .commit_external_source_revision(
+                external.get_changes(&before_external),
+                observed_source,
+                path,
+                4,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RoomDurabilityError::SourceConflict {
+                observed_source: conflict_source,
+                ..
+            } if conflict_source == observed_source
+        ));
+        assert_eq!(durability.status(), before_conflict);
+    }
+
+    #[test]
+    fn reconciled_file_checkpoint_advances_source_generation_in_the_same_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let old_source = source_fingerprint(b"old source");
+        let (snapshot, heads, _, _) = snapshot_with_change(4);
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            old_source,
+            2,
+            snapshot.clone(),
+        );
+        durability
+            .commit_snapshot(&snapshot, heads.clone(), DurableMutation::Daemon)
+            .unwrap();
+        let selected_source = source_fingerprint(b"selected recovered source");
+
+        durability
+            .commit_reconciled_file_checkpoint(
+                PathBuf::from("/tmp/recovered.ipynb"),
+                selected_source,
+                heads.clone(),
+                9,
+                3,
+            )
+            .unwrap();
+
+        let recovered = match journal.load(selected_source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        assert_eq!(recovered.record.manifest.source_generation, 3);
+        assert_eq!(recovered.record.manifest.durable_heads, heads);
+        assert_eq!(recovered.record.manifest.exported_heads, heads);
+        assert_eq!(recovered.record.manifest.file_save_sequence, Some(9));
+        assert_eq!(
+            recovered.record.manifest.canonical_path,
+            Some(PathBuf::from("/tmp/recovered.ipynb"))
+        );
+    }
+
+    #[test]
+    fn archive_reload_preserves_old_history_and_commits_a_new_active_journal() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let old_source = source_fingerprint(b"recovered source");
+        let (recovered_snapshot, recovered_heads, _, peer_hash) = snapshot_with_change(7);
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            old_source,
+            4,
+            recovered_snapshot.clone(),
+        );
+        durability
+            .commit_snapshot(
+                &recovered_snapshot,
+                recovered_heads.clone(),
+                DurableMutation::Peer {
+                    change_hashes: vec![peer_hash],
+                },
+            )
+            .unwrap();
+
+        let recovered_head_hashes = recovered_heads
+            .iter()
+            .copied()
+            .map(ChangeHash)
+            .collect::<Vec<_>>();
+        let mut disk_selected = AutoCommit::load(&recovered_snapshot).unwrap();
+        disk_selected.put(ROOT, "disk-selected", 11).unwrap();
+        let replacement_hashes = disk_selected
+            .get_changes(&recovered_head_hashes)
+            .iter()
+            .map(|change| change.hash().0)
+            .collect::<Vec<_>>();
+        let selected_heads = disk_selected
+            .get_heads()
+            .iter()
+            .map(|head| head.0)
+            .collect::<Vec<_>>();
+        let selected_snapshot = disk_selected.save();
+        let selected_source = source_fingerprint(b"disk source");
+
+        let commit = durability
+            .archive_and_commit_reconciled_source(
+                &selected_snapshot,
+                selected_heads.clone(),
+                PathBuf::from("/tmp/notebook.ipynb"),
+                selected_source,
+                5,
+                replacement_hashes.clone(),
+                12,
+            )
+            .unwrap();
+
+        assert!(commit.archived_directory.is_dir());
+        assert_eq!(commit.status.source_generation, 5);
+        assert!(!commit.status.has_peer_changes);
+        let active = match journal.load(selected_source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected selected active recovery, got {other:?}"),
+        };
+        assert_eq!(
+            active.record.manifest.staged_change_hashes,
+            replacement_hashes
+        );
+        assert!(active.record.manifest.peer_change_hashes.is_empty());
+        assert_eq!(active.record.manifest.durable_heads, selected_heads);
+        assert_eq!(active.record.manifest.exported_heads, selected_heads);
+        assert_eq!(active.record.manifest.file_save_sequence, Some(12));
+
+        let archived = RecoveryJournal::new(commit.archived_directory.join("room.recovery"));
+        let archived_record = match archived.load(old_source).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected preserved archived recovery, got {other:?}"),
+        };
+        assert_eq!(
+            archived_record.record.manifest.peer_change_hashes,
+            vec![peer_hash]
+        );
+        assert_eq!(
+            archived_record.record.automerge_snapshot,
+            recovered_snapshot
+        );
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/file_checkpoint.rs
+++ b/crates/runtimed/src/notebook_sync_server/file_checkpoint.rs
@@ -1,0 +1,1248 @@
+//! Causal `.ipynb` checkpoint coordination.
+//!
+//! Saving is deliberately two phase. A claim receives a monotonic sequence,
+//! then the complete temporary file is written and flushed without holding the
+//! coordinator lock. The sequence is checked again while holding that lock
+//! immediately before the synchronous atomic replacement. This prevents an
+//! older completion from replacing a newer file or regressing checkpoint
+//! metadata.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::SystemTime;
+
+use tokio::sync::broadcast;
+
+use super::recovery::{source_fingerprint, SourceFingerprint};
+
+const CHECKPOINT_EVENT_CAPACITY: usize = 32;
+
+/// Exact file metadata a save intends to make durable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileCheckpointTarget {
+    pub(crate) path: PathBuf,
+    pub(crate) exported_heads: Vec<[u8; 32]>,
+    pub(crate) file_fingerprint: SourceFingerprint,
+    /// Optional fingerprint of the existing target revision the caller
+    /// explicitly consented to replace. Rechecked immediately before atomic
+    /// replacement so reconciliation cannot discard a later external edit.
+    pub(crate) expected_existing_fingerprint: Option<SourceFingerprint>,
+}
+
+impl FileCheckpointTarget {
+    pub(crate) fn new(
+        path: impl Into<PathBuf>,
+        exported_heads: Vec<[u8; 32]>,
+        file_fingerprint: SourceFingerprint,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            exported_heads,
+            file_fingerprint,
+            expected_existing_fingerprint: None,
+        }
+    }
+
+    pub(crate) fn requiring_existing_fingerprint(mut self, fingerprint: SourceFingerprint) -> Self {
+        self.expected_existing_fingerprint = Some(fingerprint);
+        self
+    }
+
+    pub(crate) fn for_content(
+        path: impl Into<PathBuf>,
+        exported_heads: Vec<[u8; 32]>,
+        content: &[u8],
+    ) -> Self {
+        Self::new(path, exported_heads, source_fingerprint(content))
+    }
+
+    fn matches_checkpoint(&self, checkpoint: &FileCheckpoint) -> bool {
+        self.path == checkpoint.path
+            && self.exported_heads == checkpoint.exported_heads
+            && self.file_fingerprint == checkpoint.file_fingerprint
+    }
+}
+
+/// The last `.ipynb` revision known to have completed atomic replacement and
+/// directory synchronization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileCheckpoint {
+    pub(crate) path: PathBuf,
+    pub(crate) exported_heads: Vec<[u8; 32]>,
+    pub(crate) file_fingerprint: SourceFingerprint,
+    pub(crate) save_sequence: u64,
+    pub(crate) saved_at: SystemTime,
+}
+
+/// Causal file metadata journaled after the temporary file is durable but
+/// before atomic replacement makes it visible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileCheckpointPreparation {
+    pub(crate) path: PathBuf,
+    pub(crate) exported_heads: Vec<[u8; 32]>,
+    pub(crate) file_fingerprint: SourceFingerprint,
+    pub(crate) save_sequence: u64,
+}
+
+/// Emitted only after both file replacement and checkpoint advancement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileCheckpointEvent {
+    pub(crate) checkpoint: FileCheckpoint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SaveIoStage {
+    CreateTemp,
+    WriteTemp,
+    FlushTemp,
+    Replace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SaveBlockedReason {
+    SequenceExhausted,
+    ContentFingerprintMismatch {
+        declared: SourceFingerprint,
+        actual: SourceFingerprint,
+    },
+    ExistingContentChanged {
+        expected: SourceFingerprint,
+        actual: Option<SourceFingerprint>,
+    },
+    Superseded {
+        latest_sequence: u64,
+    },
+    Io {
+        stage: SaveIoStage,
+        message: String,
+    },
+    /// Atomic file replacement completed, but the causal journal marker did
+    /// not. The file remains intact while checkpoint state/event publication
+    /// stays blocked.
+    Commit {
+        message: String,
+    },
+}
+
+/// Honest save result. `Saved` is the only outcome that advances the
+/// checkpoint timestamp or emits a checkpoint event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SaveOutcome {
+    Saved {
+        checkpoint: FileCheckpoint,
+    },
+    AlreadyCurrent {
+        checkpoint: FileCheckpoint,
+        claim_sequence: u64,
+    },
+    Blocked {
+        save_sequence: Option<u64>,
+        reason: SaveBlockedReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SaveClaimError;
+
+/// A monotonic save sequence reserved before any asynchronous preparation.
+///
+/// The exact file target is bound only after notebook formatting, blob
+/// resolution, and serialization finish. Reserving first gives every request
+/// a stable identity; only a later committed ordering barrier supersedes it,
+/// so failed asynchronous preparation cannot burn an older viable save.
+#[derive(Debug)]
+pub(crate) struct SaveSequenceClaim {
+    sequence: u64,
+}
+
+impl SaveSequenceClaim {
+    pub(crate) fn sequence(&self) -> u64 {
+        self.sequence
+    }
+}
+
+/// A one-shot claim. It is intentionally not `Clone`: completion consumes the
+/// claim, and the coordinator checks its sequence again before replacement.
+#[derive(Debug)]
+pub(crate) struct SaveClaim {
+    sequence: u64,
+    target: FileCheckpointTarget,
+    already_current: Option<FileCheckpoint>,
+}
+
+impl SaveClaim {
+    pub(crate) fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    pub(crate) fn target(&self) -> &FileCheckpointTarget {
+        &self.target
+    }
+}
+
+#[derive(Debug)]
+struct CheckpointState {
+    latest_reserved_sequence: u64,
+    /// Highest sequence that reached a real ordering boundary: a committed
+    /// checkpoint, a validated AlreadyCurrent result, or a file replacement
+    /// whose journal commit then failed. Merely reserving a sequence during
+    /// async preparation does not supersede an older viable save.
+    latest_barrier_sequence: u64,
+    checkpoint: Option<FileCheckpoint>,
+}
+
+/// Serializes sequence claims and the short replace/checkpoint commit section.
+#[derive(Debug)]
+pub(crate) struct FileCheckpointCoordinator {
+    state: Mutex<CheckpointState>,
+    events: broadcast::Sender<FileCheckpointEvent>,
+}
+
+impl Default for FileCheckpointCoordinator {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl FileCheckpointCoordinator {
+    pub(crate) fn new(initial_checkpoint: Option<FileCheckpoint>) -> Self {
+        let initial_sequence = initial_checkpoint
+            .as_ref()
+            .map_or(0, |checkpoint| checkpoint.save_sequence);
+        let (events, _) = broadcast::channel(CHECKPOINT_EVENT_CAPACITY);
+        Self {
+            state: Mutex::new(CheckpointState {
+                latest_reserved_sequence: initial_sequence,
+                latest_barrier_sequence: initial_sequence,
+                checkpoint: initial_checkpoint,
+            }),
+            events,
+        }
+    }
+
+    /// Reserve the next monotonic save sequence before asynchronous work.
+    ///
+    /// Even an already-current request advances the sequence so it can
+    /// supersede an older in-flight write to a different revision.
+    pub(crate) fn reserve(&self) -> Result<SaveSequenceClaim, SaveClaimError> {
+        let mut state = self.lock_state();
+        let Some(sequence) = state.latest_reserved_sequence.checked_add(1) else {
+            return Err(SaveClaimError);
+        };
+        state.latest_reserved_sequence = sequence;
+        Ok(SaveSequenceClaim { sequence })
+    }
+
+    /// Claim a fully prepared target in one synchronous operation.
+    ///
+    /// Production save paths reserve before preparation and use
+    /// [`Self::complete_reserved`]. This convenience is retained for callers
+    /// that already have immutable content and for focused coordinator tests.
+    pub(crate) fn claim(&self, target: FileCheckpointTarget) -> Result<SaveClaim, SaveClaimError> {
+        let reservation = self.reserve()?;
+        Ok(self.bind(reservation, target))
+    }
+
+    fn bind(&self, reservation: SaveSequenceClaim, target: FileCheckpointTarget) -> SaveClaim {
+        let sequence = reservation.sequence;
+        let state = self.lock_state();
+        let already_current = state
+            .checkpoint
+            .as_ref()
+            .filter(|checkpoint| target.matches_checkpoint(checkpoint))
+            .cloned();
+        SaveClaim {
+            sequence,
+            target,
+            already_current,
+        }
+    }
+
+    pub(crate) fn checkpoint(&self) -> Option<FileCheckpoint> {
+        self.lock_state().checkpoint.clone()
+    }
+
+    /// Restore the last journal-committed checkpoint during room startup.
+    /// No event is emitted: this is recovered state, not a new file save.
+    pub(crate) fn restore(&self, checkpoint: FileCheckpoint) {
+        let mut state = self.lock_state();
+        if state
+            .checkpoint
+            .as_ref()
+            .is_some_and(|current| current.save_sequence > checkpoint.save_sequence)
+        {
+            return;
+        }
+        state.latest_reserved_sequence =
+            state.latest_reserved_sequence.max(checkpoint.save_sequence);
+        state.latest_barrier_sequence = state.latest_barrier_sequence.max(checkpoint.save_sequence);
+        state.checkpoint = Some(checkpoint);
+    }
+
+    pub(crate) fn latest_claimed_sequence(&self) -> u64 {
+        self.lock_state().latest_reserved_sequence
+    }
+
+    /// Return the newest save sequence that crossed a real ordering barrier.
+    ///
+    /// Async request continuations use this after the blocking file/journal
+    /// boundary so an older completion cannot later rebind the room path or
+    /// overwrite file-watcher bookkeeping installed by a newer save.
+    pub(crate) fn latest_barrier_sequence(&self) -> u64 {
+        self.lock_state().latest_barrier_sequence
+    }
+
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<FileCheckpointEvent> {
+        self.events.subscribe()
+    }
+
+    /// Claim, prepare, and causally commit one file checkpoint.
+    pub(crate) fn save(&self, target: FileCheckpointTarget, content: &[u8]) -> SaveOutcome {
+        self.save_with(target, content, &RealCheckpointIo, &SystemCheckpointClock)
+    }
+
+    /// Prepare and commit an exact previously ordered claim.
+    ///
+    /// Call [`Self::claim`] before handing work to `spawn_blocking`, then move
+    /// that claim into the blocking task and complete it here. This preserves
+    /// caller-visible save ordering even when blocking workers begin out of
+    /// order.
+    pub(crate) fn complete(&self, claim: SaveClaim, content: &[u8]) -> SaveOutcome {
+        self.complete_with(claim, content, &RealCheckpointIo, &SystemCheckpointClock)
+    }
+
+    /// Bind an exact target to a sequence reserved before asynchronous
+    /// preparation, then complete it on the calling thread.
+    pub(crate) fn complete_reserved(
+        &self,
+        reservation: SaveSequenceClaim,
+        target: FileCheckpointTarget,
+        content: &[u8],
+    ) -> SaveOutcome {
+        let claim = self.bind(reservation, target);
+        self.complete(claim, content)
+    }
+
+    /// Complete a reserved save and require a post-replacement causal commit
+    /// before advancing coordinator state or emitting the checkpoint event.
+    pub(crate) fn complete_reserved_with_commit(
+        &self,
+        reservation: SaveSequenceClaim,
+        target: FileCheckpointTarget,
+        content: &[u8],
+        commit: impl FnOnce(&FileCheckpoint) -> Result<(), String>,
+    ) -> SaveOutcome {
+        let claim = self.bind(reservation, target);
+        self.complete_with_commit(
+            claim,
+            content,
+            &RealCheckpointIo,
+            &SystemCheckpointClock,
+            commit,
+        )
+    }
+
+    /// Complete a save with a durable pre-replacement intent and an abort
+    /// marker for definitive replacement failures. A crash after replacement
+    /// but before `commit` leaves enough journal evidence for restart to
+    /// finalize the exact checkpoint instead of manufacturing a conflict.
+    pub(crate) fn complete_reserved_with_durable_intent(
+        &self,
+        reservation: SaveSequenceClaim,
+        target: FileCheckpointTarget,
+        content: &[u8],
+        prepare: impl FnOnce(&FileCheckpointPreparation) -> Result<(), String>,
+        abort: impl FnOnce(&FileCheckpointPreparation) -> Result<(), String>,
+        commit: impl FnOnce(&FileCheckpoint) -> Result<(), String>,
+    ) -> SaveOutcome {
+        let claim = self.bind(reservation, target);
+        self.complete_with_callbacks(
+            claim,
+            content,
+            &RealCheckpointIo,
+            &SystemCheckpointClock,
+            prepare,
+            abort,
+            commit,
+        )
+    }
+
+    /// Select an already-existing disk revision as the causal checkpoint for
+    /// an explicit source reconciliation.
+    ///
+    /// This performs no file write and emits no `FileCheckpointEvent`. It
+    /// holds the sequence lock from the final supersession check through the
+    /// caller's journal commit and checkpoint publication, so an older async
+    /// reload cannot regress a newer save request.
+    pub(crate) fn commit_existing_with<T>(
+        &self,
+        reservation: SaveSequenceClaim,
+        checkpoint: FileCheckpoint,
+        commit: impl FnOnce(&FileCheckpoint) -> Result<T, String>,
+    ) -> Result<T, SaveBlockedReason> {
+        debug_assert_eq!(reservation.sequence, checkpoint.save_sequence);
+        let mut state = self.lock_state();
+        if state.latest_barrier_sequence > reservation.sequence {
+            return Err(SaveBlockedReason::Superseded {
+                latest_sequence: state.latest_barrier_sequence,
+            });
+        }
+        let committed =
+            commit(&checkpoint).map_err(|message| SaveBlockedReason::Commit { message })?;
+        state.latest_barrier_sequence = reservation.sequence;
+        state.checkpoint = Some(checkpoint);
+        Ok(committed)
+    }
+
+    fn save_with(
+        &self,
+        target: FileCheckpointTarget,
+        content: &[u8],
+        io: &dyn CheckpointIo,
+        clock: &dyn CheckpointClock,
+    ) -> SaveOutcome {
+        let claim = match self.claim(target) {
+            Ok(claim) => claim,
+            Err(SaveClaimError) => {
+                return SaveOutcome::Blocked {
+                    save_sequence: None,
+                    reason: SaveBlockedReason::SequenceExhausted,
+                };
+            }
+        };
+        self.complete_with(claim, content, io, clock)
+    }
+
+    fn complete_with(
+        &self,
+        claim: SaveClaim,
+        content: &[u8],
+        io: &dyn CheckpointIo,
+        clock: &dyn CheckpointClock,
+    ) -> SaveOutcome {
+        self.complete_with_commit(claim, content, io, clock, |_| Ok(()))
+    }
+
+    fn complete_with_commit(
+        &self,
+        claim: SaveClaim,
+        content: &[u8],
+        io: &dyn CheckpointIo,
+        clock: &dyn CheckpointClock,
+        commit: impl FnOnce(&FileCheckpoint) -> Result<(), String>,
+    ) -> SaveOutcome {
+        self.complete_with_callbacks(claim, content, io, clock, |_| Ok(()), |_| Ok(()), commit)
+    }
+
+    // Fault-injection seam: prepare/abort/commit stay separate ordered hooks so
+    // tests can fail each boundary independently.
+    #[allow(clippy::too_many_arguments)]
+    fn complete_with_callbacks(
+        &self,
+        claim: SaveClaim,
+        content: &[u8],
+        io: &dyn CheckpointIo,
+        clock: &dyn CheckpointClock,
+        prepare: impl FnOnce(&FileCheckpointPreparation) -> Result<(), String>,
+        abort: impl FnOnce(&FileCheckpointPreparation) -> Result<(), String>,
+        commit: impl FnOnce(&FileCheckpoint) -> Result<(), String>,
+    ) -> SaveOutcome {
+        let actual_fingerprint = source_fingerprint(content);
+        if actual_fingerprint != claim.target.file_fingerprint {
+            return SaveOutcome::Blocked {
+                save_sequence: Some(claim.sequence),
+                reason: SaveBlockedReason::ContentFingerprintMismatch {
+                    declared: claim.target.file_fingerprint,
+                    actual: actual_fingerprint,
+                },
+            };
+        }
+
+        if let Err(outcome) = verify_expected_existing(&claim, io) {
+            return outcome;
+        }
+
+        if let Some(ref checkpoint) = claim.already_current {
+            let mut state = self.lock_state();
+            if state.latest_barrier_sequence > claim.sequence {
+                return SaveOutcome::Blocked {
+                    save_sequence: Some(claim.sequence),
+                    reason: SaveBlockedReason::Superseded {
+                        latest_sequence: state.latest_barrier_sequence,
+                    },
+                };
+            }
+            if state.checkpoint.as_ref() == Some(checkpoint)
+                && claim.target.matches_checkpoint(checkpoint)
+            {
+                state.latest_barrier_sequence = claim.sequence;
+                return SaveOutcome::AlreadyCurrent {
+                    checkpoint: checkpoint.clone(),
+                    claim_sequence: claim.sequence,
+                };
+            }
+        }
+
+        let temporary_path = sibling_temp_path(&claim.target.path, claim.sequence);
+        let mut temporary = match io.create_temp(&temporary_path, &claim.target.path) {
+            Ok(file) => file,
+            Err(error) => {
+                return blocked_io(claim.sequence, SaveIoStage::CreateTemp, error);
+            }
+        };
+        if let Err(error) = io.write_temp(&mut temporary, content) {
+            drop(temporary);
+            io.remove_temp(&temporary_path);
+            return blocked_io(claim.sequence, SaveIoStage::WriteTemp, error);
+        }
+        if let Err(error) = io.flush_temp(&temporary) {
+            drop(temporary);
+            io.remove_temp(&temporary_path);
+            return blocked_io(claim.sequence, SaveIoStage::FlushTemp, error);
+        }
+        drop(temporary);
+
+        // The temp file is complete and fsynced before checkpoint state is
+        // serialized. Hold the same lock used by `claim` from this sequence
+        // check through synchronous replacement and checkpoint publication.
+        let mut state = self.lock_state();
+        if state.latest_barrier_sequence > claim.sequence {
+            let latest_sequence = state.latest_barrier_sequence;
+            drop(state);
+            io.remove_temp(&temporary_path);
+            return SaveOutcome::Blocked {
+                save_sequence: Some(claim.sequence),
+                reason: SaveBlockedReason::Superseded { latest_sequence },
+            };
+        }
+
+        // Close the external-edit race between async serialization/temp-file
+        // preparation and atomic replacement.
+        if let Err(outcome) = verify_expected_existing(&claim, io) {
+            drop(state);
+            io.remove_temp(&temporary_path);
+            return outcome;
+        }
+
+        let preparation = FileCheckpointPreparation {
+            path: claim.target.path.clone(),
+            exported_heads: claim.target.exported_heads.clone(),
+            file_fingerprint: claim.target.file_fingerprint,
+            save_sequence: claim.sequence,
+        };
+        if let Err(message) = prepare(&preparation) {
+            drop(state);
+            io.remove_temp(&temporary_path);
+            return SaveOutcome::Blocked {
+                save_sequence: Some(claim.sequence),
+                reason: SaveBlockedReason::Commit { message },
+            };
+        }
+        if let Err(error) = io.replace_temp(&temporary_path, &claim.target.path) {
+            drop(state);
+            io.remove_temp(&temporary_path);
+            if let Err(abort_error) = abort(&preparation) {
+                return SaveOutcome::Blocked {
+                    save_sequence: Some(claim.sequence),
+                    reason: SaveBlockedReason::Commit {
+                        message: format!(
+                            "file replacement failed ({error}); checkpoint intent abort failed: {abort_error}"
+                        ),
+                    },
+                };
+            }
+            return blocked_io(claim.sequence, SaveIoStage::Replace, error);
+        }
+
+        let checkpoint = FileCheckpoint {
+            path: claim.target.path,
+            exported_heads: claim.target.exported_heads,
+            file_fingerprint: claim.target.file_fingerprint,
+            save_sequence: claim.sequence,
+            saved_at: clock.now(),
+        };
+        if let Err(message) = commit(&checkpoint) {
+            // Atomic replacement is already visible. Even though its journal
+            // marker failed, an older in-flight save must not overwrite that
+            // evidence while the room transitions to Degraded.
+            state.latest_barrier_sequence = claim.sequence;
+            return SaveOutcome::Blocked {
+                save_sequence: Some(claim.sequence),
+                reason: SaveBlockedReason::Commit { message },
+            };
+        }
+        state.latest_barrier_sequence = claim.sequence;
+        state.checkpoint = Some(checkpoint.clone());
+        let _ = self.events.send(FileCheckpointEvent {
+            checkpoint: checkpoint.clone(),
+        });
+        SaveOutcome::Saved { checkpoint }
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, CheckpointState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+fn verify_expected_existing(claim: &SaveClaim, io: &dyn CheckpointIo) -> Result<(), SaveOutcome> {
+    let Some(expected) = claim.target.expected_existing_fingerprint else {
+        return Ok(());
+    };
+    let actual = io
+        .target_fingerprint(&claim.target.path)
+        .map_err(|error| blocked_io(claim.sequence, SaveIoStage::Replace, error))?;
+    if actual == Some(expected) {
+        return Ok(());
+    }
+    Err(SaveOutcome::Blocked {
+        save_sequence: Some(claim.sequence),
+        reason: SaveBlockedReason::ExistingContentChanged { expected, actual },
+    })
+}
+
+fn blocked_io(sequence: u64, stage: SaveIoStage, error: io::Error) -> SaveOutcome {
+    SaveOutcome::Blocked {
+        save_sequence: Some(sequence),
+        reason: SaveBlockedReason::Io {
+            stage,
+            message: error.to_string(),
+        },
+    }
+}
+
+trait CheckpointClock: Send + Sync {
+    fn now(&self) -> SystemTime;
+}
+
+struct SystemCheckpointClock;
+
+impl CheckpointClock for SystemCheckpointClock {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+}
+
+trait CheckpointIo: Send + Sync {
+    fn create_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<File>;
+    fn write_temp(&self, temporary: &mut File, content: &[u8]) -> io::Result<()>;
+    fn flush_temp(&self, temporary: &File) -> io::Result<()>;
+    fn replace_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<()>;
+    fn target_fingerprint(&self, target_path: &Path) -> io::Result<Option<SourceFingerprint>> {
+        match std::fs::read(target_path) {
+            Ok(bytes) => Ok(Some(source_fingerprint(&bytes))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+    fn remove_temp(&self, temporary_path: &Path);
+}
+
+struct RealCheckpointIo;
+
+impl CheckpointIo for RealCheckpointIo {
+    fn create_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<File> {
+        ensure_parent_directory(target_path)?;
+        let temporary = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(temporary_path)?;
+        if let Ok(metadata) = std::fs::metadata(target_path) {
+            std::fs::set_permissions(temporary_path, metadata.permissions())?;
+        }
+        Ok(temporary)
+    }
+
+    fn write_temp(&self, temporary: &mut File, content: &[u8]) -> io::Result<()> {
+        temporary.write_all(content)
+    }
+
+    fn flush_temp(&self, temporary: &File) -> io::Result<()> {
+        temporary.sync_all()
+    }
+
+    fn replace_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<()> {
+        replace_file(temporary_path, target_path)?;
+        sync_parent_directory(target_path)
+    }
+
+    fn target_fingerprint(&self, target_path: &Path) -> io::Result<Option<SourceFingerprint>> {
+        match std::fs::read(target_path) {
+            Ok(bytes) => Ok(Some(source_fingerprint(&bytes))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn remove_temp(&self, temporary_path: &Path) {
+        let _ = std::fs::remove_file(temporary_path);
+    }
+}
+
+fn ensure_parent_directory(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+fn sibling_temp_path(target: &Path, save_sequence: u64) -> PathBuf {
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = target
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "notebook".to_string());
+    target.with_file_name(format!(
+        ".{file_name}.{}-{save_sequence}-{counter}.checkpoint.tmp",
+        std::process::id()
+    ))
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    std::fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let mut source_wide: Vec<u16> = source.as_os_str().encode_wide().collect();
+    source_wide.push(0);
+    let mut destination_wide: Vec<u16> = destination.as_os_str().encode_wide().collect();
+    destination_wide.push(0);
+
+    // SAFETY: both paths are owned, NUL-terminated UTF-16 buffers that remain
+    // alive for the duration of the call.
+    let result = unsafe {
+        MoveFileExW(
+            source_wide.as_ptr(),
+            destination_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::{mpsc, Arc};
+    use std::thread;
+    use std::time::Duration;
+
+    #[derive(Default)]
+    struct CountingClock {
+        calls: AtomicUsize,
+    }
+
+    impl CountingClock {
+        fn calls(&self) -> usize {
+            self.calls.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    impl CheckpointClock for CountingClock {
+        fn now(&self) -> SystemTime {
+            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst) as u64;
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_000 + call)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct InjectedFailureIo {
+        failure: SaveIoStage,
+    }
+
+    impl CheckpointIo for InjectedFailureIo {
+        fn create_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<File> {
+            if self.failure == SaveIoStage::CreateTemp {
+                return Err(io::Error::other("injected create failure"));
+            }
+            RealCheckpointIo.create_temp(temporary_path, target_path)
+        }
+
+        fn write_temp(&self, temporary: &mut File, content: &[u8]) -> io::Result<()> {
+            if self.failure == SaveIoStage::WriteTemp {
+                return Err(io::Error::other("injected write failure"));
+            }
+            RealCheckpointIo.write_temp(temporary, content)
+        }
+
+        fn flush_temp(&self, temporary: &File) -> io::Result<()> {
+            if self.failure == SaveIoStage::FlushTemp {
+                return Err(io::Error::other("injected flush failure"));
+            }
+            RealCheckpointIo.flush_temp(temporary)
+        }
+
+        fn replace_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<()> {
+            if self.failure == SaveIoStage::Replace {
+                return Err(io::Error::other("injected replace failure"));
+            }
+            RealCheckpointIo.replace_temp(temporary_path, target_path)
+        }
+
+        fn remove_temp(&self, temporary_path: &Path) {
+            RealCheckpointIo.remove_temp(temporary_path);
+        }
+    }
+
+    struct BlockingFlushIo {
+        prepared: mpsc::Sender<()>,
+        release: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl CheckpointIo for BlockingFlushIo {
+        fn create_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<File> {
+            RealCheckpointIo.create_temp(temporary_path, target_path)
+        }
+
+        fn write_temp(&self, temporary: &mut File, content: &[u8]) -> io::Result<()> {
+            RealCheckpointIo.write_temp(temporary, content)
+        }
+
+        fn flush_temp(&self, temporary: &File) -> io::Result<()> {
+            RealCheckpointIo.flush_temp(temporary)?;
+            self.prepared
+                .send(())
+                .map_err(|_| io::Error::other("prepared receiver dropped"))?;
+            self.release
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .recv()
+                .map_err(|_| io::Error::other("release sender dropped"))?;
+            Ok(())
+        }
+
+        fn replace_temp(&self, temporary_path: &Path, target_path: &Path) -> io::Result<()> {
+            RealCheckpointIo.replace_temp(temporary_path, target_path)
+        }
+
+        fn remove_temp(&self, temporary_path: &Path) {
+            RealCheckpointIo.remove_temp(temporary_path);
+        }
+    }
+
+    fn target(path: &Path, head: u8, content: &[u8]) -> FileCheckpointTarget {
+        FileCheckpointTarget::for_content(path, vec![[head; 32]], content)
+    }
+
+    fn assert_blocked_at(outcome: SaveOutcome, expected_stage: SaveIoStage) {
+        assert!(matches!(
+            outcome,
+            SaveOutcome::Blocked {
+                save_sequence: Some(1),
+                reason: SaveBlockedReason::Io { stage, .. },
+            } if stage == expected_stage
+        ));
+    }
+
+    fn assert_no_commit(
+        coordinator: &FileCheckpointCoordinator,
+        clock: &CountingClock,
+        events: &mut broadcast::Receiver<FileCheckpointEvent>,
+    ) {
+        assert!(coordinator.checkpoint().is_none());
+        assert_eq!(clock.calls(), 0);
+        assert!(matches!(
+            events.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn successful_save_records_exact_causal_checkpoint_and_event() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let content = b"{\"cells\":[]}";
+        let target = target(&path, 9, content);
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let mut events = coordinator.subscribe();
+
+        let outcome = coordinator.save_with(target.clone(), content, &RealCheckpointIo, &clock);
+        let checkpoint = match outcome {
+            SaveOutcome::Saved { checkpoint } => checkpoint,
+            other => panic!("expected saved checkpoint, got {other:?}"),
+        };
+
+        assert_eq!(std::fs::read(&path).unwrap(), content);
+        assert_eq!(checkpoint.path, path);
+        assert_eq!(checkpoint.exported_heads, vec![[9; 32]]);
+        assert_eq!(checkpoint.file_fingerprint, source_fingerprint(content));
+        assert_eq!(checkpoint.save_sequence, 1);
+        assert_eq!(
+            checkpoint.saved_at,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_000)
+        );
+        assert_eq!(coordinator.checkpoint(), Some(checkpoint.clone()));
+        assert_eq!(events.try_recv().unwrap().checkpoint, checkpoint);
+        assert_eq!(clock.calls(), 1);
+    }
+
+    #[test]
+    fn already_current_advances_claim_but_not_checkpoint_timestamp_or_event() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let content = b"current";
+        let target = target(&path, 1, content);
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let mut events = coordinator.subscribe();
+
+        let saved = coordinator.save_with(target.clone(), content, &RealCheckpointIo, &clock);
+        let checkpoint = match saved {
+            SaveOutcome::Saved { checkpoint } => checkpoint,
+            other => panic!("expected initial save, got {other:?}"),
+        };
+        assert_eq!(events.try_recv().unwrap().checkpoint, checkpoint);
+
+        assert_eq!(
+            coordinator.save_with(target, content, &RealCheckpointIo, &clock),
+            SaveOutcome::AlreadyCurrent {
+                checkpoint: checkpoint.clone(),
+                claim_sequence: 2,
+            }
+        );
+        assert_eq!(coordinator.latest_claimed_sequence(), 2);
+        assert_eq!(coordinator.checkpoint(), Some(checkpoint));
+        assert_eq!(clock.calls(), 1);
+        assert!(matches!(
+            events.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn write_failure_does_not_advance_checkpoint_timestamp_or_event() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let content = b"new";
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let mut events = coordinator.subscribe();
+
+        let outcome = coordinator.save_with(
+            target(&path, 1, content),
+            content,
+            &InjectedFailureIo {
+                failure: SaveIoStage::WriteTemp,
+            },
+            &clock,
+        );
+
+        assert_blocked_at(outcome, SaveIoStage::WriteTemp);
+        assert_no_commit(&coordinator, &clock, &mut events);
+        assert!(!path.exists());
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn flush_failure_does_not_advance_checkpoint_timestamp_or_event() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let content = b"new";
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let mut events = coordinator.subscribe();
+
+        let outcome = coordinator.save_with(
+            target(&path, 1, content),
+            content,
+            &InjectedFailureIo {
+                failure: SaveIoStage::FlushTemp,
+            },
+            &clock,
+        );
+
+        assert_blocked_at(outcome, SaveIoStage::FlushTemp);
+        assert_no_commit(&coordinator, &clock, &mut events);
+        assert!(!path.exists());
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn replace_failure_preserves_old_file_and_does_not_advance_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        std::fs::write(&path, b"old").unwrap();
+        let content = b"new";
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let mut events = coordinator.subscribe();
+
+        let outcome = coordinator.save_with(
+            target(&path, 1, content),
+            content,
+            &InjectedFailureIo {
+                failure: SaveIoStage::Replace,
+            },
+            &clock,
+        );
+
+        assert_blocked_at(outcome, SaveIoStage::Replace);
+        assert_no_commit(&coordinator, &clock, &mut events);
+        assert_eq!(std::fs::read(&path).unwrap(), b"old");
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn journal_commit_failure_keeps_replaced_file_but_emits_no_checkpoint() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        std::fs::write(&path, b"old").unwrap();
+        let content = b"new";
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let mut events = coordinator.subscribe();
+        let claim = coordinator.claim(target(&path, 1, content)).unwrap();
+
+        let outcome =
+            coordinator.complete_with_commit(claim, content, &RealCheckpointIo, &clock, |_| {
+                Err("injected journal failure".to_string())
+            });
+
+        assert_eq!(
+            outcome,
+            SaveOutcome::Blocked {
+                save_sequence: Some(1),
+                reason: SaveBlockedReason::Commit {
+                    message: "injected journal failure".to_string(),
+                },
+            }
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), content);
+        assert!(coordinator.checkpoint().is_none());
+        assert!(matches!(
+            events.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+        assert_eq!(clock.calls(), 1);
+    }
+
+    #[test]
+    fn newer_save_claim_blocks_older_completion_before_replace() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let old_content = b"old completion".to_vec();
+        let new_content = b"new completion".to_vec();
+        let coordinator = Arc::new(FileCheckpointCoordinator::default());
+        let clock = Arc::new(CountingClock::default());
+        let mut events = coordinator.subscribe();
+        let (prepared_tx, prepared_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let old_io = BlockingFlushIo {
+            prepared: prepared_tx,
+            release: Mutex::new(release_rx),
+        };
+        let old_claim = coordinator.claim(target(&path, 1, &old_content)).unwrap();
+
+        let old_coordinator = Arc::clone(&coordinator);
+        let old_clock = Arc::clone(&clock);
+        let old_thread = thread::spawn(move || {
+            old_coordinator.complete_with(old_claim, &old_content, &old_io, old_clock.as_ref())
+        });
+
+        prepared_rx.recv().unwrap();
+        let new_claim = coordinator.claim(target(&path, 2, &new_content)).unwrap();
+        let new_outcome =
+            coordinator.complete_with(new_claim, &new_content, &RealCheckpointIo, clock.as_ref());
+        let new_checkpoint = match new_outcome {
+            SaveOutcome::Saved { checkpoint } => checkpoint,
+            other => panic!("expected newer save to commit, got {other:?}"),
+        };
+        release_tx.send(()).unwrap();
+        let old_outcome = old_thread.join().unwrap();
+
+        assert_eq!(
+            old_outcome,
+            SaveOutcome::Blocked {
+                save_sequence: Some(1),
+                reason: SaveBlockedReason::Superseded { latest_sequence: 2 },
+            }
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), new_content);
+        assert_eq!(new_checkpoint.save_sequence, 2);
+        assert_eq!(new_checkpoint.exported_heads, vec![[2; 32]]);
+        assert_eq!(coordinator.checkpoint(), Some(new_checkpoint.clone()));
+        assert_eq!(events.try_recv().unwrap().checkpoint, new_checkpoint);
+        assert!(matches!(
+            events.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+        assert_eq!(clock.calls(), 1);
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn restored_checkpoint_continues_monotonic_sequence_claims() {
+        let initial = FileCheckpoint {
+            path: PathBuf::from("/tmp/notebook.ipynb"),
+            exported_heads: vec![[4; 32]],
+            file_fingerprint: source_fingerprint(b"old"),
+            save_sequence: 41,
+            saved_at: SystemTime::UNIX_EPOCH,
+        };
+        let coordinator = FileCheckpointCoordinator::new(Some(initial));
+
+        let claim = coordinator
+            .claim(FileCheckpointTarget::for_content(
+                "/tmp/notebook.ipynb",
+                vec![[5; 32]],
+                b"new",
+            ))
+            .unwrap();
+
+        assert_eq!(claim.sequence(), 42);
+        assert_eq!(coordinator.latest_claimed_sequence(), 42);
+        assert_eq!(claim.target().exported_heads, vec![[5; 32]]);
+    }
+
+    #[test]
+    fn unsettled_newer_reservation_does_not_supersede_existing_checkpoint() {
+        let coordinator = FileCheckpointCoordinator::default();
+        let old_reservation = coordinator.reserve().unwrap();
+        let _new_reservation = coordinator.reserve().unwrap();
+        let checkpoint = FileCheckpoint {
+            path: PathBuf::from("/tmp/notebook.ipynb"),
+            exported_heads: vec![[1; 32]],
+            file_fingerprint: source_fingerprint(b"disk"),
+            save_sequence: old_reservation.sequence(),
+            saved_at: SystemTime::UNIX_EPOCH,
+        };
+        let mut commit_called = false;
+
+        let result = coordinator.commit_existing_with(old_reservation, checkpoint, |_| {
+            commit_called = true;
+            Ok(())
+        });
+
+        assert_eq!(result, Ok(()));
+        assert!(commit_called);
+        assert!(coordinator.checkpoint().is_some());
+    }
+
+    #[test]
+    fn failed_newer_preparation_does_not_burn_older_viable_save() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let coordinator = FileCheckpointCoordinator::default();
+        let clock = CountingClock::default();
+        let old_content = b"older viable content";
+        let new_content = b"newer declared content";
+        let old_claim = coordinator.claim(target(&path, 1, old_content)).unwrap();
+        let new_claim = coordinator.claim(target(&path, 2, new_content)).unwrap();
+
+        assert!(matches!(
+            coordinator.complete_with(
+                new_claim,
+                b"different prepared bytes",
+                &RealCheckpointIo,
+                &clock,
+            ),
+            SaveOutcome::Blocked {
+                save_sequence: Some(2),
+                reason: SaveBlockedReason::ContentFingerprintMismatch { .. },
+            }
+        ));
+
+        let old = coordinator.complete_with(old_claim, old_content, &RealCheckpointIo, &clock);
+        assert!(matches!(old, SaveOutcome::Saved { .. }));
+        assert_eq!(std::fs::read(&path).unwrap(), old_content);
+    }
+
+    #[test]
+    fn reconciliation_refuses_to_replace_a_newer_external_revision() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("notebook.ipynb");
+        let selected_revision = b"revision user selected";
+        let later_revision = b"later external edit";
+        let recovered_content = b"recovered notebook";
+        std::fs::write(&path, selected_revision).unwrap();
+        let coordinator = FileCheckpointCoordinator::default();
+        let target = target(&path, 3, recovered_content)
+            .requiring_existing_fingerprint(source_fingerprint(selected_revision));
+        let claim = coordinator.claim(target).unwrap();
+
+        std::fs::write(&path, later_revision).unwrap();
+        let outcome = coordinator.complete_with(
+            claim,
+            recovered_content,
+            &RealCheckpointIo,
+            &CountingClock::default(),
+        );
+
+        assert!(matches!(
+            outcome,
+            SaveOutcome::Blocked {
+                save_sequence: Some(1),
+                reason: SaveBlockedReason::ExistingContentChanged {
+                    expected,
+                    actual: Some(actual),
+                },
+            } if expected == source_fingerprint(selected_revision)
+                && actual == source_fingerprint(later_revision)
+        ));
+        assert_eq!(std::fs::read(&path).unwrap(), later_revision);
+        assert!(coordinator.checkpoint().is_none());
+    }
+
+    #[test]
+    fn existing_source_checkpoint_commits_without_emitting_a_saved_event() {
+        let coordinator = FileCheckpointCoordinator::default();
+        let reservation = coordinator.reserve().unwrap();
+        let checkpoint = FileCheckpoint {
+            path: PathBuf::from("/tmp/notebook.ipynb"),
+            exported_heads: vec![[7; 32]],
+            file_fingerprint: source_fingerprint(b"disk"),
+            save_sequence: reservation.sequence(),
+            saved_at: SystemTime::UNIX_EPOCH,
+        };
+        let mut events = coordinator.subscribe();
+
+        let committed = coordinator
+            .commit_existing_with(reservation, checkpoint.clone(), |_| Ok(7))
+            .unwrap();
+
+        assert_eq!(committed, 7);
+        assert_eq!(coordinator.checkpoint(), Some(checkpoint));
+        assert!(matches!(
+            events.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -51,6 +51,13 @@ mod attachments;
 mod blob_upload;
 mod catalog;
 mod comments_store;
+// The coordinator is wired into room mutation paths after the standalone
+// journal and checkpoint primitives.
+#[allow(dead_code)]
+pub(crate) mod durability;
+// The checkpoint primitive intentionally lands before persistence integration.
+#[allow(dead_code)]
+pub(crate) mod file_checkpoint;
 mod hosted_bridge;
 mod identity;
 mod load;
@@ -72,6 +79,9 @@ mod peer_writer;
 mod persist;
 mod project_context;
 mod projection;
+// The journal primitive intentionally lands before room integration.
+#[allow(dead_code)]
+pub(crate) mod recovery;
 mod registry;
 mod room;
 mod runtime_bridge;

--- a/crates/runtimed/src/notebook_sync_server/recovery.rs
+++ b/crates/runtimed/src/notebook_sync_server/recovery.rs
@@ -1,0 +1,2196 @@
+//! Crash-safe, append-only recovery journal primitives for file-backed rooms.
+//!
+//! The journal stores complete Automerge snapshots rather than incremental
+//! changes. Each record is independently checksummed, so recovery can stop at
+//! a torn or corrupt tail and use the last complete record. Callers must
+//! serialize append and compaction operations for a journal path.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::paths::notebook_doc_filename;
+
+const RECORD_MAGIC: [u8; 8] = *b"NTRJNL01";
+const RECORD_FORMAT_VERSION: u16 = 1;
+pub(crate) const RECOVERY_MANIFEST_VERSION: u16 = 1;
+
+const HEADER_PREFIX_LEN: usize = 8 + 2 + 4 + 8;
+const CHECKSUM_LEN: usize = 32;
+const HEADER_LEN: usize = HEADER_PREFIX_LEN + CHECKSUM_LEN;
+const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+const MAX_AUTOMERGE_SNAPSHOT_BYTES: usize = 256 * 1024 * 1024;
+const MAX_RECORD_BYTES: usize = HEADER_LEN + MAX_MANIFEST_BYTES + MAX_AUTOMERGE_SNAPSHOT_BYTES;
+/// Full snapshots keep recovery simple and independently checksummed, but the
+/// active journal must remain bounded on mutation-heavy rooms.
+const COMPACT_AFTER_RECORDS: usize = 32;
+const COMPACT_AFTER_BYTES: u64 = 64 * 1024 * 1024;
+
+/// SHA-256 of the exact source `.ipynb` bytes associated with a recovery
+/// generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct SourceFingerprint([u8; 32]);
+
+impl SourceFingerprint {
+    pub(crate) fn from_content(bytes: &[u8]) -> Self {
+        Self(Sha256::digest(bytes).into())
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub(crate) fn to_hex(self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+/// Compute the content fingerprint used to distinguish a matching source file
+/// from an externally edited one.
+pub(crate) fn source_fingerprint(bytes: &[u8]) -> SourceFingerprint {
+    SourceFingerprint::from_content(bytes)
+}
+
+/// Durable progress of the file-backed source generation represented by a
+/// journal record. This is independent from whether a previous process had
+/// already exposed all batches to its then-connected peers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecoverySourcePhase {
+    /// No immutable source generation has reached the journal yet.
+    #[default]
+    Pending,
+    /// The exact staged source changes are durable. Restart may finalize this
+    /// generation, but must not regenerate it with a new actor/history.
+    DurablyStaged,
+    /// Source publication and its runtime-sidecar reconstruction completed.
+    Ready,
+    /// A source task failed before becoming durably staged.
+    Failed,
+}
+
+/// Durable intent written before atomically replacing a notebook file.
+///
+/// A crash can otherwise leave the new `.ipynb` bytes visible while the
+/// journal still names the previous fingerprint, manufacturing a source
+/// conflict on restart. Recovery accepts either the old fingerprint (replace
+/// never happened) or this intended fingerprint (replace happened), then
+/// appends the corresponding abort/final checkpoint marker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PendingFileCheckpoint {
+    pub(crate) canonical_path: PathBuf,
+    pub(crate) file_fingerprint: SourceFingerprint,
+    pub(crate) exported_heads: Vec<[u8; 32]>,
+    pub(crate) save_sequence: u64,
+    #[serde(default)]
+    pub(crate) source_generation: Option<u64>,
+}
+
+/// Versioned causal metadata stored beside every full Automerge snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RecoveryManifest {
+    pub(crate) version: u16,
+    pub(crate) sequence: u64,
+    pub(crate) notebook_id: Uuid,
+    pub(crate) canonical_path: Option<PathBuf>,
+    /// NotebookDoc schema version represented by `automerge_snapshot`.
+    /// This is independent from the journal manifest and record formats.
+    pub(crate) notebook_schema_version: u64,
+    pub(crate) source_fingerprint: SourceFingerprint,
+    pub(crate) source_generation: u64,
+    #[serde(default)]
+    pub(crate) source_phase: RecoverySourcePhase,
+    pub(crate) staged_change_hashes: Vec<[u8; 32]>,
+    /// Peer-authored changes durably accepted after (or concurrently with)
+    /// source publication. Recovery uses this evidence to forbid implicit
+    /// source regeneration over collaborative work.
+    #[serde(default)]
+    pub(crate) peer_change_hashes: Vec<[u8; 32]>,
+    pub(crate) durable_heads: Vec<[u8; 32]>,
+    pub(crate) exported_heads: Vec<[u8; 32]>,
+    #[serde(default)]
+    pub(crate) file_save_sequence: Option<u64>,
+    #[serde(default)]
+    pub(crate) pending_file_checkpoint: Option<PendingFileCheckpoint>,
+}
+
+impl RecoveryManifest {
+    pub(crate) fn new(
+        sequence: u64,
+        notebook_id: Uuid,
+        canonical_path: Option<PathBuf>,
+        notebook_schema_version: u64,
+        source_fingerprint: SourceFingerprint,
+        source_generation: u64,
+    ) -> Self {
+        Self {
+            version: RECOVERY_MANIFEST_VERSION,
+            sequence,
+            notebook_id,
+            canonical_path,
+            notebook_schema_version,
+            source_fingerprint,
+            source_generation,
+            source_phase: RecoverySourcePhase::Pending,
+            staged_change_hashes: Vec::new(),
+            peer_change_hashes: Vec::new(),
+            durable_heads: Vec::new(),
+            exported_heads: Vec::new(),
+            file_save_sequence: None,
+            pending_file_checkpoint: None,
+        }
+    }
+
+    fn validate(&self) -> Result<(), RecoveryJournalError> {
+        if self.version != RECOVERY_MANIFEST_VERSION {
+            return Err(RecoveryJournalError::UnsupportedManifestVersion {
+                version: self.version,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// One independently recoverable journal record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoveryRecord {
+    pub(crate) manifest: RecoveryManifest,
+    pub(crate) automerge_snapshot: Vec<u8>,
+}
+
+/// A corrupt or incomplete suffix ignored after the newest valid record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum JournalTailIssue {
+    TruncatedHeader {
+        offset: u64,
+        available: u64,
+    },
+    InvalidMagic {
+        offset: u64,
+    },
+    UnsupportedRecordVersion {
+        offset: u64,
+        version: u16,
+    },
+    InvalidLengths {
+        offset: u64,
+        manifest_len: u64,
+        snapshot_len: u64,
+    },
+    TruncatedPayload {
+        offset: u64,
+        expected: u64,
+        available: u64,
+    },
+    ChecksumMismatch {
+        offset: u64,
+    },
+    InvalidManifest {
+        offset: u64,
+        reason: String,
+    },
+    UnsupportedManifestVersion {
+        offset: u64,
+        version: u16,
+    },
+}
+
+impl JournalTailIssue {
+    fn is_unsupported_version(&self) -> bool {
+        matches!(
+            self,
+            Self::UnsupportedRecordVersion { .. } | Self::UnsupportedManifestVersion { .. }
+        )
+    }
+
+    /// Only byte-short EOF records are unambiguously torn appends. Semantic
+    /// corruption (bad checksum/magic/manifest/length) may sit in the middle
+    /// of otherwise valid data, so truncating it would silently destroy
+    /// evidence and any valid suffix.
+    pub(crate) fn is_repairable_torn_suffix(&self) -> bool {
+        matches!(
+            self,
+            Self::TruncatedHeader { .. } | Self::TruncatedPayload { .. }
+        )
+    }
+}
+
+/// Why no complete recovery record could be returned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryUnavailableReason {
+    MissingJournal,
+    EmptyJournal,
+    NoValidRecord { tail: JournalTailIssue },
+}
+
+/// A valid record plus any ignored suffix that followed it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoveredJournalRecord {
+    pub(crate) record: RecoveryRecord,
+    pub(crate) ignored_tail: Option<JournalTailIssue>,
+}
+
+/// Recovery classification against the exact bytes currently on disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryLoadOutcome {
+    Match(RecoveredJournalRecord),
+    SourceConflict {
+        recovery: RecoveredJournalRecord,
+        current_source_fingerprint: SourceFingerprint,
+    },
+    Unavailable {
+        reason: RecoveryUnavailableReason,
+    },
+}
+
+/// Latest authoritative record from a journal, without comparing it to a
+/// source file. This is used to recover the room identity when the auxiliary
+/// path registry is missing or unavailable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryLatestOutcome {
+    Recovered(Box<RecoveredJournalRecord>),
+    Unavailable { reason: RecoveryUnavailableReason },
+}
+
+/// Result of searching the room recovery directory for a canonical path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryJournalDiscovery {
+    NotFound,
+    Found {
+        notebook_id: Uuid,
+        journal_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum RecoveryJournalDiscoveryError {
+    #[error("could not inspect recovery directory {directory}: {source}")]
+    Directory {
+        directory: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("could not inspect recovery journal {journal}: {source}")]
+    Journal {
+        journal: PathBuf,
+        #[source]
+        source: Box<RecoveryJournalError>,
+    },
+    #[error(
+        "recovery journal {journal} claims notebook {notebook_id}, but that identity belongs at {expected}"
+    )]
+    MisboundJournal {
+        notebook_id: Uuid,
+        journal: PathBuf,
+        expected: PathBuf,
+    },
+    #[error(
+        "multiple recovery journals claim canonical notebook path {canonical_path}: {candidates:?}"
+    )]
+    AmbiguousPath {
+        canonical_path: PathBuf,
+        candidates: Vec<(Uuid, PathBuf)>,
+    },
+}
+
+/// Durable append coordinates useful for fault injection and future journal
+/// checkpointing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JournalAppendReceipt {
+    pub(crate) start_offset: u64,
+    pub(crate) end_offset: u64,
+    pub(crate) checksum: [u8; 32],
+    pub(crate) manifest_index: RecoveryManifestIndex,
+}
+
+/// Status of the non-authoritative JSON index for the newest journal record.
+///
+/// The checksummed append-only record is the commit point. An index failure
+/// must never turn a committed batch into an apparent failure: doing so could
+/// make callers roll back or withhold an acknowledgement even though recovery
+/// would replay the batch after restart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryManifestIndex {
+    Updated,
+    Stale { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryCompactionOutcome {
+    Compacted {
+        record: Box<RecoveryRecord>,
+        bytes_before: u64,
+        bytes_after: u64,
+        manifest_index: RecoveryManifestIndex,
+    },
+    Unavailable {
+        reason: RecoveryUnavailableReason,
+    },
+}
+
+/// The durably published copy of an archived recovery journal.
+///
+/// Archives are directories so the authoritative journal and its optional
+/// manifest sidecar become visible under one unique path at the same instant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoveryArchivePaths {
+    pub(crate) directory: PathBuf,
+    pub(crate) journal: PathBuf,
+    pub(crate) manifest: Option<PathBuf>,
+}
+
+/// Whether retiring the active journal name was durably flushed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryArchiveDurability {
+    Durable,
+    /// The atomic retirement succeeded, but a directory flush failed. The
+    /// archive still preserves the journal bytes, while crash-time selection
+    /// between the active and retired names is uncertain.
+    Uncertain {
+        reason: String,
+    },
+}
+
+/// The manifest is an inspectability index, not recovery authority. Its
+/// retirement is therefore best-effort after the journal commit point.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryArchiveSidecar {
+    NotPresent,
+    Retired,
+    RetainedActive { reason: String },
+}
+
+/// Result of archiving a journal.
+///
+/// `JournalRetired` is the commit point: the active journal path no longer
+/// exists and disk reload may become authoritative. Any returned error means
+/// that the active journal was left in place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryArchiveOutcome {
+    JournalRetired {
+        archive: RecoveryArchivePaths,
+        durability: RecoveryArchiveDurability,
+        sidecar: RecoveryArchiveSidecar,
+    },
+    Unavailable {
+        reason: RecoveryUnavailableReason,
+    },
+}
+
+/// Result of preserving the old active journal and atomically replacing it
+/// with one reconciled record. Unlike [`RecoveryArchiveOutcome`], the active
+/// name is never intentionally absent at a successful boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoveryArchiveReplacement {
+    pub(crate) archive: RecoveryArchivePaths,
+    pub(crate) durability_warning: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum RecoveryJournalError {
+    #[error("recovery journal I/O failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("recovery manifest serialization failed: {0}")]
+    ManifestSerialization(#[from] serde_json::Error),
+    #[error("unsupported recovery manifest version {version}")]
+    UnsupportedManifestVersion { version: u16 },
+    #[error("Automerge recovery snapshot is empty")]
+    EmptySnapshot,
+    #[error("recovery manifest is {actual} bytes; maximum is {maximum}")]
+    ManifestTooLarge { actual: usize, maximum: usize },
+    #[error("Automerge recovery snapshot is {actual} bytes; maximum is {maximum}")]
+    SnapshotTooLarge { actual: usize, maximum: usize },
+    #[error("encoded recovery record is {actual} bytes; maximum is {maximum}")]
+    RecordTooLarge { actual: usize, maximum: usize },
+    #[error("journal contains no valid record before corrupt tail: {tail:?}")]
+    NoValidRecord { tail: JournalTailIssue },
+    #[error("refusing to rewrite recovery data from a newer format: {tail:?}")]
+    UnsupportedTailVersion { tail: JournalTailIssue },
+    #[error("refusing to truncate corrupt recovery data without reconciliation: {tail:?}")]
+    CorruptTailRequiresReconciliation { tail: JournalTailIssue },
+    #[error(
+        "recovery archive was published at {archive:?}, but the active journal was not retired: {source}"
+    )]
+    ArchiveNotCommitted {
+        archive: RecoveryArchivePaths,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Filesystem-backed append-only journal.
+#[derive(Debug, Clone)]
+pub(crate) struct RecoveryJournal {
+    path: PathBuf,
+    /// Process-local append cursor. The journal path is room-owned, and clones
+    /// share this cache so ordinary appends do not re-read and re-hash every
+    /// previous full snapshot. A length or modification-time mismatch forces
+    /// a complete rescan, preserving externally corrupted same-length data.
+    append_cursor: Arc<Mutex<Option<JournalAppendCursor>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct JournalAppendCursor {
+    file_len: u64,
+    modified: Option<std::time::SystemTime>,
+    last_valid_end: u64,
+    valid_record_count: usize,
+}
+
+impl RecoveryJournal {
+    pub(crate) fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            append_cursor: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Atomically replaced index for the newest committed journal record.
+    ///
+    /// The append-only journal remains the recovery authority. This sidecar
+    /// makes the latest identity/fingerprint/head metadata directly
+    /// inspectable without weakening torn-tail recovery: it is replaced only
+    /// after the corresponding checksummed record has been flushed.
+    pub(crate) fn manifest_path(&self) -> PathBuf {
+        let file_name = self
+            .path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "room.recovery".to_string());
+        self.path
+            .with_file_name(format!("{file_name}.manifest.json"))
+    }
+
+    /// Append one full snapshot and flush it before returning.
+    ///
+    /// A torn suffix after an older valid record is truncated and flushed
+    /// before the new record is written. A wholly corrupt journal or a record
+    /// from a newer format is never overwritten implicitly.
+    pub(crate) fn append(
+        &self,
+        manifest: &RecoveryManifest,
+        automerge_snapshot: &[u8],
+    ) -> Result<JournalAppendReceipt, RecoveryJournalError> {
+        self.append_with_directory_sync(manifest, automerge_snapshot, sync_directory)
+    }
+
+    fn append_with_directory_sync<SyncDirectory>(
+        &self,
+        manifest: &RecoveryManifest,
+        automerge_snapshot: &[u8],
+        mut sync_directory: SyncDirectory,
+    ) -> Result<JournalAppendReceipt, RecoveryJournalError>
+    where
+        SyncDirectory: FnMut(&Path) -> io::Result<()>,
+    {
+        let mut append_cursor = self
+            .append_cursor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let encoded = encode_record(manifest, automerge_snapshot)?;
+        ensure_parent_directory(&self.path)?;
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.path)?;
+
+        // Establish the complete directory chain and the new journal name
+        // before writing its first record. An unsuccessful directory flush
+        // leaves the file empty, so the next append retries every required
+        // flush instead of mistaking mere pathname existence for durability.
+        let metadata = file.metadata()?;
+        if metadata.len() == 0 {
+            sync_pathname_directory_chain(&self.path, &mut sync_directory)?;
+        }
+        let file_len = metadata.len();
+        let file_modified = metadata.modified().ok();
+        let (last_valid_end, valid_record_count, ignored_tail, has_valid_record) =
+            match append_cursor.as_ref().filter(|cursor| {
+                cursor.file_len == file_len
+                    && cursor.modified.is_some()
+                    && cursor.modified == file_modified
+            }) {
+                Some(cursor) => (
+                    cursor.last_valid_end,
+                    cursor.valid_record_count,
+                    None,
+                    cursor.valid_record_count > 0,
+                ),
+                None => {
+                    let scan = scan_file(&mut file)?;
+                    (
+                        scan.last_valid_end,
+                        scan.valid_record_count,
+                        scan.ignored_tail,
+                        scan.latest.is_some(),
+                    )
+                }
+            };
+
+        if let Some(tail) = &ignored_tail {
+            if tail.is_unsupported_version() {
+                return Err(RecoveryJournalError::UnsupportedTailVersion { tail: tail.clone() });
+            }
+            if !has_valid_record {
+                return Err(RecoveryJournalError::NoValidRecord { tail: tail.clone() });
+            }
+            if !tail.is_repairable_torn_suffix() {
+                return Err(RecoveryJournalError::CorruptTailRequiresReconciliation {
+                    tail: tail.clone(),
+                });
+            }
+            file.set_len(last_valid_end)?;
+            file.sync_all()?;
+        }
+
+        let start_offset = last_valid_end;
+        file.seek(SeekFrom::Start(start_offset))?;
+        file.write_all(&encoded.bytes)?;
+        file.sync_all()?;
+        drop(file);
+
+        // The record above is the durable batch marker. The manifest is only
+        // an inspectability index, so its replacement is deliberately
+        // best-effort after that commit point. Returning an error here would
+        // invite callers to roll back an already durable batch and let restart
+        // replay work that was never acknowledged.
+        let manifest_index = match serde_json::to_vec(manifest)
+            .map_err(RecoveryJournalError::from)
+            .and_then(|bytes| {
+                replace_file_atomically(&self.manifest_path(), &bytes)
+                    .map_err(RecoveryJournalError::from)
+            }) {
+            Ok(()) => RecoveryManifestIndex::Updated,
+            Err(error) => RecoveryManifestIndex::Stale {
+                reason: error.to_string(),
+            },
+        };
+
+        let encoded_len = u64::try_from(encoded.bytes.len()).map_err(|_| {
+            RecoveryJournalError::RecordTooLarge {
+                actual: encoded.bytes.len(),
+                maximum: MAX_RECORD_BYTES,
+            }
+        })?;
+        let appended_end = start_offset + encoded_len;
+        let appended_record_count = valid_record_count.saturating_add(1);
+        let should_compact =
+            appended_record_count >= COMPACT_AFTER_RECORDS || appended_end >= COMPACT_AFTER_BYTES;
+        let (active_start, active_end, active_record_count) = if should_compact {
+            // The just-appended record is already the newest complete record.
+            // Replacing the active file with those same encoded bytes is a
+            // crash-safe production compaction and avoids a second full scan.
+            match replace_file_atomically(&self.path, &encoded.bytes) {
+                Ok(()) => (0, encoded_len, 1),
+                Err(error) => {
+                    // The append above is already the durable commit point.
+                    // Compaction is maintenance; failing it must not invite a
+                    // caller to roll back a batch restart will replay.
+                    tracing::warn!(
+                        "[notebook-sync] Recovery journal compaction deferred for {}: {}",
+                        self.path.display(),
+                        error
+                    );
+                    (start_offset, appended_end, appended_record_count)
+                }
+            }
+        } else {
+            (start_offset, appended_end, appended_record_count)
+        };
+        *append_cursor = Some(JournalAppendCursor {
+            file_len: active_end,
+            modified: std::fs::metadata(&self.path)
+                .and_then(|metadata| metadata.modified())
+                .ok(),
+            last_valid_end: active_end,
+            valid_record_count: active_record_count,
+        });
+
+        Ok(JournalAppendReceipt {
+            start_offset: active_start,
+            end_offset: active_end,
+            checksum: encoded.checksum,
+            manifest_index,
+        })
+    }
+
+    /// Load the last complete valid record without consulting a source file.
+    ///
+    /// Identity discovery uses this authoritative scan rather than the
+    /// best-effort manifest sidecar. A valid record followed by a torn tail is
+    /// still recoverable and reports that tail on the returned record.
+    pub(crate) fn latest_record(&self) -> Result<RecoveryLatestOutcome, RecoveryJournalError> {
+        let mut file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(RecoveryLatestOutcome::Unavailable {
+                    reason: RecoveryUnavailableReason::MissingJournal,
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let scan = scan_file(&mut file)?;
+        let Some(record) = scan.latest else {
+            let reason = match scan.ignored_tail {
+                Some(tail) => RecoveryUnavailableReason::NoValidRecord { tail },
+                None => RecoveryUnavailableReason::EmptyJournal,
+            };
+            return Ok(RecoveryLatestOutcome::Unavailable { reason });
+        };
+
+        Ok(RecoveryLatestOutcome::Recovered(Box::new(
+            RecoveredJournalRecord {
+                record,
+                ignored_tail: scan.ignored_tail,
+            },
+        )))
+    }
+
+    /// Load the last complete valid record and compare its source fingerprint
+    /// with the exact current source bytes.
+    pub(crate) fn load(
+        &self,
+        current_source_fingerprint: SourceFingerprint,
+    ) -> Result<RecoveryLoadOutcome, RecoveryJournalError> {
+        let recovery = match self.latest_record()? {
+            RecoveryLatestOutcome::Recovered(recovery) => *recovery,
+            RecoveryLatestOutcome::Unavailable { reason } => {
+                return Ok(RecoveryLoadOutcome::Unavailable { reason });
+            }
+        };
+
+        let matches_source = recovery.record.manifest.source_fingerprint
+            == current_source_fingerprint
+            || recovery
+                .record
+                .manifest
+                .pending_file_checkpoint
+                .as_ref()
+                .is_some_and(|pending| pending.file_fingerprint == current_source_fingerprint);
+        if matches_source {
+            Ok(RecoveryLoadOutcome::Match(recovery))
+        } else {
+            Ok(RecoveryLoadOutcome::SourceConflict {
+                recovery,
+                current_source_fingerprint,
+            })
+        }
+    }
+
+    /// Preserve the active journal under a unique archival path, then retire
+    /// the active journal name atomically.
+    ///
+    /// The complete archive is copied, flushed, and published before the
+    /// authoritative journal is moved over that copy. The move is the commit
+    /// point: failures before it leave the active journal untouched; after it,
+    /// this method always returns `JournalRetired`. The manifest sidecar is
+    /// moved only after that commit and is best-effort because it is not the
+    /// recovery authority.
+    ///
+    /// Callers must serialize this operation with appends and compaction for
+    /// the same path.
+    pub(crate) fn archive(&self) -> Result<RecoveryArchiveOutcome, RecoveryJournalError> {
+        self.archive_with(|| Ok(()), replace_file)
+    }
+
+    /// Preserve the current journal and sidecar in a uniquely published
+    /// archive directory while leaving the active names untouched.
+    fn publish_archive_copy(&self) -> Result<RecoveryArchivePaths, RecoveryJournalError> {
+        match File::open(&self.path) {
+            Ok(file) => drop(file),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Err(RecoveryJournalError::Io(error));
+            }
+            Err(error) => return Err(error.into()),
+        }
+
+        let active_manifest = self.manifest_path();
+        let manifest_present = active_manifest.try_exists()?;
+        let (staging_directory, archive) =
+            create_archive_staging_directory(&self.path, manifest_present)?;
+        let staging_journal = staging_directory.join(
+            archive
+                .journal
+                .file_name()
+                .unwrap_or_else(|| std::ffi::OsStr::new("room.recovery")),
+        );
+        let staging_manifest = archive.manifest.as_ref().map(|path| {
+            staging_directory.join(
+                path.file_name()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("room.recovery.manifest.json")),
+            )
+        });
+
+        let stage_result = (|| {
+            copy_file_durably(&self.path, &staging_journal)?;
+            if let Some(staging_manifest) = &staging_manifest {
+                copy_file_durably(&active_manifest, staging_manifest)?;
+            }
+            sync_directory(&staging_directory)?;
+            std::fs::rename(&staging_directory, &archive.directory)?;
+            sync_parent_directory(&archive.directory)
+        })();
+
+        if let Err(source) = stage_result {
+            if staging_directory.exists() {
+                let _ = std::fs::remove_dir_all(&staging_directory);
+                return Err(source.into());
+            }
+            return Err(RecoveryJournalError::ArchiveNotCommitted { archive, source });
+        }
+        Ok(archive)
+    }
+
+    fn archive_with<BeforeRetire, RetireSidecar>(
+        &self,
+        before_journal_retire: BeforeRetire,
+        retire_sidecar: RetireSidecar,
+    ) -> Result<RecoveryArchiveOutcome, RecoveryJournalError>
+    where
+        BeforeRetire: FnOnce() -> io::Result<()>,
+        RetireSidecar: FnOnce(&Path, &Path) -> io::Result<()>,
+    {
+        if !self.path.try_exists()? {
+            return Ok(RecoveryArchiveOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::MissingJournal,
+            });
+        }
+        let active_manifest = self.manifest_path();
+        let archive = self.publish_archive_copy()?;
+
+        if let Err(source) = before_journal_retire() {
+            return Err(RecoveryJournalError::ArchiveNotCommitted { archive, source });
+        }
+        if let Err(source) = replace_file(&self.path, &archive.journal) {
+            return Err(RecoveryJournalError::ArchiveNotCommitted { archive, source });
+        }
+
+        // The active journal name is gone from this point onward. Do not turn
+        // later sidecar or fsync failures into an error that could be mistaken
+        // for a pre-commit failure.
+        let mut durability_issues = Vec::new();
+        if let Err(error) = sync_directory(&archive.directory) {
+            durability_issues.push(format!("archive directory flush failed: {error}"));
+        }
+        if let Err(error) = sync_parent_directory(&self.path) {
+            durability_issues.push(format!("active directory flush failed: {error}"));
+        }
+        let durability = if durability_issues.is_empty() {
+            RecoveryArchiveDurability::Durable
+        } else {
+            RecoveryArchiveDurability::Uncertain {
+                reason: durability_issues.join("; "),
+            }
+        };
+
+        let sidecar = match &archive.manifest {
+            None => RecoveryArchiveSidecar::NotPresent,
+            Some(archived_manifest) => match retire_sidecar(&active_manifest, archived_manifest) {
+                Ok(()) => RecoveryArchiveSidecar::Retired,
+                Err(_error) if !active_manifest.exists() => RecoveryArchiveSidecar::Retired,
+                Err(error) => RecoveryArchiveSidecar::RetainedActive {
+                    reason: error.to_string(),
+                },
+            },
+        };
+
+        Ok(RecoveryArchiveOutcome::JournalRetired {
+            archive,
+            durability,
+            sidecar,
+        })
+    }
+
+    /// Preserve the current active journal, then atomically replace the active
+    /// name with one reconciled record.
+    ///
+    /// The replacement bytes are fully encoded before the archive copy is
+    /// published. A failure before atomic replacement leaves the old active
+    /// journal in place; a failure reported after replacement is recognized by
+    /// its exact bytes and returned as a durability warning. There is no
+    /// successful or retryable boundary where the active name is absent.
+    pub(crate) fn archive_and_replace(
+        &self,
+        manifest: &RecoveryManifest,
+        automerge_snapshot: &[u8],
+    ) -> Result<RecoveryArchiveReplacement, RecoveryJournalError> {
+        self.archive_and_replace_with(manifest, automerge_snapshot, replace_file_atomically)
+    }
+
+    fn archive_and_replace_with<ReplaceActive>(
+        &self,
+        manifest: &RecoveryManifest,
+        automerge_snapshot: &[u8],
+        replace_active: ReplaceActive,
+    ) -> Result<RecoveryArchiveReplacement, RecoveryJournalError>
+    where
+        ReplaceActive: FnOnce(&Path, &[u8]) -> io::Result<()>,
+    {
+        let mut append_guard = self
+            .append_cursor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let encoded = encode_record(manifest, automerge_snapshot)?;
+        let archive = self.publish_archive_copy()?;
+        let durability_warning = match replace_active(&self.path, &encoded.bytes) {
+            Ok(()) => None,
+            Err(source) => {
+                let replacement_is_active =
+                    std::fs::read(&self.path).is_ok_and(|active| active == encoded.bytes);
+                if !replacement_is_active {
+                    return Err(RecoveryJournalError::ArchiveNotCommitted { archive, source });
+                }
+                Some(format!(
+                    "reconciled journal replacement committed, but its directory flush failed: {source}"
+                ))
+            }
+        };
+
+        let encoded_len = u64::try_from(encoded.bytes.len()).map_err(|_| {
+            RecoveryJournalError::RecordTooLarge {
+                actual: encoded.bytes.len(),
+                maximum: MAX_RECORD_BYTES,
+            }
+        })?;
+        *append_guard = Some(JournalAppendCursor {
+            file_len: encoded_len,
+            modified: std::fs::metadata(&self.path)
+                .and_then(|metadata| metadata.modified())
+                .ok(),
+            last_valid_end: encoded_len,
+            valid_record_count: 1,
+        });
+
+        // The active journal is authoritative. Refreshing its inspectability
+        // sidecar remains best-effort after the replacement commit point.
+        if let Ok(manifest_bytes) = serde_json::to_vec(manifest) {
+            let _ = replace_file_atomically(&self.manifest_path(), &manifest_bytes);
+        }
+
+        Ok(RecoveryArchiveReplacement {
+            archive,
+            durability_warning,
+        })
+    }
+
+    /// Atomically replace the journal with its newest complete valid record.
+    ///
+    /// Scanning retains at most the previous and candidate bounded records in
+    /// memory. The existing journal remains intact until the replacement has
+    /// been fully written and flushed.
+    pub(crate) fn compact(&self) -> Result<RecoveryCompactionOutcome, RecoveryJournalError> {
+        let mut file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(RecoveryCompactionOutcome::Unavailable {
+                    reason: RecoveryUnavailableReason::MissingJournal,
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let scan = scan_file(&mut file)?;
+        if let Some(tail) = &scan.ignored_tail {
+            if tail.is_unsupported_version() {
+                return Err(RecoveryJournalError::UnsupportedTailVersion { tail: tail.clone() });
+            }
+            if !tail.is_repairable_torn_suffix() {
+                return Err(RecoveryJournalError::CorruptTailRequiresReconciliation {
+                    tail: tail.clone(),
+                });
+            }
+        }
+        let Some(record) = scan.latest else {
+            let reason = match scan.ignored_tail {
+                Some(tail) => RecoveryUnavailableReason::NoValidRecord { tail },
+                None => RecoveryUnavailableReason::EmptyJournal,
+            };
+            return Ok(RecoveryCompactionOutcome::Unavailable { reason });
+        };
+
+        let encoded = encode_record(&record.manifest, &record.automerge_snapshot)?;
+        let bytes_after = u64::try_from(encoded.bytes.len()).map_err(|_| {
+            RecoveryJournalError::RecordTooLarge {
+                actual: encoded.bytes.len(),
+                maximum: MAX_RECORD_BYTES,
+            }
+        })?;
+        replace_file_atomically(&self.path, &encoded.bytes)?;
+        *self
+            .append_cursor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(JournalAppendCursor {
+            file_len: bytes_after,
+            modified: std::fs::metadata(&self.path)
+                .and_then(|metadata| metadata.modified())
+                .ok(),
+            last_valid_end: bytes_after,
+            valid_record_count: 1,
+        });
+        // As with append, the atomically replaced journal is authoritative.
+        // A stale inspectability index does not undo a committed compaction.
+        let manifest_index = match serde_json::to_vec(&record.manifest)
+            .map_err(RecoveryJournalError::from)
+            .and_then(|bytes| {
+                replace_file_atomically(&self.manifest_path(), &bytes)
+                    .map_err(RecoveryJournalError::from)
+            }) {
+            Ok(()) => RecoveryManifestIndex::Updated,
+            Err(error) => RecoveryManifestIndex::Stale {
+                reason: error.to_string(),
+            },
+        };
+
+        Ok(RecoveryCompactionOutcome::Compacted {
+            record: Box::new(record),
+            bytes_before: scan.file_len,
+            bytes_after,
+            manifest_index,
+        })
+    }
+}
+
+/// Find the UUID-owned recovery journal whose latest checksummed manifest
+/// claims `canonical_path`.
+///
+/// This is deliberately a fallback for a missing path-registry entry. It scans
+/// the authoritative `*.recovery` records and never trusts the optional JSON
+/// manifest index. Multiple claims are a recovery conflict, not an invitation
+/// to pick whichever directory entry happened to be visited first.
+pub(crate) fn discover_journal_by_canonical_path(
+    docs_dir: &Path,
+    canonical_path: &Path,
+) -> Result<RecoveryJournalDiscovery, RecoveryJournalDiscoveryError> {
+    let entries = match std::fs::read_dir(docs_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(RecoveryJournalDiscovery::NotFound);
+        }
+        Err(source) => {
+            return Err(RecoveryJournalDiscoveryError::Directory {
+                directory: docs_dir.to_path_buf(),
+                source,
+            });
+        }
+    };
+
+    let mut journal_paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| RecoveryJournalDiscoveryError::Directory {
+            directory: docs_dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "recovery")
+        {
+            journal_paths.push(path);
+        }
+    }
+    journal_paths.sort();
+
+    let mut candidates = Vec::new();
+    for journal_path in journal_paths {
+        let journal = RecoveryJournal::new(&journal_path);
+        let recovery = match journal.latest_record() {
+            Ok(RecoveryLatestOutcome::Recovered(recovery)) => recovery,
+            Ok(RecoveryLatestOutcome::Unavailable {
+                reason:
+                    RecoveryUnavailableReason::MissingJournal | RecoveryUnavailableReason::EmptyJournal,
+            }) => continue,
+            Ok(RecoveryLatestOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::NoValidRecord { tail },
+            }) => {
+                return Err(RecoveryJournalDiscoveryError::Journal {
+                    journal: journal_path,
+                    source: Box::new(RecoveryJournalError::NoValidRecord { tail }),
+                });
+            }
+            Err(source) => {
+                return Err(RecoveryJournalDiscoveryError::Journal {
+                    journal: journal_path,
+                    source: Box::new(source),
+                });
+            }
+        };
+
+        let manifest = &recovery.record.manifest;
+        if manifest.canonical_path.as_deref() != Some(canonical_path) {
+            continue;
+        }
+
+        let expected = docs_dir
+            .join(notebook_doc_filename(&manifest.notebook_id.to_string()))
+            .with_extension("recovery");
+        if journal_path != expected {
+            return Err(RecoveryJournalDiscoveryError::MisboundJournal {
+                notebook_id: manifest.notebook_id,
+                journal: journal_path,
+                expected,
+            });
+        }
+        candidates.push((manifest.notebook_id, journal_path));
+    }
+
+    match candidates.len() {
+        0 => Ok(RecoveryJournalDiscovery::NotFound),
+        1 => {
+            let (notebook_id, journal_path) = candidates.remove(0);
+            Ok(RecoveryJournalDiscovery::Found {
+                notebook_id,
+                journal_path,
+            })
+        }
+        _ => Err(RecoveryJournalDiscoveryError::AmbiguousPath {
+            canonical_path: canonical_path.to_path_buf(),
+            candidates,
+        }),
+    }
+}
+
+struct EncodedRecord {
+    bytes: Vec<u8>,
+    checksum: [u8; 32],
+}
+
+fn encode_record(
+    manifest: &RecoveryManifest,
+    automerge_snapshot: &[u8],
+) -> Result<EncodedRecord, RecoveryJournalError> {
+    manifest.validate()?;
+    if automerge_snapshot.is_empty() {
+        return Err(RecoveryJournalError::EmptySnapshot);
+    }
+    if automerge_snapshot.len() > MAX_AUTOMERGE_SNAPSHOT_BYTES {
+        return Err(RecoveryJournalError::SnapshotTooLarge {
+            actual: automerge_snapshot.len(),
+            maximum: MAX_AUTOMERGE_SNAPSHOT_BYTES,
+        });
+    }
+
+    let manifest_bytes = serde_json::to_vec(manifest)?;
+    if manifest_bytes.len() > MAX_MANIFEST_BYTES {
+        return Err(RecoveryJournalError::ManifestTooLarge {
+            actual: manifest_bytes.len(),
+            maximum: MAX_MANIFEST_BYTES,
+        });
+    }
+
+    let total_len = HEADER_LEN
+        .checked_add(manifest_bytes.len())
+        .and_then(|length| length.checked_add(automerge_snapshot.len()))
+        .ok_or(RecoveryJournalError::RecordTooLarge {
+            actual: usize::MAX,
+            maximum: MAX_RECORD_BYTES,
+        })?;
+    if total_len > MAX_RECORD_BYTES {
+        return Err(RecoveryJournalError::RecordTooLarge {
+            actual: total_len,
+            maximum: MAX_RECORD_BYTES,
+        });
+    }
+
+    let manifest_len = u32::try_from(manifest_bytes.len()).map_err(|_| {
+        RecoveryJournalError::ManifestTooLarge {
+            actual: manifest_bytes.len(),
+            maximum: MAX_MANIFEST_BYTES,
+        }
+    })?;
+    let snapshot_len = u64::try_from(automerge_snapshot.len()).map_err(|_| {
+        RecoveryJournalError::SnapshotTooLarge {
+            actual: automerge_snapshot.len(),
+            maximum: MAX_AUTOMERGE_SNAPSHOT_BYTES,
+        }
+    })?;
+
+    let mut prefix = Vec::with_capacity(HEADER_PREFIX_LEN);
+    prefix.extend_from_slice(&RECORD_MAGIC);
+    prefix.extend_from_slice(&RECORD_FORMAT_VERSION.to_le_bytes());
+    prefix.extend_from_slice(&manifest_len.to_le_bytes());
+    prefix.extend_from_slice(&snapshot_len.to_le_bytes());
+
+    let checksum = record_checksum(&prefix, &manifest_bytes, automerge_snapshot);
+    let mut bytes = Vec::with_capacity(total_len);
+    bytes.extend_from_slice(&prefix);
+    bytes.extend_from_slice(&checksum);
+    bytes.extend_from_slice(&manifest_bytes);
+    bytes.extend_from_slice(automerge_snapshot);
+    Ok(EncodedRecord { bytes, checksum })
+}
+
+struct JournalScan {
+    latest: Option<RecoveryRecord>,
+    ignored_tail: Option<JournalTailIssue>,
+    last_valid_end: u64,
+    file_len: u64,
+    valid_record_count: usize,
+}
+
+fn scan_file(file: &mut File) -> Result<JournalScan, RecoveryJournalError> {
+    let file_len = file.metadata()?.len();
+    file.seek(SeekFrom::Start(0))?;
+
+    let mut latest = None;
+    let mut offset = 0_u64;
+    let mut last_valid_end = 0_u64;
+    let mut ignored_tail = None;
+    let mut valid_record_count = 0_usize;
+
+    while offset < file_len {
+        let available_header = file_len - offset;
+        if available_header < HEADER_LEN as u64 {
+            ignored_tail = Some(JournalTailIssue::TruncatedHeader {
+                offset,
+                available: available_header,
+            });
+            break;
+        }
+
+        let mut header = [0_u8; HEADER_LEN];
+        file.read_exact(&mut header)?;
+        if header[..RECORD_MAGIC.len()] != RECORD_MAGIC {
+            ignored_tail = Some(JournalTailIssue::InvalidMagic { offset });
+            break;
+        }
+
+        let record_version = read_u16(&header[8..10]);
+        if record_version != RECORD_FORMAT_VERSION {
+            ignored_tail = Some(JournalTailIssue::UnsupportedRecordVersion {
+                offset,
+                version: record_version,
+            });
+            break;
+        }
+
+        let manifest_len = u64::from(read_u32(&header[10..14]));
+        let snapshot_len = read_u64(&header[14..22]);
+        let payload_len = match manifest_len.checked_add(snapshot_len) {
+            Some(length)
+                if manifest_len <= MAX_MANIFEST_BYTES as u64
+                    && snapshot_len > 0
+                    && snapshot_len <= MAX_AUTOMERGE_SNAPSHOT_BYTES as u64
+                    && length <= (MAX_RECORD_BYTES - HEADER_LEN) as u64 =>
+            {
+                length
+            }
+            _ => {
+                ignored_tail = Some(JournalTailIssue::InvalidLengths {
+                    offset,
+                    manifest_len,
+                    snapshot_len,
+                });
+                break;
+            }
+        };
+
+        let available_payload = file_len - offset - HEADER_LEN as u64;
+        if available_payload < payload_len {
+            ignored_tail = Some(JournalTailIssue::TruncatedPayload {
+                offset,
+                expected: payload_len,
+                available: available_payload,
+            });
+            break;
+        }
+
+        let manifest_size =
+            usize::try_from(manifest_len).map_err(|_| RecoveryJournalError::RecordTooLarge {
+                actual: usize::MAX,
+                maximum: MAX_RECORD_BYTES,
+            })?;
+        let snapshot_size =
+            usize::try_from(snapshot_len).map_err(|_| RecoveryJournalError::RecordTooLarge {
+                actual: usize::MAX,
+                maximum: MAX_RECORD_BYTES,
+            })?;
+        let mut manifest_bytes = vec![0_u8; manifest_size];
+        let mut automerge_snapshot = vec![0_u8; snapshot_size];
+        file.read_exact(&mut manifest_bytes)?;
+        file.read_exact(&mut automerge_snapshot)?;
+
+        let expected_checksum: [u8; 32] = header[HEADER_PREFIX_LEN..HEADER_LEN]
+            .try_into()
+            .map_err(|_| RecoveryJournalError::RecordTooLarge {
+                actual: HEADER_LEN,
+                maximum: HEADER_LEN,
+            })?;
+        let actual_checksum = record_checksum(
+            &header[..HEADER_PREFIX_LEN],
+            &manifest_bytes,
+            &automerge_snapshot,
+        );
+        if actual_checksum != expected_checksum {
+            ignored_tail = Some(JournalTailIssue::ChecksumMismatch { offset });
+            break;
+        }
+
+        let manifest: RecoveryManifest = match serde_json::from_slice(&manifest_bytes) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                ignored_tail = Some(JournalTailIssue::InvalidManifest {
+                    offset,
+                    reason: error.to_string(),
+                });
+                break;
+            }
+        };
+        if manifest.version != RECOVERY_MANIFEST_VERSION {
+            ignored_tail = Some(JournalTailIssue::UnsupportedManifestVersion {
+                offset,
+                version: manifest.version,
+            });
+            break;
+        }
+
+        let record_len = HEADER_LEN as u64 + payload_len;
+        last_valid_end = offset + record_len;
+        offset = last_valid_end;
+        latest = Some(RecoveryRecord {
+            manifest,
+            automerge_snapshot,
+        });
+        valid_record_count = valid_record_count.saturating_add(1);
+    }
+
+    Ok(JournalScan {
+        latest,
+        ignored_tail,
+        last_valid_end,
+        file_len,
+        valid_record_count,
+    })
+}
+
+fn record_checksum(prefix: &[u8], manifest: &[u8], snapshot: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix);
+    hasher.update(manifest);
+    hasher.update(snapshot);
+    hasher.finalize().into()
+}
+
+fn read_u16(bytes: &[u8]) -> u16 {
+    let mut value = [0_u8; 2];
+    value.copy_from_slice(bytes);
+    u16::from_le_bytes(value)
+}
+
+fn read_u32(bytes: &[u8]) -> u32 {
+    let mut value = [0_u8; 4];
+    value.copy_from_slice(bytes);
+    u32::from_le_bytes(value)
+}
+
+fn read_u64(bytes: &[u8]) -> u64 {
+    let mut value = [0_u8; 8];
+    value.copy_from_slice(bytes);
+    u64::from_le_bytes(value)
+}
+
+fn create_archive_staging_directory(
+    journal_path: &Path,
+    manifest_present: bool,
+) -> Result<(PathBuf, RecoveryArchivePaths), RecoveryJournalError> {
+    ensure_parent_directory(journal_path)?;
+    let journal_name = journal_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "room.recovery".to_string());
+    let manifest_name = format!("{journal_name}.manifest.json");
+
+    // UUID collisions are fantastically unlikely, but retrying keeps the
+    // create-new uniqueness guarantee explicit and bounded.
+    for _ in 0..16 {
+        let archive_id = Uuid::new_v4().simple();
+        let archive_directory =
+            journal_path.with_file_name(format!("{journal_name}.archive-{archive_id}"));
+        let staging_directory =
+            journal_path.with_file_name(format!(".{journal_name}.archive-{archive_id}.staging"));
+        if archive_directory.try_exists()? {
+            continue;
+        }
+        match std::fs::create_dir(&staging_directory) {
+            Ok(()) => {
+                let archive = RecoveryArchivePaths {
+                    journal: archive_directory.join(&journal_name),
+                    manifest: manifest_present.then(|| archive_directory.join(&manifest_name)),
+                    directory: archive_directory,
+                };
+                return Ok((staging_directory, archive));
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique recovery archive path after 16 attempts",
+    )
+    .into())
+}
+
+/// Copy exactly the source length captured at open time without buffering the
+/// whole journal in memory, then flush the copy before publishing it.
+fn copy_file_durably(source_path: &Path, destination_path: &Path) -> io::Result<()> {
+    let source = File::open(source_path)?;
+    let metadata = source.metadata()?;
+    let expected_len = metadata.len();
+    let mut bounded_source = source.take(expected_len);
+    let mut destination = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination_path)?;
+    let copied = io::copy(&mut bounded_source, &mut destination)?;
+    if copied != expected_len {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!(
+                "recovery source changed while archiving: expected {expected_len} bytes, copied {copied}"
+            ),
+        ));
+    }
+    std::fs::set_permissions(destination_path, metadata.permissions())?;
+    destination.sync_all()
+}
+
+fn ensure_parent_directory(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+fn canonical_parent_directory(path: &Path) -> io::Result<PathBuf> {
+    match path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        Some(parent) => parent.canonicalize(),
+        None => std::env::current_dir()?.canonicalize(),
+    }
+}
+
+/// Flush the directory containing `path`, then each ancestor through the
+/// filesystem root. Leaf-to-root ordering makes each child durable before the
+/// parent entry that makes the child reachable.
+fn sync_pathname_directory_chain<SyncDirectory>(
+    path: &Path,
+    sync_directory: &mut SyncDirectory,
+) -> io::Result<()>
+where
+    SyncDirectory: FnMut(&Path) -> io::Result<()>,
+{
+    let parent = canonical_parent_directory(path)?;
+    for directory in parent.ancestors() {
+        sync_directory(directory)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn replace_file_atomically(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    ensure_parent_directory(path)?;
+    let temporary_path = sibling_temp_path(path);
+    let result = (|| {
+        let mut temporary = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary_path)?;
+        temporary.write_all(bytes)?;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            std::fs::set_permissions(&temporary_path, metadata.permissions())?;
+        }
+        temporary.sync_all()?;
+        drop(temporary);
+        replace_file(&temporary_path, path)?;
+        sync_parent_directory(path)
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+fn sibling_temp_path(path: &Path) -> PathBuf {
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let sequence = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "recovery-journal".to_string());
+    path.with_file_name(format!(
+        ".{file_name}.{}-{sequence}.compact.tmp",
+        std::process::id()
+    ))
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    std::fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let mut source_wide: Vec<u16> = source.as_os_str().encode_wide().collect();
+    source_wide.push(0);
+    let mut destination_wide: Vec<u16> = destination.as_os_str().encode_wide().collect();
+    destination_wide.push(0);
+
+    // SAFETY: both paths are owned, NUL-terminated UTF-16 buffers that remain
+    // alive for the duration of the call.
+    let result = unsafe {
+        MoveFileExW(
+            source_wide.as_ptr(),
+            destination_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> io::Result<()> {
+    sync_directory(&canonical_parent_directory(path)?)
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use automerge::{transaction::Transactable, AutoCommit, ROOT};
+
+    fn snapshot(value: &str) -> Vec<u8> {
+        let mut document = AutoCommit::new();
+        document.put(ROOT, "value", value).unwrap();
+        document.save()
+    }
+
+    fn manifest(sequence: u64, source: &[u8]) -> RecoveryManifest {
+        let mut manifest = RecoveryManifest::new(
+            sequence,
+            Uuid::from_u128(0x1234),
+            Some(PathBuf::from("/tmp/notebook.ipynb")),
+            notebook_doc::SCHEMA_VERSION,
+            source_fingerprint(source),
+            7,
+        );
+        manifest.staged_change_hashes = vec![[sequence as u8; 32]];
+        manifest.durable_heads = vec![[(sequence + 1) as u8; 32]];
+        manifest.exported_heads = vec![[(sequence + 2) as u8; 32]];
+        manifest
+    }
+
+    fn matched_record(outcome: RecoveryLoadOutcome) -> RecoveredJournalRecord {
+        match outcome {
+            RecoveryLoadOutcome::Match(recovery) => recovery,
+            other => panic!("expected matching recovery record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn source_fingerprint_is_sha256_of_exact_content() {
+        let fingerprint = source_fingerprint(b"abc");
+        assert_eq!(
+            fingerprint.to_hex(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_ne!(fingerprint, source_fingerprint(b"abc\n"));
+    }
+
+    #[test]
+    fn notebook_schema_version_round_trips_independently_from_journal_version() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let source = b"source";
+        let mut manifest = manifest(1, source);
+        manifest.notebook_schema_version = 42;
+
+        journal.append(&manifest, &snapshot("value")).unwrap();
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+
+        assert_eq!(recovered.record.manifest.version, RECOVERY_MANIFEST_VERSION);
+        assert_eq!(recovered.record.manifest.notebook_schema_version, 42);
+    }
+
+    #[test]
+    fn append_and_load_selects_latest_matching_snapshot() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"{\"cells\":[]}";
+        let first_snapshot = snapshot("first");
+        let second_snapshot = snapshot("second");
+
+        let first = journal
+            .append(&manifest(1, source), &first_snapshot)
+            .unwrap();
+        let second = journal
+            .append(&manifest(2, source), &second_snapshot)
+            .unwrap();
+
+        assert_eq!(first.start_offset, 0);
+        assert_eq!(first.end_offset, second.start_offset);
+        assert_eq!(first.manifest_index, RecoveryManifestIndex::Updated);
+        assert_eq!(second.manifest_index, RecoveryManifestIndex::Updated);
+        assert_eq!(journal.path(), path);
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        let indexed_manifest: RecoveryManifest =
+            serde_json::from_slice(&std::fs::read(journal.manifest_path()).unwrap()).unwrap();
+        assert_eq!(recovered.record.manifest.sequence, 2);
+        assert_eq!(indexed_manifest, recovered.record.manifest);
+        assert_eq!(recovered.record.automerge_snapshot, second_snapshot);
+        assert!(recovered.ignored_tail.is_none());
+        AutoCommit::load(&recovered.record.automerge_snapshot).unwrap();
+    }
+
+    #[test]
+    fn canonical_path_discovery_uses_authoritative_journal_without_sidecar() {
+        let directory = tempfile::tempdir().unwrap();
+        let canonical_path = directory.path().join("recover-me.ipynb");
+        let notebook_id = Uuid::new_v4();
+        let journal_path = directory
+            .path()
+            .join(notebook_doc_filename(&notebook_id.to_string()))
+            .with_extension("recovery");
+        let journal = RecoveryJournal::new(&journal_path);
+        let source = b"source";
+        let mut durable_manifest = manifest(1, source);
+        durable_manifest.notebook_id = notebook_id;
+        durable_manifest.canonical_path = Some(canonical_path.clone());
+        journal
+            .append(&durable_manifest, &snapshot("acknowledged"))
+            .unwrap();
+
+        // The JSON sidecar is only an inspectability index. Identity recovery
+        // must still work when it is missing and the authoritative journal has
+        // a torn suffix after its last complete record.
+        std::fs::remove_file(journal.manifest_path()).unwrap();
+        let mut file = OpenOptions::new().append(true).open(&journal_path).unwrap();
+        file.write_all(b"torn-tail").unwrap();
+        file.sync_all().unwrap();
+
+        assert_eq!(
+            discover_journal_by_canonical_path(directory.path(), &canonical_path).unwrap(),
+            RecoveryJournalDiscovery::Found {
+                notebook_id,
+                journal_path,
+            }
+        );
+    }
+
+    #[test]
+    fn canonical_path_discovery_refuses_ambiguous_journals() {
+        let directory = tempfile::tempdir().unwrap();
+        let canonical_path = directory.path().join("ambiguous.ipynb");
+        let mut notebook_ids = Vec::new();
+
+        for sequence in [1_u64, 2] {
+            let notebook_id = Uuid::new_v4();
+            notebook_ids.push(notebook_id);
+            let journal_path = directory
+                .path()
+                .join(notebook_doc_filename(&notebook_id.to_string()))
+                .with_extension("recovery");
+            let mut durable_manifest = manifest(sequence, b"source");
+            durable_manifest.notebook_id = notebook_id;
+            durable_manifest.canonical_path = Some(canonical_path.clone());
+            RecoveryJournal::new(journal_path)
+                .append(&durable_manifest, &snapshot("acknowledged"))
+                .unwrap();
+        }
+
+        let error =
+            discover_journal_by_canonical_path(directory.path(), &canonical_path).unwrap_err();
+        match error {
+            RecoveryJournalDiscoveryError::AmbiguousPath { candidates, .. } => {
+                let candidate_ids = candidates
+                    .into_iter()
+                    .map(|(notebook_id, _)| notebook_id)
+                    .collect::<Vec<_>>();
+                assert_eq!(candidate_ids.len(), 2);
+                assert!(notebook_ids.iter().all(|id| candidate_ids.contains(id)));
+            }
+            other => panic!("expected ambiguous recovery journals, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn first_journal_pathname_sync_is_retried_after_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("nested").join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        let recovered_snapshot = snapshot("durable after retry");
+        let mut first_attempted_directory = None;
+
+        let error = journal
+            .append_with_directory_sync(&manifest(1, source), &recovered_snapshot, |directory| {
+                first_attempted_directory = Some(directory.to_path_buf());
+                Err(io::Error::other("injected directory sync failure"))
+            })
+            .unwrap_err();
+
+        assert!(matches!(error, RecoveryJournalError::Io(_)));
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 0);
+        let canonical_parent = path.parent().unwrap().canonicalize().unwrap();
+        assert_eq!(first_attempted_directory, Some(canonical_parent.clone()));
+
+        let mut retried_directories = Vec::new();
+        let receipt = journal
+            .append_with_directory_sync(&manifest(1, source), &recovered_snapshot, |directory| {
+                retried_directories.push(directory.to_path_buf());
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(receipt.start_offset, 0);
+        assert_eq!(retried_directories.first(), Some(&canonical_parent));
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 1);
+        assert_eq!(recovered.record.automerge_snapshot, recovered_snapshot);
+    }
+
+    #[test]
+    fn first_journal_flushes_every_new_directory_entry_leaf_to_root() {
+        let directory = tempfile::tempdir().unwrap();
+        let stable_parent = directory.path().join("stable");
+        std::fs::create_dir(&stable_parent).unwrap();
+        let path = stable_parent
+            .join("new-parent")
+            .join("new-child")
+            .join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let mut synced_directories = Vec::new();
+
+        journal
+            .append_with_directory_sync(&manifest(1, b"source"), &snapshot("nested"), |directory| {
+                synced_directories.push(directory.to_path_buf());
+                Ok(())
+            })
+            .unwrap();
+
+        let canonical_child = path.parent().unwrap().canonicalize().unwrap();
+        let canonical_new_parent = canonical_child.parent().unwrap().to_path_buf();
+        let canonical_stable_parent = canonical_new_parent.parent().unwrap().to_path_buf();
+        assert_eq!(
+            &synced_directories[..3],
+            &[
+                canonical_child,
+                canonical_new_parent,
+                canonical_stable_parent
+            ]
+        );
+    }
+
+    #[test]
+    fn manifest_index_failure_does_not_turn_a_committed_append_into_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+
+        // A directory at the sidecar path makes atomic file replacement fail
+        // without preventing the authoritative journal append.
+        std::fs::create_dir(journal.manifest_path()).unwrap();
+        let recovered_snapshot = snapshot("durable despite stale index");
+        let receipt = journal
+            .append(&manifest(1, source), &recovered_snapshot)
+            .unwrap();
+
+        assert!(matches!(
+            receipt.manifest_index,
+            RecoveryManifestIndex::Stale { .. }
+        ));
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 1);
+        assert_eq!(recovered.record.automerge_snapshot, recovered_snapshot);
+    }
+
+    #[test]
+    fn load_reports_source_conflict_without_discarding_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let snapshot = snapshot("unsaved");
+        journal
+            .append(&manifest(1, b"source-a"), &snapshot)
+            .unwrap();
+
+        match journal.load(source_fingerprint(b"source-b")).unwrap() {
+            RecoveryLoadOutcome::SourceConflict {
+                recovery,
+                current_source_fingerprint,
+            } => {
+                assert_eq!(recovery.record.automerge_snapshot, snapshot);
+                assert_eq!(
+                    recovery.record.manifest.source_fingerprint,
+                    source_fingerprint(b"source-a")
+                );
+                assert_eq!(current_source_fingerprint, source_fingerprint(b"source-b"));
+            }
+            other => panic!("expected source conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn archive_durably_publishes_both_files_before_retiring_active_names() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        journal
+            .append(&manifest(1, source), &snapshot("recovered"))
+            .unwrap();
+        let original_journal = std::fs::read(&path).unwrap();
+        let original_manifest = std::fs::read(journal.manifest_path()).unwrap();
+
+        let (archive, durability, sidecar) = match journal.archive().unwrap() {
+            RecoveryArchiveOutcome::JournalRetired {
+                archive,
+                durability,
+                sidecar,
+            } => (archive, durability, sidecar),
+            other => panic!("expected retired journal, got {other:?}"),
+        };
+
+        assert_eq!(durability, RecoveryArchiveDurability::Durable);
+        assert_eq!(sidecar, RecoveryArchiveSidecar::Retired);
+        assert!(!path.exists());
+        assert!(!journal.manifest_path().exists());
+        assert_eq!(std::fs::read(&archive.journal).unwrap(), original_journal);
+        let archived_manifest = archive.manifest.as_ref().unwrap();
+        assert_eq!(std::fs::read(archived_manifest).unwrap(), original_manifest);
+
+        let archived_journal = RecoveryJournal::new(&archive.journal);
+        let recovered = matched_record(archived_journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 1);
+        assert_eq!(
+            journal.archive().unwrap(),
+            RecoveryArchiveOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::MissingJournal
+            }
+        );
+    }
+
+    #[test]
+    fn archive_failure_before_commit_preserves_active_and_published_copies() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        journal
+            .append(&manifest(1, source), &snapshot("recovered"))
+            .unwrap();
+        let original_journal = std::fs::read(&path).unwrap();
+        let original_manifest = std::fs::read(journal.manifest_path()).unwrap();
+
+        let error = journal
+            .archive_with(
+                || Err(io::Error::other("injected before journal retirement")),
+                replace_file,
+            )
+            .unwrap_err();
+        let archive = match error {
+            RecoveryJournalError::ArchiveNotCommitted { archive, source } => {
+                assert_eq!(source.kind(), io::ErrorKind::Other);
+                archive
+            }
+            other => panic!("expected an uncommitted archive, got {other:?}"),
+        };
+
+        assert_eq!(std::fs::read(&path).unwrap(), original_journal);
+        assert_eq!(
+            std::fs::read(journal.manifest_path()).unwrap(),
+            original_manifest
+        );
+        assert_eq!(std::fs::read(&archive.journal).unwrap(), original_journal);
+        assert_eq!(
+            std::fs::read(archive.manifest.as_ref().unwrap()).unwrap(),
+            original_manifest
+        );
+    }
+
+    #[test]
+    fn reconciled_replacement_failure_keeps_old_active_journal() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        journal
+            .append(&manifest(1, b"old-source"), &snapshot("old"))
+            .unwrap();
+        let original = std::fs::read(&path).unwrap();
+
+        let error = journal
+            .archive_and_replace_with(
+                &manifest(2, b"new-source"),
+                &snapshot("new"),
+                |_path, _bytes| Err(io::Error::other("injected replacement failure")),
+            )
+            .unwrap_err();
+        let archive = match error {
+            RecoveryJournalError::ArchiveNotCommitted { archive, source } => {
+                assert_eq!(source.kind(), io::ErrorKind::Other);
+                archive
+            }
+            other => panic!("expected replacement failure, got {other:?}"),
+        };
+
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+        assert_eq!(std::fs::read(&archive.journal).unwrap(), original);
+        let recovered = matched_record(journal.load(source_fingerprint(b"old-source")).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 1);
+    }
+
+    #[test]
+    fn manifest_retirement_failure_does_not_undo_journal_commit() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        journal
+            .append(&manifest(1, b"source"), &snapshot("recovered"))
+            .unwrap();
+
+        let (archive, durability, sidecar) = match journal
+            .archive_with(
+                || Ok(()),
+                |_source, _destination| {
+                    Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "injected sidecar retirement failure",
+                    ))
+                },
+            )
+            .unwrap()
+        {
+            RecoveryArchiveOutcome::JournalRetired {
+                archive,
+                durability,
+                sidecar,
+            } => (archive, durability, sidecar),
+            other => panic!("expected retired journal, got {other:?}"),
+        };
+
+        assert_eq!(durability, RecoveryArchiveDurability::Durable);
+        assert!(matches!(
+            sidecar,
+            RecoveryArchiveSidecar::RetainedActive { reason }
+                if reason.contains("injected sidecar retirement failure")
+        ));
+        assert!(!path.exists());
+        assert!(journal.manifest_path().exists());
+        assert!(archive.journal.exists());
+        assert!(archive.manifest.unwrap().exists());
+        assert_eq!(
+            journal.load(source_fingerprint(b"source")).unwrap(),
+            RecoveryLoadOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::MissingJournal
+            }
+        );
+    }
+
+    #[test]
+    fn torn_tail_recovers_last_complete_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        let first_snapshot = snapshot("first");
+        let second_snapshot = snapshot("second");
+        let first = journal
+            .append(&manifest(1, source), &first_snapshot)
+            .unwrap();
+        let second = journal
+            .append(&manifest(2, source), &second_snapshot)
+            .unwrap();
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(second.end_offset - 7)
+            .unwrap();
+
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 1);
+        assert_eq!(recovered.record.automerge_snapshot, first_snapshot);
+        assert!(matches!(
+            recovered.ignored_tail,
+            Some(JournalTailIssue::TruncatedPayload { offset, .. }) if offset == first.end_offset
+        ));
+    }
+
+    #[test]
+    fn checksum_failure_at_tail_recovers_previous_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        let first = journal
+            .append(&manifest(1, source), &snapshot("first"))
+            .unwrap();
+        let second = journal
+            .append(&manifest(2, source), &snapshot("second"))
+            .unwrap();
+
+        let mut file = File::options().read(true).write(true).open(&path).unwrap();
+        file.seek(SeekFrom::Start(second.end_offset - 1)).unwrap();
+        let mut byte = [0_u8; 1];
+        file.read_exact(&mut byte).unwrap();
+        file.seek(SeekFrom::Start(second.end_offset - 1)).unwrap();
+        file.write_all(&[byte[0] ^ 0xff]).unwrap();
+        file.sync_all().unwrap();
+
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 1);
+        assert_eq!(
+            recovered.ignored_tail,
+            Some(JournalTailIssue::ChecksumMismatch {
+                offset: first.end_offset
+            })
+        );
+    }
+
+    #[test]
+    fn append_refuses_to_truncate_corrupt_record_and_valid_suffix() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        let first = journal
+            .append(&manifest(1, source), &snapshot("first"))
+            .unwrap();
+        let second = journal
+            .append(&manifest(2, source), &snapshot("second"))
+            .unwrap();
+        journal
+            .append(&manifest(3, source), &snapshot("valid suffix"))
+            .unwrap();
+
+        let mut file = File::options().read(true).write(true).open(&path).unwrap();
+        file.seek(SeekFrom::Start(second.start_offset + HEADER_LEN as u64))
+            .unwrap();
+        let mut byte = [0_u8; 1];
+        file.read_exact(&mut byte).unwrap();
+        file.seek(SeekFrom::Start(second.start_offset + HEADER_LEN as u64))
+            .unwrap();
+        file.write_all(&[byte[0] ^ 0xff]).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+        *journal
+            .append_cursor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        let preserved = std::fs::read(&path).unwrap();
+
+        let error = journal
+            .append(&manifest(4, source), &snapshot("must not append"))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RecoveryJournalError::CorruptTailRequiresReconciliation {
+                tail: JournalTailIssue::ChecksumMismatch { offset }
+            } if offset == first.end_offset
+        ));
+        assert_eq!(std::fs::read(&path).unwrap(), preserved);
+    }
+
+    #[test]
+    fn append_repairs_torn_tail_after_valid_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        let first = journal
+            .append(&manifest(1, source), &snapshot("first"))
+            .unwrap();
+        let torn = journal
+            .append(&manifest(2, source), &snapshot("torn"))
+            .unwrap();
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(torn.end_offset - 11)
+            .unwrap();
+
+        let replacement_snapshot = snapshot("replacement");
+        let replacement = journal
+            .append(&manifest(3, source), &replacement_snapshot)
+            .unwrap();
+        assert_eq!(replacement.start_offset, first.end_offset);
+
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 3);
+        assert_eq!(recovered.record.automerge_snapshot, replacement_snapshot);
+        assert!(recovered.ignored_tail.is_none());
+    }
+
+    #[test]
+    fn compaction_atomically_preserves_newest_valid_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let source = b"source";
+        journal
+            .append(&manifest(1, source), &snapshot("first"))
+            .unwrap();
+        let newest_snapshot = snapshot("newest");
+        let newest = journal
+            .append(&manifest(2, source), &newest_snapshot)
+            .unwrap();
+
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"torn-tail").unwrap();
+        file.sync_all().unwrap();
+        let bytes_before = std::fs::metadata(&path).unwrap().len();
+
+        let compacted = journal.compact().unwrap();
+        let bytes_after = match compacted {
+            RecoveryCompactionOutcome::Compacted {
+                record,
+                bytes_before: reported_before,
+                bytes_after,
+                manifest_index,
+            } => {
+                assert_eq!(reported_before, bytes_before);
+                assert_eq!(record.manifest.sequence, 2);
+                assert_eq!(record.automerge_snapshot, newest_snapshot);
+                assert_eq!(manifest_index, RecoveryManifestIndex::Updated);
+                bytes_after
+            }
+            other => panic!("expected compacted journal, got {other:?}"),
+        };
+        assert!(bytes_after < newest.end_offset);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), bytes_after);
+
+        let recovered = matched_record(journal.load(source_fingerprint(source)).unwrap());
+        assert_eq!(recovered.record.manifest.sequence, 2);
+        assert_eq!(recovered.record.automerge_snapshot, newest_snapshot);
+        assert!(recovered.ignored_tail.is_none());
+
+        let mut entries: Vec<_> = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        entries.sort();
+        let mut expected = vec![
+            path.file_name().unwrap().to_os_string(),
+            journal.manifest_path().file_name().unwrap().to_os_string(),
+        ];
+        expected.sort();
+        assert_eq!(entries, expected);
+    }
+
+    #[test]
+    fn append_automatically_compacts_the_active_journal() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("bounded.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let mut last_receipt = None;
+        for sequence in 1..=COMPACT_AFTER_RECORDS {
+            let manifest = manifest(sequence as u64, b"source");
+            last_receipt = Some(journal.append(&manifest, &snapshot("value")).unwrap());
+        }
+
+        let receipt = last_receipt.unwrap();
+        assert_eq!(receipt.start_offset, 0);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), receipt.end_offset);
+        let latest = match journal.latest_record().unwrap() {
+            RecoveryLatestOutcome::Recovered(recovery) => recovery,
+            other => panic!("expected compacted recovery record, got {other:?}"),
+        };
+        assert_eq!(
+            latest.record.manifest.sequence,
+            COMPACT_AFTER_RECORDS as u64
+        );
+    }
+
+    #[test]
+    fn unavailable_distinguishes_missing_empty_and_invalid_journals() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("room.recovery");
+        let journal = RecoveryJournal::new(&path);
+        let fingerprint = source_fingerprint(b"source");
+
+        assert_eq!(
+            journal.load(fingerprint).unwrap(),
+            RecoveryLoadOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::MissingJournal
+            }
+        );
+
+        File::create(&path).unwrap().sync_all().unwrap();
+        assert_eq!(
+            journal.load(fingerprint).unwrap(),
+            RecoveryLoadOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::EmptyJournal
+            }
+        );
+
+        std::fs::write(&path, b"partial").unwrap();
+        assert!(matches!(
+            journal.load(fingerprint).unwrap(),
+            RecoveryLoadOutcome::Unavailable {
+                reason: RecoveryUnavailableReason::NoValidRecord {
+                    tail: JournalTailIssue::TruncatedHeader { offset: 0, .. }
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn invalid_manifest_version_is_rejected_before_append() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let mut invalid = manifest(1, b"source");
+        invalid.version = RECOVERY_MANIFEST_VERSION + 1;
+
+        assert!(matches!(
+            journal.append(&invalid, &snapshot("value")),
+            Err(RecoveryJournalError::UnsupportedManifestVersion { version })
+                if version == RECOVERY_MANIFEST_VERSION + 1
+        ));
+        assert!(!journal.path().exists());
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of 6 in the room lifecycle stack (carved from #3997, related to #3907). Lands the durable primitives standalone, ahead of any room integration:

- `recovery.rs`: append-only recovery journal with crash-safe records, atomic manifest (notebook identity, source fingerprint, staged change hashes, durable heads, exported heads), and automatic compaction
- `durability.rs`: `RoomDurability`, the single serialization point for a room's durable NotebookDoc history, with watch-based status and degraded-state tracking
- `file_checkpoint.rs`: causal `FileCheckpoint` replacing timestamp save truth - temp-file write, durable flush, atomic replacement, monotonic save sequences so stale completions cannot regress exported heads
- runtime-doc: `FileCheckpointState`, `FileSourceIssue`, and accessors on `RuntimeStateDoc`, the durable client-visible surface for checkpoint facts

The modules register with `allow(dead_code)` and explicit landing-order comments; room mutation paths wire them in next slice. The room-facing `commit_daemon_notebook_mutation` wrapper stays with that slice since it needs the `NotebookRoom` durability/lifecycle fields introduced there.

Two clippy fixes over the integration branch tip: needless borrows in the already-current checkpoint comparison, and an explicit `too_many_arguments` allow on the fault-injection seam (`complete_with_callbacks` keeps prepare/abort/commit as separate ordered hooks so tests can fail each boundary independently).

## Stack

1. #4009 room-loader foundations and ADRs (base of this PR)
2. durability primitives (this PR)
3. #4016 room source lifecycle and staged imports
4. #4011 causal saves and explicit reconciliation
5. #4012 client causal dirty-state
6. #4013 progressive MCP connect

## Validation

- `cargo clippy -p runtimed --lib -p runtime-doc --all-targets -- -D warnings` clean
- `cargo test -p runtimed --lib` module suites: 49 passed (recovery, durability, file_checkpoint)
- `cargo test -p runtime-doc`: 248 passed, 2 ignored
- `cargo fmt --check` clean
