### PR TITLE
feat(notebook): report dirty state from causal exported heads

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -64,6 +64,7 @@ import {
   NotebookConnectionIdentity,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookNotice,
   PoolErrorBanner,
   shouldShowKernelLaunchErrorBanner,
   TrustDialog,
@@ -136,6 +137,7 @@ import { useNotebookActionPolicy } from "./lib/notebook-action-policy";
 import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
 import { hostedNotebookWindowTitle } from "./lib/hosted-notebook-url";
+import { fileSourceIssueNotice, notebookDocumentIsDirty } from "./lib/notebook-file-state";
 import {
   attachExecutionPerformanceId,
   installExecutionPerformanceApi,
@@ -377,6 +379,7 @@ function AppContent() {
     getHandle,
     getEngine,
     sessionStatus$,
+    notebookDocChanged$,
     triggerSync,
     localActor,
     connectionScope,
@@ -505,9 +508,9 @@ function AppContent() {
   const runtime = deriveRuntimeKind(runtimeState, detectedRuntime, runtimeHint);
 
   // `true` when the room is in-memory only (untitled); reported by the daemon
-  // via `daemon:ready`. Drives the always-dirty titlebar asterisk. Null until
-  // the first ready event lands — treated conservatively as "unknown, assume
-  // persisted" so we don't flash an asterisk on open-from-disk notebooks.
+  // via `daemon:ready`. Untitled rooms are always dirty. Null until the first
+  // ready event lands — treated conservatively as "unknown, assume persisted"
+  // so we don't flash an asterisk on open-from-disk notebooks.
   const [ephemeral, setEphemeral] = useState<boolean | null>(null);
 
   // Canonical window-title base. Bootstrapped from the host on mount (Rust
@@ -516,6 +519,7 @@ function AppContent() {
   // without a getTitle-then-setTitle round-trip that would race with the
   // concurrent Rust-side title update from `applyPathChanged`.
   const [titleBase, setTitleBase] = useState<string | null>(null);
+  const [fileBackedDirty, setFileBackedDirty] = useState(false);
 
   // UV Dependency management
   const {
@@ -1635,6 +1639,27 @@ function AppContent() {
     applyNotebookPath(runtimePath, hostedNotebookUrl);
   }, [applyNotebookPath, hostedNotebookUrl, runtimePath]);
 
+  const fileCheckpointRef = useRef(runtimeState.file_checkpoint);
+  fileCheckpointRef.current = runtimeState.file_checkpoint;
+  const fileCheckpointCausalKey = `${runtimeState.file_checkpoint.save_sequence ?? "none"}\0${runtimeState.file_checkpoint.exported_heads.join("\0")}`;
+  const isFileBacked = ephemeral === false && runtimePath !== null && hostedNotebookUrl === null;
+  useEffect(() => {
+    const refreshDirtyState = () => {
+      setFileBackedDirty(
+        notebookDocumentIsDirty({
+          ephemeral,
+          fileBacked: isFileBacked,
+          fileCheckpoint: fileCheckpointRef.current,
+          handle: getHandle(),
+        }),
+      );
+    };
+
+    refreshDirtyState();
+    const subscription = notebookDocChanged$.subscribe(refreshDirtyState);
+    return () => subscription.unsubscribe();
+  }, [ephemeral, fileCheckpointCausalKey, getHandle, isFileBacked, notebookDocChanged$]);
+
   const reconnectRuntime = useCallback(() => {
     setDaemonStatus({ status: "checking" });
     host.daemon.reconnect({ force: true }).catch((e: unknown) => {
@@ -1645,17 +1670,20 @@ function AppContent() {
     });
   }, [host]);
 
-  // Title is purely a function of `ephemeral`. Untitled notebooks get
-  // the `*` prefix; saved notebooks render their filename. Autosave
-  // (2s quiet, 10s max) keeps the file current within seconds of any
-  // edit, so the file-backed case never shows an unsaved-changes dot.
+  const documentDirty = ephemeral === true ? true : isFileBacked ? fileBackedDirty : false;
+
+  // Untitled notebooks remain dirty. File-backed notebooks get the `*`
+  // prefix only while the local NotebookDoc contains changes beyond the
+  // daemon's causally committed exported heads.
   useEffect(() => {
     if (titleBase == null) return;
-    const next = ephemeral === true ? `* ${titleBase}` : titleBase;
+    const next = documentDirty ? `* ${titleBase}` : titleBase;
     host.window.setTitle(next).catch(() => {
       // Window may have been closed mid-render.
     });
-  }, [host, ephemeral, titleBase]);
+  }, [documentDirty, host, titleBase]);
+
+  const sourceIssueNotice = fileSourceIssueNotice(runtimeState.file_checkpoint.source_issue);
 
   // Cmd+F to open global find
   useEffect(() => {
@@ -2032,6 +2060,17 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
+          notices={
+            sourceIssueNotice ? (
+              <NotebookNotice
+                tone="warning"
+                title={sourceIssueNotice.title}
+                data-testid="notebook-file-source-issue"
+              >
+                {sourceIssueNotice.message}
+              </NotebookNotice>
+            ) : null
+          }
           stageClassName={cn(
             "flex-row min-w-0 flex-1",
             !railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -154,6 +154,7 @@ export function useNotebook() {
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const [hostedNotebookUrl, setHostedNotebookUrl] = useState<string | null>(null);
   const canWriteNotebookRef = useRef(true);
+  const initialLoadReadyForMutationsRef = useRef(false);
   const readyNotebookIdentityRef = useRef<string | null>(null);
 
   const [handleHost] = useState(
@@ -260,11 +261,22 @@ export function useNotebook() {
 
   const refreshCanAcceptCellMutations = useCallback(
     (handle = handleHost.current) => {
-      const canAccept = canWriteNotebookRef.current && (handle?.has_cells_map() ?? false);
+      const canAccept =
+        canWriteNotebookRef.current &&
+        initialLoadReadyForMutationsRef.current &&
+        (handle?.has_cells_map() ?? false);
       setCanAcceptCellMutations(canAccept);
       return canAccept;
     },
     [handleHost],
+  );
+
+  const setInitialLoadReadyForMutations = useCallback(
+    (ready: boolean) => {
+      initialLoadReadyForMutationsRef.current = ready;
+      refreshCanAcceptCellMutations();
+    },
+    [refreshCanAcceptCellMutations],
   );
 
   const focusCellInStore = useCallback((cellId: string) => {
@@ -277,9 +289,12 @@ export function useNotebook() {
       createNotebookController<NotebookHandle>({
         getHandle: () => handleHost.current,
         getEngine: () => engineRef.current,
-        canWriteCellSource: () => canWriteNotebookRef.current,
-        canEditStructure: () => canWriteNotebookRef.current,
-        canAcceptStructure: (handle) => handle.has_cells_map(),
+        canWriteCellSource: () =>
+          canWriteNotebookRef.current && initialLoadReadyForMutationsRef.current,
+        canEditStructure: () =>
+          canWriteNotebookRef.current && initialLoadReadyForMutationsRef.current,
+        canAcceptStructure: (handle) =>
+          initialLoadReadyForMutationsRef.current && handle.has_cells_map(),
         applyMutationEvent: (event) => {
           const engine = engineRef.current;
           return engine
@@ -309,6 +324,7 @@ export function useNotebook() {
       if (!bootstrapped) return false;
 
       setCanAcceptCellMutations(false);
+      initialLoadReadyForMutationsRef.current = false;
       setLoadError(null);
       setIsLoading(true);
 
@@ -363,6 +379,7 @@ export function useNotebook() {
       outputCache: outputCacheRef.current,
       projectExecutionViewChangeset,
       refreshCanAcceptCellMutations,
+      setInitialLoadReadyForMutations,
       setIsLoading,
       setLoadError,
       bootstrapTimeoutMs: BOOTSTRAP_INTERACTIVE_TIMEOUT_MS,
@@ -466,6 +483,7 @@ export function useNotebook() {
       resetRuntimeStoresProjection();
       resetPoolState();
       canWriteNotebookRef.current = false;
+      initialLoadReadyForMutationsRef.current = false;
       setCanAcceptCellMutations(false);
       handleHost.clear();
     };
@@ -476,6 +494,7 @@ export function useNotebook() {
     materializeCells,
     notifyRelayReady,
     refreshCanAcceptCellMutations,
+    setInitialLoadReadyForMutations,
   ]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
@@ -609,6 +628,21 @@ export function useNotebook() {
     [],
   );
 
+  /**
+   * Stable proxy for causal NotebookDoc change hints. Desktop title state
+   * subscribes once and performs the cheap head-containment query only when
+   * this fires or the daemon publishes a new file checkpoint.
+   */
+  const notebookDocChanged$ = useMemo(
+    () =>
+      new Observable<void>((subscriber) => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        return engine.notebookDocChanged$.subscribe(subscriber);
+      }),
+    [],
+  );
+
   return {
     cellIds,
     isLoading,
@@ -631,6 +665,7 @@ export function useNotebook() {
     getHandle,
     getEngine,
     sessionStatus$,
+    notebookDocChanged$,
     triggerSync,
     localActor,
     connectionScope,

--- a/apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts
@@ -83,6 +83,8 @@ describe("saveNotebook", () => {
     mockSendRequest.mockResolvedValueOnce({
       result: "notebook_saved",
       path: "/home/user/notebooks/MyNotebook.ipynb",
+      exported_heads: ["abc123"],
+      save_sequence: 1,
     });
 
     const result = await saveNotebook(stubHost, flushSync, true);
@@ -128,6 +130,27 @@ describe("saveNotebook", () => {
     const result = await saveNotebook(stubHost, flushSync, true);
 
     expect(result).toBe(false);
+  });
+
+  it("treats an already-current causal checkpoint as a successful save", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      result: "notebook_already_current",
+      path: "/home/user/notebooks/MyNotebook.ipynb",
+      exported_heads: ["abc123"],
+      save_sequence: 4,
+    });
+
+    await expect(saveNotebook(stubHost, flushSync, true)).resolves.toBe(true);
+  });
+
+  it("returns false for a typed blocked save outcome", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      result: "notebook_save_blocked",
+      save_sequence: 3,
+      reason: { type: "superseded", latest_sequence: 4 },
+    });
+
+    await expect(saveNotebook(stubHost, flushSync, true)).resolves.toBe(false);
   });
 
   it("returns false on transport failure", async () => {

--- a/apps/notebook/src/lib/__tests__/notebook-file-state.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-file-state.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { FileCheckpointState } from "runtimed";
+import {
+  fileSourceIssueNotice,
+  notebookDocumentIsDirty,
+  type NotebookCausalHeadsReader,
+} from "../notebook-file-state";
+
+const NO_CHECKPOINT: FileCheckpointState = {
+  exported_heads: [],
+  save_sequence: null,
+  source_issue: null,
+};
+
+function reader(result: boolean | undefined): NotebookCausalHeadsReader {
+  return {
+    has_changes_not_contained_by_heads: vi.fn(() => result),
+  };
+}
+
+describe("notebookDocumentIsDirty", () => {
+  it("keeps untitled notebooks dirty before a handle exists", () => {
+    expect(
+      notebookDocumentIsDirty({
+        ephemeral: true,
+        fileBacked: false,
+        fileCheckpoint: NO_CHECKPOINT,
+        handle: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("queries the whole causal history when no checkpoint has committed", () => {
+    const handle = reader(true);
+
+    expect(
+      notebookDocumentIsDirty({
+        ephemeral: false,
+        fileBacked: true,
+        fileCheckpoint: NO_CHECKPOINT,
+        handle,
+      }),
+    ).toBe(true);
+    expect(handle.has_changes_not_contained_by_heads).toHaveBeenCalledWith([]);
+  });
+
+  it("uses exported checkpoint heads instead of exact head-array equality", () => {
+    const handle = reader(false);
+    const fileCheckpoint: FileCheckpointState = {
+      exported_heads: ["head-a", "head-b"],
+      save_sequence: 4,
+      source_issue: null,
+    };
+
+    expect(
+      notebookDocumentIsDirty({ ephemeral: false, fileBacked: true, fileCheckpoint, handle }),
+    ).toBe(false);
+    expect(handle.has_changes_not_contained_by_heads).toHaveBeenCalledWith([
+      "head-a",
+      "head-b",
+    ]);
+
+    const dirtyHandle = reader(true);
+    expect(
+      notebookDocumentIsDirty({
+        ephemeral: false,
+        fileBacked: true,
+        fileCheckpoint,
+        handle: dirtyHandle,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not apply local file checkpoints to hosted notebooks", () => {
+    const handle = reader(true);
+
+    expect(
+      notebookDocumentIsDirty({
+        ephemeral: false,
+        fileBacked: false,
+        fileCheckpoint: NO_CHECKPOINT,
+        handle,
+      }),
+    ).toBe(false);
+    expect(handle.has_changes_not_contained_by_heads).not.toHaveBeenCalled();
+  });
+
+  it("waits for unknown checkpoint heads and fails closed on malformed heads", () => {
+    const fileCheckpoint: FileCheckpointState = {
+      exported_heads: ["not-here-yet"],
+      save_sequence: 2,
+      source_issue: null,
+    };
+
+    expect(
+      notebookDocumentIsDirty({
+        ephemeral: false,
+        fileBacked: true,
+        fileCheckpoint,
+        handle: reader(undefined),
+      }),
+    ).toBe(false);
+    expect(
+      notebookDocumentIsDirty({
+        ephemeral: false,
+        fileBacked: true,
+        fileCheckpoint,
+        handle: {
+          has_changes_not_contained_by_heads: () => {
+            throw new Error("invalid change hash");
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("fileSourceIssueNotice", () => {
+  it("projects calm conflict and degraded copy", () => {
+    expect(fileSourceIssueNotice(null)).toBeNull();
+    expect(
+      fileSourceIssueNotice({ kind: "conflict", reason: "Disk fingerprint changed." }),
+    ).toEqual({
+      title: "Notebook file needs reconciliation",
+      message:
+        "The live notebook and file on disk are both being preserved. Disk fingerprint changed.",
+    });
+    expect(
+      fileSourceIssueNotice({ kind: "degraded", reason: "Journal flush failed." }),
+    ).toEqual({
+      title: "Notebook recovery needs attention",
+      message:
+        "The notebook remains open, but durable recovery is not confirmed. Journal flush failed.",
+    });
+  });
+});

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -167,6 +167,7 @@ function startBridge(overrides: Partial<NotebookSyncStoreBridgeOptions> = {}) {
   };
   const projectExecutionViewChangeset = vi.fn(() => projection);
   const refreshCanAcceptCellMutations = vi.fn(() => true);
+  const setInitialLoadReadyForMutations = vi.fn();
   const setIsLoading = vi.fn();
   const setLoadError = vi.fn();
 
@@ -177,6 +178,7 @@ function startBridge(overrides: Partial<NotebookSyncStoreBridgeOptions> = {}) {
     outputCache: new Map(),
     projectExecutionViewChangeset,
     refreshCanAcceptCellMutations,
+    setInitialLoadReadyForMutations,
     setIsLoading,
     setLoadError,
     ...overrides,
@@ -190,6 +192,7 @@ function startBridge(overrides: Partial<NotebookSyncStoreBridgeOptions> = {}) {
     options,
     projectExecutionViewChangeset,
     refreshCanAcceptCellMutations,
+    setInitialLoadReadyForMutations,
     setIsLoading,
     setLoadError,
     subjects,
@@ -227,6 +230,7 @@ describe("startNotebookSyncStoreBridge", () => {
       materializeCells,
       projectExecutionViewChangeset,
       refreshCanAcceptCellMutations,
+      setInitialLoadReadyForMutations,
       setIsLoading,
       subjects,
     } = startBridge();
@@ -243,9 +247,38 @@ describe("startNotebookSyncStoreBridge", () => {
     expect(mocks.seedOutputStoresFromHandle).toHaveBeenCalledWith(handle, [
       "cell-1",
     ]);
-    expect(refreshCanAcceptCellMutations).toHaveBeenCalledWith(handle);
+    expect(setInitialLoadReadyForMutations).toHaveBeenLastCalledWith(true);
+    expect(refreshCanAcceptCellMutations).toHaveBeenCalledTimes(1);
     expect(setIsLoading).toHaveBeenLastCalledWith(false);
     expect(mocks.notifyMetadataChanged).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
+  it("keeps mutations disabled while a room source is streaming", async () => {
+    const {
+      bridge,
+      setInitialLoadReadyForMutations,
+      subjects,
+    } = startBridge();
+
+    subjects.sessionStatus$.next(streamingStatus());
+    subjects.initialSyncComplete$.next();
+    subjects.cellChanges$.next({
+      added: ["cell-1"],
+      changed: [],
+      order_changed: true,
+      removed: [],
+    });
+    await flushMicrotasks();
+
+    expect(setInitialLoadReadyForMutations).toHaveBeenCalledWith(false);
+    expect(setInitialLoadReadyForMutations).not.toHaveBeenCalledWith(true);
+
+    subjects.sessionStatus$.next(readyStatus());
+    await flushMicrotasks();
+
+    expect(setInitialLoadReadyForMutations).toHaveBeenLastCalledWith(true);
 
     bridge.stop();
   });

--- a/apps/notebook/src/lib/notebook-file-ops.ts
+++ b/apps/notebook/src/lib/notebook-file-ops.ts
@@ -1,5 +1,5 @@
 import type { NotebookHost } from "@nteract/notebook-host";
-import { NotebookClient, SaveNotebookError } from "runtimed";
+import { NotebookClient } from "runtimed";
 import { logger } from "./logger";
 
 /**
@@ -45,7 +45,11 @@ export async function saveNotebook(
 
     if (hasPath) {
       const client = new NotebookClient({ transport: host.transport });
-      await client.saveNotebook({ formatCells: true });
+      const outcome = await client.saveNotebook({ formatCells: true });
+      if (outcome.outcome === "blocked") {
+        logger.error("[notebook-file-ops] Save blocked:", outcome.reason);
+        return false;
+      }
     } else {
       const defaultDir = await host.notebook.getDefaultSaveDirectory();
       const filePath = await host.dialog.saveFile({
@@ -58,11 +62,7 @@ export async function saveNotebook(
 
     return true;
   } catch (e) {
-    if (e instanceof SaveNotebookError) {
-      logger.error("[notebook-file-ops] Save failed:", e.message);
-    } else {
-      logger.error("[notebook-file-ops] Save failed:", e);
-    }
+    logger.error("[notebook-file-ops] Save failed:", e);
     return false;
   }
 }

--- a/apps/notebook/src/lib/notebook-file-state.ts
+++ b/apps/notebook/src/lib/notebook-file-state.ts
@@ -1,0 +1,66 @@
+import type { FileCheckpointState, FileSourceIssue } from "runtimed";
+
+export interface NotebookCausalHeadsReader {
+  has_changes_not_contained_by_heads(heads: string[]): boolean | undefined;
+}
+
+export interface NotebookDirtyStateInput {
+  /** `true` for an untitled local room; `null` while room kind is unknown. */
+  ephemeral: boolean | null;
+  /** Whether this room is backed by a local notebook file. */
+  fileBacked: boolean;
+  fileCheckpoint: FileCheckpointState;
+  handle: NotebookCausalHeadsReader | null;
+}
+
+/**
+ * Project titlebar dirty state from causal NotebookDoc/file-checkpoint facts.
+ *
+ * Untitled notebooks remain dirty. A file-backed notebook is dirty only when
+ * its live local document has a change outside the exported checkpoint's
+ * causal history. An unavailable handle or checkpoint heads that have not yet
+ * reached this peer stay clean until the comparison becomes knowable, avoiding
+ * a false dirty flash during bootstrap.
+ */
+export function notebookDocumentIsDirty({
+  ephemeral,
+  fileBacked,
+  fileCheckpoint,
+  handle,
+}: NotebookDirtyStateInput): boolean {
+  if (ephemeral === true) return true;
+  if (!fileBacked || handle === null) return false;
+
+  const exportedHeads = fileCheckpoint.save_sequence === null ? [] : fileCheckpoint.exported_heads;
+  try {
+    return handle.has_changes_not_contained_by_heads([...exportedHeads]) ?? false;
+  } catch {
+    // A malformed checkpoint cannot prove that local work is durable. Fail
+    // closed in the title while the source issue projection catches up.
+    return true;
+  }
+}
+
+export interface FileSourceIssueNotice {
+  title: string;
+  message: string;
+}
+
+/** Calm, durable-state-derived notice copy for source recovery problems. */
+export function fileSourceIssueNotice(
+  issue: FileSourceIssue | null,
+): FileSourceIssueNotice | null {
+  if (issue === null) return null;
+  switch (issue.kind) {
+    case "conflict":
+      return {
+        title: "Notebook file needs reconciliation",
+        message: `The live notebook and file on disk are both being preserved. ${issue.reason}`,
+      };
+    case "degraded":
+      return {
+        title: "Notebook recovery needs attention",
+        message: `The notebook remains open, but durable recovery is not confirmed. ${issue.reason}`,
+      };
+  }
+}

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -35,6 +35,13 @@ type SyncEngineStoreStreams = Pick<
   | "poolState$"
 >;
 
+function initialLoadAllowsMutations(status: SessionStatus | null): boolean {
+  return (
+    status?.initial_load.phase === "ready" ||
+    status?.initial_load.phase === "not_needed"
+  );
+}
+
 export interface NotebookSyncStoreBridgeOptions {
   engine: SyncEngineStoreStreams;
   getHandle: () => NotebookHandle | null;
@@ -44,6 +51,7 @@ export interface NotebookSyncStoreBridgeOptions {
     handle: NotebookHandle,
   ) => ExecutionViewChangeset | null | undefined;
   refreshCanAcceptCellMutations: (handle?: NotebookHandle) => boolean;
+  setInitialLoadReadyForMutations: (ready: boolean) => void;
   setIsLoading: (isLoading: boolean) => void;
   setLoadError: (loadError: string | null) => void;
   bootstrapTimeoutMs?: number;
@@ -111,6 +119,7 @@ export function startNotebookSyncStoreBridge(
     initialLoadWasStreaming = false;
     latestSessionStatus = null;
     bootstrapTimeoutFired = false;
+    options.setInitialLoadReadyForMutations(false);
     armBootstrapTimeout();
   };
 
@@ -121,6 +130,7 @@ export function startNotebookSyncStoreBridge(
     const handle = options.getHandle();
     if (!handle) {
       initialMaterializeDeferred = false;
+      options.setInitialLoadReadyForMutations(false);
       options.setIsLoading(false);
       return;
     }
@@ -160,7 +170,9 @@ export function startNotebookSyncStoreBridge(
           options.projectExecutionViewChangeset(handle),
         );
         seedOutputStoresFromHandle(handle, cellIdList);
-        options.refreshCanAcceptCellMutations(handle);
+        options.setInitialLoadReadyForMutations(
+          initialLoadAllowsMutations(latestSessionStatus),
+        );
         options.setLoadError(null);
         options.setIsLoading(
           latestSessionStatus
@@ -174,6 +186,7 @@ export function startNotebookSyncStoreBridge(
         initialMaterializeInFlight = false;
         if (stopped) return;
         logger.warn("[automerge-notebook] initial materialize failed:", err);
+        options.setInitialLoadReadyForMutations(false);
         options.setLoadError(err instanceof Error ? err.message : String(err));
         options.setIsLoading(false);
       });
@@ -192,6 +205,7 @@ export function startNotebookSyncStoreBridge(
         initialMaterializeDeferred = false;
         initialLoadCurrentlyStreaming = false;
         initialLoadWasStreaming = false;
+        options.setInitialLoadReadyForMutations(false);
         options.setLoadError(status.initial_load.reason);
         options.setIsLoading(false);
         return;
@@ -204,6 +218,7 @@ export function startNotebookSyncStoreBridge(
       if (initialLoadStreaming) {
         initialLoadCurrentlyStreaming = true;
         initialLoadWasStreaming = true;
+        options.setInitialLoadReadyForMutations(false);
         clearBootstrapTimeout(true);
       } else if (
         !interactiveReady &&
@@ -220,6 +235,9 @@ export function startNotebookSyncStoreBridge(
         return;
       }
       if (interactiveReady) {
+        options.setInitialLoadReadyForMutations(
+          initialLoadAllowsMutations(latestSessionStatus),
+        );
         options.setIsLoading(initialLoadStreaming);
       }
     }),

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -271,6 +271,13 @@ export interface SyncableHandle {
   /** Current Automerge notebook document heads as hex strings. */
   get_heads_hex(): string[];
 
+  /**
+   * Whether the local NotebookDoc has changes outside the causal history of
+   * the supplied heads. `undefined` means one or more heads have not reached
+   * this peer yet, so containment is not currently knowable.
+   */
+  has_changes_not_contained_by_heads?(heads_hex: string[]): boolean | undefined;
+
   /** Dependency metadata fingerprint covered by trust approval. */
   get_dependency_fingerprint(): string | undefined;
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -200,6 +200,8 @@ export {
   type EnvProgressPhase,
   type ExecutionState,
   type ExecutionTransition,
+  type FileCheckpointState,
+  type FileSourceIssue,
   KERNEL_ERROR_REASON,
   type KernelActivity,
   type KernelErrorReasonKey,
@@ -556,7 +558,9 @@ export {
   NotebookClient,
   type ExecuteCellOptions,
   type NotebookClientOptions,
+  type ReconcileNotebookSourceOutcome,
   type RunAllCellsOptions,
+  type SaveNotebookOutcome,
   SaveNotebookError,
 } from "./notebook-client";
 export type {
@@ -575,7 +579,11 @@ export type {
   NotebookRequest,
   NotebookResponse,
   PackageManager,
+  SaveBlockedReason,
   SaveErrorKind,
+  SourceReconciliation,
+  SourceReconciliationBlockedReason,
+  SourceReconciliationOperation,
 } from "./request-types";
 
 // Blob upload

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -22,7 +22,11 @@ import type {
   HistoryEntry,
   NotebookRequest,
   NotebookResponse,
+  SaveBlockedReason,
   SaveErrorKind,
+  SourceReconciliation,
+  SourceReconciliationBlockedReason,
+  SourceReconciliationOperation,
 } from "./request-types";
 
 /**
@@ -90,6 +94,42 @@ export interface ApplyBokehSessionPatchOptions {
   patch: Record<string, unknown>;
   buffers?: BokehPatchBuffer[];
 }
+
+export type SaveNotebookOutcome =
+  | {
+      outcome: "saved";
+      path: string;
+      exportedHeads: string[];
+      saveSequence: number;
+    }
+  | {
+      outcome: "already_current";
+      path: string;
+      exportedHeads: string[];
+      saveSequence: number;
+    }
+  | {
+      outcome: "blocked";
+      path?: string | null;
+      saveSequence?: number | null;
+      reason: SaveBlockedReason;
+    };
+
+export type ReconcileNotebookSourceOutcome =
+  | {
+      outcome: "reconciled";
+      operation: SourceReconciliationOperation;
+      path: string;
+      archivedJournal?: string | null;
+      exportedHeads: string[];
+      saveSequence: number;
+      sourceGeneration: number;
+    }
+  | {
+      outcome: "blocked";
+      operation: SourceReconciliationOperation;
+      reason: SourceReconciliationBlockedReason;
+    };
 
 export class NotebookClient {
   private readonly transport: NotebookTransport;
@@ -348,11 +388,16 @@ export class NotebookClient {
    * uses the room's current path and returns `save_error` if the room
    * is still untitled.
    *
-   * Throws `SaveNotebookError` on structured `save_error` responses (the
-   * `.kind` payload carries `path_already_open` / `io` details). Throws
-   * a plain `Error` on transport failures or unexpected response shapes.
+   * Returns an honest causal outcome. Only `saved` means atomic replacement
+   * committed and advanced RuntimeStateDoc's file checkpoint;
+   * `already_current` emits no saved timestamp, and `blocked` exposes the
+   * structured reason without turning it into a timeout or false success.
+   * Transport failures and unexpected response shapes still throw.
    */
-  async saveNotebook(options: { formatCells: boolean; path?: string }): Promise<{ path: string }> {
+  async saveNotebook(options: {
+    formatCells: boolean;
+    path?: string;
+  }): Promise<SaveNotebookOutcome> {
     const request: NotebookRequest = {
       type: "save_notebook",
       format_cells: options.formatCells,
@@ -369,13 +414,84 @@ export class NotebookClient {
 
     switch (response.result) {
       case "notebook_saved":
-        return { path: response.path };
+        return {
+          outcome: "saved",
+          path: response.path,
+          exportedHeads: response.exported_heads,
+          saveSequence: response.save_sequence,
+        };
+      case "notebook_already_current":
+        return {
+          outcome: "already_current",
+          path: response.path,
+          exportedHeads: response.exported_heads,
+          saveSequence: response.save_sequence,
+        };
+      case "notebook_save_blocked":
+        return {
+          outcome: "blocked",
+          path: response.path,
+          saveSequence: response.save_sequence,
+          reason: response.reason,
+        };
       case "save_error":
-        throw new SaveNotebookError(response.error);
+        return {
+          outcome: "blocked",
+          path: options.path,
+          reason: response.error,
+        };
       case "error":
         throw new Error(`Daemon save failed: ${response.error}`);
       default:
         throw new Error(`Unexpected save_notebook response: ${JSON.stringify(response)}`);
+    }
+  }
+
+  /**
+   * Resolve a degraded room's recovered state against its bound `.ipynb`.
+   *
+   * This is intentionally separate from ordinary save/reload. The operation
+   * names which side wins (or preserves recovered state elsewhere), and the
+   * daemon restores mutation capabilities only after its file and recovery
+   * journal checkpoint commits.
+   */
+  async reconcileNotebookSource(
+    operation: SourceReconciliation,
+  ): Promise<ReconcileNotebookSourceOutcome> {
+    let response: NotebookResponse;
+    try {
+      response = await this.sendRequest(
+        { type: "reconcile_notebook_source", operation },
+        this.requiredHeadsOptions(),
+      );
+    } catch (e) {
+      this.log.error("[notebook-client] Source reconciliation request failed:", e);
+      throw e;
+    }
+
+    switch (response.result) {
+      case "notebook_source_reconciled":
+        return {
+          outcome: "reconciled",
+          operation: response.operation,
+          path: response.path,
+          archivedJournal: response.archived_journal,
+          exportedHeads: response.exported_heads,
+          saveSequence: response.save_sequence,
+          sourceGeneration: response.source_generation,
+        };
+      case "notebook_source_reconciliation_blocked":
+        return {
+          outcome: "blocked",
+          operation: response.operation,
+          reason: response.reason,
+        };
+      case "error":
+        throw new Error(`Daemon source reconciliation failed: ${response.error}`);
+      default:
+        throw new Error(
+          `Unexpected reconcile_notebook_source response: ${JSON.stringify(response)}`,
+        );
     }
   }
 

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -360,6 +360,24 @@ export interface WorkstationAttachmentState {
   runtime_session_id?: string | null;
 }
 
+/** Why the file-backed source is not currently healthy. */
+export type FileSourceIssue =
+  | { kind: "conflict"; reason: string }
+  | { kind: "degraded"; reason: string };
+
+/**
+ * Causal `.ipynb` checkpoint projected by the daemon.
+ *
+ * Empty heads plus a null sequence means no file checkpoint has committed.
+ * `source_issue` is independent so a recovery conflict can be surfaced even
+ * before any checkpoint exists.
+ */
+export interface FileCheckpointState {
+  exported_heads: string[];
+  save_sequence: number | null;
+  source_issue: FileSourceIssue | null;
+}
+
 export interface RuntimeState {
   /**
    * RuntimeStateDoc identity. Mirrors the NotebookDoc's runtime_state_doc_id
@@ -371,6 +389,8 @@ export interface RuntimeState {
   env: EnvState;
   trust: TrustState;
   last_saved: string | null;
+  /** Daemon-authored causal file checkpoint and source health. */
+  file_checkpoint: FileCheckpointState;
   /**
    * Path to the notebook's `.ipynb` on the daemon's disk. `null` for
    * untitled notebooks; the daemon writes this on save / save-as.
@@ -427,6 +447,11 @@ export const DEFAULT_RUNTIME_STATE: RuntimeState = {
     approved_pixi_channels: [],
   },
   last_saved: null,
+  file_checkpoint: {
+    exported_heads: [],
+    save_sequence: null,
+    source_issue: null,
+  },
   path: null,
   executions: {},
   comms: {},

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -94,6 +94,124 @@ describe("NotebookClient", () => {
     });
   });
 
+  it("returns the committed causal save checkpoint", async () => {
+    const { client, sendRequest } = stubClient();
+    sendRequest.mockResolvedValueOnce({
+      result: "notebook_saved",
+      path: "/tmp/notebook.ipynb",
+      exported_heads: ["head-a"],
+      save_sequence: 7,
+    });
+
+    await expect(client.saveNotebook({ formatCells: true })).resolves.toEqual({
+      outcome: "saved",
+      path: "/tmp/notebook.ipynb",
+      exportedHeads: ["head-a"],
+      saveSequence: 7,
+    });
+  });
+
+  it("distinguishes already-current from a new checkpoint", async () => {
+    const { client, sendRequest } = stubClient();
+    sendRequest.mockResolvedValueOnce({
+      result: "notebook_already_current",
+      path: "/tmp/notebook.ipynb",
+      exported_heads: ["head-a"],
+      save_sequence: 7,
+    });
+
+    await expect(client.saveNotebook({ formatCells: false })).resolves.toEqual({
+      outcome: "already_current",
+      path: "/tmp/notebook.ipynb",
+      exportedHeads: ["head-a"],
+      saveSequence: 7,
+    });
+  });
+
+  it("returns structured blocked save state without throwing", async () => {
+    const { client, sendRequest } = stubClient();
+    sendRequest.mockResolvedValueOnce({
+      result: "notebook_save_blocked",
+      save_sequence: 3,
+      reason: { type: "superseded", latest_sequence: 4 },
+    });
+
+    await expect(client.saveNotebook({ formatCells: false })).resolves.toEqual({
+      outcome: "blocked",
+      path: undefined,
+      saveSequence: 3,
+      reason: { type: "superseded", latest_sequence: 4 },
+    });
+  });
+
+  it("reconciles a disk-source conflict behind the caller's required heads", async () => {
+    const { client, flush, sendRequest } = stubClientWithHeads(["head-a"]);
+    sendRequest.mockResolvedValueOnce({
+      result: "notebook_source_reconciled",
+      operation: "archive_recovery_and_reload_source",
+      path: "/tmp/notebook.ipynb",
+      archived_journal: "/tmp/room.recovery.archived",
+      exported_heads: ["head-disk"],
+      save_sequence: 8,
+      source_generation: 4,
+    });
+
+    await expect(
+      client.reconcileNotebookSource({ type: "archive_recovery_and_reload_source" }),
+    ).resolves.toEqual({
+      outcome: "reconciled",
+      operation: "archive_recovery_and_reload_source",
+      path: "/tmp/notebook.ipynb",
+      archivedJournal: "/tmp/room.recovery.archived",
+      exportedHeads: ["head-disk"],
+      saveSequence: 8,
+      sourceGeneration: 4,
+    });
+    expect(flush).toHaveBeenCalledOnce();
+    expect(sendRequest).toHaveBeenCalledWith(
+      {
+        type: "reconcile_notebook_source",
+        operation: { type: "archive_recovery_and_reload_source" },
+      },
+      { required_heads: ["head-a"] },
+    );
+  });
+
+  it("returns a structured source-reconciliation block without false success", async () => {
+    const { client, sendRequest } = stubClient();
+    sendRequest.mockResolvedValueOnce({
+      result: "notebook_source_reconciliation_blocked",
+      operation: "save_recovered_as",
+      reason: {
+        type: "target_must_differ",
+        bound_path: "/tmp/notebook.ipynb",
+        requested_path: "/tmp/notebook.ipynb",
+      },
+    });
+
+    await expect(
+      client.reconcileNotebookSource({
+        type: "save_recovered_as",
+        path: "/tmp/notebook.ipynb",
+      }),
+    ).resolves.toEqual({
+      outcome: "blocked",
+      operation: "save_recovered_as",
+      reason: {
+        type: "target_must_differ",
+        bound_path: "/tmp/notebook.ipynb",
+        requested_path: "/tmp/notebook.ipynb",
+      },
+    });
+    expect(sendRequest).toHaveBeenCalledWith({
+      type: "reconcile_notebook_source",
+      operation: {
+        type: "save_recovered_as",
+        path: "/tmp/notebook.ipynb",
+      },
+    });
+  });
+
   it("attaches required heads to daemon-managed execute requests", async () => {
     const { client, flush, sendRequest } = stubClientWithHeads(["head-a"]);
 

--- a/packages/runtimed/tests/runtime-state-file-checkpoint.test.ts
+++ b/packages/runtimed/tests/runtime-state-file-checkpoint.test.ts
@@ -1,0 +1,50 @@
+import {
+  DEFAULT_RUNTIME_STATE,
+  type FileCheckpointState,
+  type FileSourceIssue,
+  type RuntimeState,
+} from "runtimed";
+import { describe, expect, it } from "vite-plus/test";
+
+function issueLabel(issue: FileSourceIssue | null): string | null {
+  if (issue === null) return null;
+  switch (issue.kind) {
+    case "conflict":
+      return `conflict: ${issue.reason}`;
+    case "degraded":
+      return `degraded: ${issue.reason}`;
+  }
+}
+
+describe("RuntimeState file checkpoint", () => {
+  it("defaults to no checkpoint and no source issue", () => {
+    expect(DEFAULT_RUNTIME_STATE.file_checkpoint).toEqual({
+      exported_heads: [],
+      save_sequence: null,
+      source_issue: null,
+    });
+  });
+
+  it("carries exact exported heads, sequence, and tagged source issues", () => {
+    const checkpoint: FileCheckpointState = {
+      exported_heads: ["aa11", "bb22"],
+      save_sequence: 17,
+      source_issue: {
+        kind: "conflict",
+        reason: "disk and recovery journal diverged",
+      },
+    };
+    const state: RuntimeState = {
+      ...DEFAULT_RUNTIME_STATE,
+      file_checkpoint: checkpoint,
+    };
+
+    expect(state.file_checkpoint).toEqual(checkpoint);
+    expect(issueLabel(state.file_checkpoint.source_issue)).toBe(
+      "conflict: disk and recovery journal diverged",
+    );
+    expect(issueLabel({ kind: "degraded", reason: "journal flush failed" })).toBe(
+      "degraded: journal flush failed",
+    );
+  });
+});

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -165,6 +165,7 @@ function makeRuntimeState(
     project_context: { state: "Pending" },
     workstation: null,
     last_saved: null,
+    file_checkpoint: { exported_heads: [], save_sequence: null, source_issue: null },
     executions: executions as RuntimeState["executions"],
     comms: {},
     bokeh_sessions: {},
@@ -820,6 +821,7 @@ describe("SyncEngine", () => {
         project_context: { state: "Pending" },
         workstation: null,
         last_saved: null,
+        file_checkpoint: { exported_heads: [], save_sequence: null, source_issue: null },
         executions: {},
         comms: {},
         bokeh_sessions: {},
@@ -914,6 +916,7 @@ describe("SyncEngine", () => {
         project_context: { state: "Pending" },
         workstation: null,
         last_saved: null,
+        file_checkpoint: { exported_heads: [], save_sequence: null, source_issue: null },
         executions: {
           "exec-1": {
             status: "running",


### PR DESCRIPTION
## Summary

PR 5 of 6 in the room lifecycle stack (carved from #3997, related to #3907). Migrates desktop dirty-state and save reporting from timestamps to causal exported heads:

- `notebook-file-state.ts`: dirty/saved derived from exported heads vs document heads, not wall-clock comparison
- save flows consume the typed `Saved`/`AlreadyCurrent`/`Blocked` outcomes from #4011; `last_saved` stays display metadata only
- `packages/runtimed`: the TS client exposes `FileCheckpointState`/`FileSourceIssue` from RuntimeStateDoc and the new save outcome shapes

## Stack

1. #4009 room-loader foundations and ADRs
2. #4010 durability primitives
3. #4016 room source lifecycle and staged imports
4. #4011 causal saves and explicit reconciliation (base of this PR)
5. client causal dirty-state (this PR)
6. #4013 progressive MCP connect

## Validation

- `pnpm --dir packages/runtimed run typecheck` clean
- vp test over packages/runtimed and apps/notebook/src/lib: 1085 passed; only the known local-only isolated-diagnostics localStorage flake failed (passes in CI)
- `pnpm --dir apps/notebook build` clean
