### PR TITLE
refactor(runtimed): delete room substrate shims

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4618,9 +4618,7 @@ impl Daemon {
             }
 
             Request::GetNotebookProjection { notebook_id } => {
-                use crate::notebook_sync_server::{
-                    RoomAvailability, RoomAvailabilityTarget, RoomSourceState,
-                };
+                use crate::notebook_sync_server::{RoomAvailability, RoomSourceState};
                 use runtimed_client::protocol::NotebookProjectionFailure;
 
                 info!(
@@ -4641,10 +4639,7 @@ impl Daemon {
 
                 let availability = room
                     .lifecycle
-                    .wait_for_availability(
-                        RoomAvailabilityTarget::ProjectionReady,
-                        std::time::Duration::from_secs(120),
-                    )
+                    .wait_for_projection_ready(std::time::Duration::from_secs(120))
                     .await
                     .into_current();
                 let generation = match availability {

--- a/crates/runtimed/src/notebook_sync_server/lifecycle.rs
+++ b/crates/runtimed/src/notebook_sync_server/lifecycle.rs
@@ -156,14 +156,6 @@ impl RoomAvailability {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
-pub enum RoomAvailabilityTarget {
-    Attached,
-    ProjectionReady,
-    Interactive,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RoomWaitResult<T> {
     Reached(T),
@@ -183,8 +175,6 @@ impl<T> RoomWaitResult<T> {
 pub struct StagedChangeBatch {
     pub changes: Vec<Change>,
     pub hashes: Vec<ChangeHash>,
-    #[allow(dead_code)]
-    pub resulting_heads: Vec<ChangeHash>,
 }
 
 #[derive(Clone)]
@@ -1188,9 +1178,8 @@ impl RoomLifecycle {
         }
     }
 
-    pub async fn wait_for_availability(
+    pub async fn wait_for_projection_ready(
         &self,
-        target: RoomAvailabilityTarget,
         timeout: Duration,
     ) -> RoomWaitResult<RoomAvailability> {
         let mut receiver = self.subscribe_availability();
@@ -1198,16 +1187,8 @@ impl RoomLifecycle {
             loop {
                 let state = receiver.borrow().clone();
                 let reached = matches!(
-                    (target, &state),
-                    (RoomAvailabilityTarget::Attached, _)
-                        | (
-                            RoomAvailabilityTarget::ProjectionReady,
-                            RoomAvailability::ProjectionReady(_) | RoomAvailability::Interactive(_)
-                        )
-                        | (
-                            RoomAvailabilityTarget::Interactive,
-                            RoomAvailability::Interactive(_)
-                        )
+                    &state,
+                    RoomAvailability::ProjectionReady(_) | RoomAvailability::Interactive(_)
                 );
                 if reached || matches!(state, RoomAvailability::Degraded(_)) {
                     return state;
@@ -1314,10 +1295,7 @@ mod tests {
         let lifecycle = RoomLifecycle::test_default();
         lifecycle.mark_source_required();
         let result = lifecycle
-            .wait_for_availability(
-                RoomAvailabilityTarget::ProjectionReady,
-                Duration::from_millis(1),
-            )
+            .wait_for_projection_ready(Duration::from_millis(1))
             .await;
         assert!(matches!(
             result,

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -24,11 +24,6 @@ pub(crate) struct ParsedIpynbCells {
 /// nbformat 4.5 and removing the ordinal fallback.
 ///
 /// Positions are generated incrementally using fractional indexing.
-#[cfg(test)]
-pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedIpynbCells> {
-    parse_cells_from_ipynb_for_notebook(json, uuid::Uuid::nil())
-}
-
 pub(crate) fn parse_cells_from_ipynb_for_notebook(
     json: &serde_json::Value,
     notebook_id: uuid::Uuid,
@@ -247,12 +242,7 @@ fn jobj_get<'a, 's>(
 /// Returns `(cells, Option<metadata_snapshot>)`. Outputs are kept as
 /// `serde_json::Value` so they can be passed directly to `create_manifest`
 /// without a serialize→parse round-trip.
-#[cfg(test)]
-pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebook, String> {
-    parse_notebook_jiter_for_notebook(bytes, uuid::Uuid::nil())
-}
-
-fn parse_notebook_jiter_for_notebook(
+pub(crate) fn parse_notebook_jiter_for_notebook(
     bytes: &[u8],
     notebook_id: uuid::Uuid,
 ) -> Result<ParsedStreamingNotebook, String> {
@@ -838,17 +828,12 @@ fn capture_staged_batch(
     staged: &mut NotebookDoc,
     previous_heads: &[automerge::ChangeHash],
 ) -> Option<StagedChangeBatch> {
-    let resulting_heads = staged.get_heads();
     let changes = staged.doc_mut().get_changes(previous_heads);
     if changes.is_empty() {
         return None;
     }
     let hashes = changes.iter().map(automerge::Change::hash).collect();
-    Some(StagedChangeBatch {
-        changes,
-        hashes,
-        resulting_heads,
-    })
+    Some(StagedChangeBatch { changes, hashes })
 }
 
 async fn stage_initial_import(
@@ -1731,7 +1716,7 @@ pub(crate) async fn prepare_notebook_load(
         cells,
         outputs_by_cell,
         attachments: nbformat_attachments,
-    } = parse_cells_from_ipynb(&json)
+    } = parse_cells_from_ipynb_for_notebook(&json, uuid::Uuid::nil())
         .ok_or_else(|| "Failed to parse cells from notebook".to_string())?;
     let widget_comms = widget_comms_from_notebook_metadata(json.get("metadata"), blob_store).await;
     let context_id = path.to_string_lossy().to_string();

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -203,22 +203,8 @@ pub(crate) async fn save_notebook_to_disk(
                 save_sequence: None,
                 reason: notebook_protocol::protocol::SaveBlockedReason::SequenceExhausted,
             })?;
-    save_notebook_to_disk_with_claim(room, target_path, claim).await
-}
-
-/// Save using a sequence reserved by the request handler before formatting.
-pub(crate) async fn save_notebook_to_disk_with_claim(
-    room: &NotebookRoom,
-    target_path: Option<&str>,
-    save_claim: super::file_checkpoint::SaveSequenceClaim,
-) -> Result<FileSaveOutcome, SaveError> {
-    save_notebook_to_disk_with_claim_and_intent(
-        room,
-        target_path,
-        save_claim,
-        FileSaveIntent::Ordinary,
-    )
-    .await
+    save_notebook_to_disk_with_claim_and_intent(room, target_path, claim, FileSaveIntent::Ordinary)
+        .await
 }
 
 pub(crate) async fn save_notebook_to_disk_with_claim_and_intent(

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -983,12 +983,6 @@ impl ReservationGuard {
             .fetch_add(1, Ordering::Relaxed);
         Self { room }
     }
-
-    /// The room this guard is reserving.
-    #[allow(dead_code)]
-    pub fn room(&self) -> &Arc<NotebookRoom> {
-        &self.room
-    }
 }
 
 impl Drop for ReservationGuard {

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -821,22 +821,6 @@ async fn reservation_guards_stack() {
 }
 
 #[tokio::test]
-async fn reservation_guard_room_accessor_returns_same_arc() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let blob_store = test_blob_store(&tmp);
-    let room = Arc::new(NotebookRoom::new_fresh(
-        Uuid::new_v4(),
-        None,
-        tmp.path(),
-        blob_store,
-        false,
-    ));
-
-    let guard = ReservationGuard::new(room.clone());
-    assert!(Arc::ptr_eq(guard.room(), &room));
-}
-
-#[tokio::test]
 async fn test_room_load_or_create_new() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
@@ -1003,10 +987,7 @@ async fn published_room_source_claim_cancellation_terminalizes_projection_waits(
     ));
     let waited = room
         .lifecycle
-        .wait_for_availability(
-            RoomAvailabilityTarget::ProjectionReady,
-            std::time::Duration::from_secs(1),
-        )
+        .wait_for_projection_ready(std::time::Duration::from_secs(1))
         .await;
     assert!(matches!(
         waited,
@@ -3990,7 +3971,8 @@ fn test_parse_cells_from_ipynb_with_ids() {
         ]
     });
 
-    let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
+    let parsed = parse_cells_from_ipynb_for_notebook(&json, Uuid::nil())
+        .expect("Should parse valid notebook");
     let cells = &parsed.cells;
     assert_eq!(cells.len(), 2);
     assert_eq!(cells[0].id, "cell-1");
@@ -4025,7 +4007,8 @@ fn test_parse_cells_from_ipynb_missing_ids() {
         ]
     });
 
-    let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
+    let parsed = parse_cells_from_ipynb_for_notebook(&json, Uuid::nil())
+        .expect("Should parse valid notebook");
     let cells = &parsed.cells;
     assert_eq!(cells.len(), 2);
     // Should derive UUIDs for ID-less cells so recovery and watcher reparses
@@ -4071,7 +4054,8 @@ fn test_parse_cells_from_ipynb_empty() {
     let json = serde_json::json!({
         "cells": []
     });
-    let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid empty notebook");
+    let parsed = parse_cells_from_ipynb_for_notebook(&json, Uuid::nil())
+        .expect("Should parse valid empty notebook");
     assert!(parsed.cells.is_empty());
     assert!(parsed.outputs_by_cell.is_empty());
 }
@@ -4083,7 +4067,7 @@ fn test_parse_cells_from_ipynb_no_cells_key() {
         "metadata": {}
     });
     assert!(
-        parse_cells_from_ipynb(&json).is_none(),
+        parse_cells_from_ipynb_for_notebook(&json, Uuid::nil()).is_none(),
         "Should return None for invalid notebook"
     );
 }
@@ -5933,7 +5917,7 @@ async fn bench_streaming_load_steps() {
     let read_elapsed = t0.elapsed();
 
     let t_parse = std::time::Instant::now();
-    let parsed = parse_notebook_jiter(&bytes).unwrap();
+    let parsed = parse_notebook_jiter_for_notebook(&bytes, Uuid::nil()).unwrap();
     let cells = parsed.cells;
     let parse_elapsed = t_parse.elapsed();
 
@@ -11898,14 +11882,15 @@ fn parse_notebook_jiter_errors_on_missing_or_invalid_cells() {
     // Missing `cells` key -> Err (was previously Ok with empty cells).
     let missing = br#"{"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
     assert!(
-        parse_notebook_jiter(missing).is_err(),
+        parse_notebook_jiter_for_notebook(missing, Uuid::nil()).is_err(),
         "a notebook with no cells key must fail to load"
     );
     // `cells` present but not an array -> Err (unchanged).
     let not_array = br#"{"cells":{},"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
-    assert!(parse_notebook_jiter(not_array).is_err());
+    assert!(parse_notebook_jiter_for_notebook(not_array, Uuid::nil()).is_err());
     // A genuine empty notebook (cells: []) still parses successfully.
     let empty = br#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
-    let ok = parse_notebook_jiter(empty).expect("cells: [] is a valid empty notebook");
+    let ok = parse_notebook_jiter_for_notebook(empty, Uuid::nil())
+        .expect("cells: [] is a valid empty notebook");
     assert_eq!(ok.cells.len(), 0);
 }

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -257,13 +257,9 @@ async fn handle_with_intent(
     if was_untitled {
         if let Err(message) = finalize_untitled_promotion(room, canonical.clone()).await {
             NotebookFileBinding::release_path(&daemon.notebook_rooms, &canonical).await;
-            let save_sequence = match &save_outcome {
-                FileSaveOutcome::Saved { save_sequence, .. }
-                | FileSaveOutcome::AlreadyCurrent { save_sequence, .. } => *save_sequence,
-            };
             return NotebookResponse::NotebookSaveBlocked {
                 path: Some(written),
-                save_sequence: Some(save_sequence),
+                save_sequence: Some(checkpoint_sequence),
                 reason: notebook_protocol::protocol::SaveBlockedReason::Io { message },
             };
         }


### PR DESCRIPTION
Room substrate micro-deletions: `RoomAvailabilityTarget` collapses into `wait_for_projection_ready`, `ReservationGuard::room` and its self-referential test go, `save_notebook_to_disk_with_claim` is inlined, nil-uuid parser shims become explicit `Uuid::nil()` at test sites, `StagedChangeBatch::resulting_heads` is dropped, and `save_notebook.rs` reuses the already-reserved `checkpoint_sequence`.

Behavior is unchanged at every site:

- Projection waits still return early for degraded rooms so recovery surfaces remain readable while mutation stays gated.
- Handshake reservations still increment and decrement the room reservation count until attach commits or aborts.
- Save requests still use the checkpoint sequence reserved before formatting, and stale save continuations still report the committed sequence.
- Parser tests now name the nil notebook id explicitly, preserving legacy idless-cell derivation without parser shims.
- Staged imports still publish the captured changes and hashes without retaining unused resulting heads.

Item-13 micro-deletions from `docs/memos/room-lifecycle-simplification-and-verification.md`; lifecycle.rs edits stay green under the transition-lock lint (#4021).
