### PR TITLE
refactor(runtimed): extract the watcher ingest classifier and drop the self-write window

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -769,7 +769,7 @@ pub(crate) async fn save_notebook_to_disk_with_claim_and_intent(
         }
         if !room
             .persistence
-            .note_primary_save_baseline(checkpoint.save_sequence, saved, &content_bytes, true)
+            .note_primary_save_baseline(checkpoint.save_sequence, saved, &content_bytes)
             .await
         {
             debug!(
@@ -815,7 +815,6 @@ pub(crate) async fn refresh_primary_baseline_from_checkpoint(
     room: &NotebookRoom,
     path: &Path,
     save_sequence: u64,
-    self_write: bool,
 ) -> bool {
     let bytes = match tokio::fs::read(path).await {
         Ok(bytes) => bytes,
@@ -862,7 +861,7 @@ pub(crate) async fn refresh_primary_baseline_from_checkpoint(
         .map(|cell| (cell.id, cell.source))
         .collect();
     room.persistence
-        .note_primary_save_baseline(save_sequence, sources, &bytes, self_write)
+        .note_primary_save_baseline(save_sequence, sources, &bytes)
         .await
 }
 
@@ -2174,9 +2173,6 @@ async fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 // Watch .ipynb files for external changes (git, VS Code, other editors).
 // When changes are detected, merge them into the Automerge doc and broadcast.
 
-/// Time window (ms) to skip file change events after our own writes.
-pub(crate) const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
-
 /// One debounced watcher observation, reduced to the side-effect-free reads
 /// that decide skip versus ingest. Captured once per event so the decision
 /// can be exercised as a pure function.
@@ -2184,10 +2180,6 @@ pub(crate) const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
 pub(crate) struct WatcherObservation {
     /// Fingerprint of the bytes currently on disk at the watched path.
     pub(crate) observed: super::recovery::SourceFingerprint,
-    /// Milliseconds since epoch at classification time.
-    pub(crate) now_ms: u64,
-    /// Milliseconds since epoch of the last self-write baseline install.
-    pub(crate) last_self_write_ms: u64,
     /// Disk baseline recorded by saves and watcher merges
     /// ([`RoomPersistence::known_disk_hash`]). `None` disables that guard.
     pub(crate) known_disk_hash: Option<[u8; 32]>,
@@ -2204,8 +2196,6 @@ pub(crate) struct WatcherObservation {
 /// Which guard suppressed a watcher observation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WatcherSkipReason {
-    /// The event landed inside the self-write suppression window.
-    SelfWriteWindow,
     /// Bytes match the disk baseline recorded by saves and watcher merges.
     KnownDiskContent,
     /// Bytes match the committed manifest source fingerprint.
@@ -2238,13 +2228,6 @@ pub(crate) enum WatcherIngestDecision {
 pub(crate) fn classify_watcher_observation(
     observation: &WatcherObservation,
 ) -> WatcherIngestDecision {
-    if observation
-        .now_ms
-        .saturating_sub(observation.last_self_write_ms)
-        < SELF_WRITE_SKIP_WINDOW_MS
-    {
-        return WatcherIngestDecision::Skip(WatcherSkipReason::SelfWriteWindow);
-    }
     if observation.known_disk_hash == Some(*observation.observed.as_bytes()) {
         return WatcherIngestDecision::Skip(WatcherSkipReason::KnownDiskContent);
     }
@@ -2319,8 +2302,6 @@ pub(crate) async fn process_watcher_event(room: &NotebookRoom, notebook_path: &P
     let manifest = room.durability.manifest();
     let observation = WatcherObservation {
         observed: super::recovery::source_fingerprint(contents.as_bytes()),
-        now_ms: unix_now_ms(),
-        last_self_write_ms: room.persistence.last_self_write.load(Ordering::Relaxed),
         known_disk_hash: room.persistence.known_disk_hash(),
         manifest_fingerprint: manifest.source_fingerprint,
         pending_checkpoint_fingerprint: manifest
@@ -2449,7 +2430,7 @@ pub(crate) async fn process_watcher_event(room: &NotebookRoom, notebook_path: &P
             .collect();
         let _ = room
             .persistence
-            .note_primary_save_baseline(source_save_sequence, sources, contents.as_bytes(), false)
+            .note_primary_save_baseline(source_save_sequence, sources, contents.as_bytes())
             .await;
     }
 

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -2177,6 +2177,86 @@ async fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 /// Time window (ms) to skip file change events after our own writes.
 pub(crate) const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
 
+/// One debounced watcher observation, reduced to the side-effect-free reads
+/// that decide skip versus ingest. Captured once per event so the decision
+/// can be exercised as a pure function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WatcherObservation {
+    /// Fingerprint of the bytes currently on disk at the watched path.
+    pub(crate) observed: super::recovery::SourceFingerprint,
+    /// Milliseconds since epoch at classification time.
+    pub(crate) now_ms: u64,
+    /// Milliseconds since epoch of the last self-write baseline install.
+    pub(crate) last_self_write_ms: u64,
+    /// Disk baseline recorded by saves and watcher merges
+    /// ([`RoomPersistence::known_disk_hash`]). `None` disables that guard.
+    pub(crate) known_disk_hash: Option<[u8; 32]>,
+    /// Committed source fingerprint from the durability manifest, advanced
+    /// at journal-commit time under the checkpoint coordinator lock.
+    pub(crate) manifest_fingerprint: super::recovery::SourceFingerprint,
+    /// Fingerprint of a prepared-but-uncommitted file checkpoint. Present
+    /// only inside the rename-to-commit window of an in-flight save, when
+    /// the new bytes are visible on disk but the manifest still names the
+    /// previous source fingerprint.
+    pub(crate) pending_checkpoint_fingerprint: Option<super::recovery::SourceFingerprint>,
+}
+
+/// Which guard suppressed a watcher observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WatcherSkipReason {
+    /// The event landed inside the self-write suppression window.
+    SelfWriteWindow,
+    /// Bytes match the disk baseline recorded by saves and watcher merges.
+    KnownDiskContent,
+    /// Bytes match the committed manifest source fingerprint.
+    ManifestFingerprint,
+    /// Bytes match a prepared checkpoint whose journal commit has not
+    /// landed yet (the rename-to-commit window).
+    PendingCheckpoint,
+}
+
+/// The watcher's skip/ingest decision for one debounced observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WatcherIngestDecision {
+    Skip(WatcherSkipReason),
+    Ingest,
+}
+
+/// Decide whether a debounced file event carries new disk truth.
+///
+/// Pure over the captured observation: bytes already reconciled carry no new
+/// disk truth, and skipping them is load-bearing on Linux where inotify
+/// reports reads (IN_ACCESS): a poller merely reading the file would
+/// otherwise re-run the merge on every debounce window, churning the journal,
+/// resetting the autosave debounce, and bumping the source generation for
+/// content the room already ingested. Three fingerprint sources of "already
+/// known": the disk baseline recorded by saves and watcher merges, the
+/// manifest fingerprint recorded at journal-commit time (which also covers
+/// the initial load, which never sets the save baseline), and the pending
+/// checkpoint fingerprint covering the rename-to-commit window of an
+/// in-flight save. Anything else is genuine external truth to ingest.
+pub(crate) fn classify_watcher_observation(
+    observation: &WatcherObservation,
+) -> WatcherIngestDecision {
+    if observation
+        .now_ms
+        .saturating_sub(observation.last_self_write_ms)
+        < SELF_WRITE_SKIP_WINDOW_MS
+    {
+        return WatcherIngestDecision::Skip(WatcherSkipReason::SelfWriteWindow);
+    }
+    if observation.known_disk_hash == Some(*observation.observed.as_bytes()) {
+        return WatcherIngestDecision::Skip(WatcherSkipReason::KnownDiskContent);
+    }
+    if observation.observed == observation.manifest_fingerprint {
+        return WatcherIngestDecision::Skip(WatcherSkipReason::ManifestFingerprint);
+    }
+    if observation.pending_checkpoint_fingerprint == Some(observation.observed) {
+        return WatcherIngestDecision::Skip(WatcherSkipReason::PendingCheckpoint);
+    }
+    WatcherIngestDecision::Ingest
+}
+
 /// Preserve both disk and journal truth when an external file revision races
 /// unsaved causal heads. This transition is shared by the watcher and tests so
 /// the structured `source_conflict` state cannot drift from the detection
@@ -2219,6 +2299,184 @@ pub(crate) async fn mark_external_source_conflict_if_needed(
     }
     warn!("[notebook-watch] {reason}");
     true
+}
+
+/// Handle one debounced watcher event for `notebook_path`: read the file,
+/// classify the observation against the room's skip baselines, and ingest
+/// genuine external truth. Extracted from the watcher loop so tests can
+/// drive the classifier and ingest seams directly instead of through real
+/// filesystem notifications.
+pub(crate) async fn process_watcher_event(room: &NotebookRoom, notebook_path: &Path) {
+    // Read and parse the file
+    let contents = match tokio::fs::read_to_string(notebook_path).await {
+        Ok(c) => c,
+        Err(e) => {
+            // File may be deleted or being written
+            debug!("[notebook-watch] Cannot read {:?}: {}", notebook_path, e);
+            return;
+        }
+    };
+    let manifest = room.durability.manifest();
+    let observation = WatcherObservation {
+        observed: super::recovery::source_fingerprint(contents.as_bytes()),
+        now_ms: unix_now_ms(),
+        last_self_write_ms: room.persistence.last_self_write.load(Ordering::Relaxed),
+        known_disk_hash: room.persistence.known_disk_hash(),
+        manifest_fingerprint: manifest.source_fingerprint,
+        pending_checkpoint_fingerprint: manifest
+            .pending_file_checkpoint
+            .map(|pending| pending.file_fingerprint),
+    };
+    let observed_fingerprint = observation.observed;
+    match classify_watcher_observation(&observation) {
+        WatcherIngestDecision::Skip(reason) => {
+            debug!(
+                "[notebook-watch] Skipping event for {:?} ({:?})",
+                notebook_path, reason
+            );
+            return;
+        }
+        WatcherIngestDecision::Ingest => {}
+    }
+
+    // A journal with heads newer than its causal file
+    // checkpoint represents unsaved collaborative
+    // truth. If disk changed to different bytes, keep
+    // both versions and require explicit reconciliation
+    // instead of merging or choosing a winner.
+    if mark_external_source_conflict_if_needed(room, notebook_path, contents.as_bytes()).await {
+        return;
+    }
+
+    let json: serde_json::Value = match serde_json::from_str(&contents) {
+        Ok(j) => j,
+        Err(e) => {
+            // Partial write or invalid JSON - try again next event
+            debug!("[notebook-watch] Cannot parse {:?}: {}", notebook_path, e);
+            return;
+        }
+    };
+
+    // Parse cells from the .ipynb
+    // None = parse failure (missing cells key), Some([]) = valid empty notebook
+    let ParsedIpynbCells {
+        cells: external_cells,
+        outputs_by_cell: external_outputs,
+        attachments: external_attachments,
+    } = match parse_cells_from_ipynb_for_notebook(&json, room.id) {
+        Some(parsed) => parsed,
+        None => {
+            warn!(
+                "[notebook-watch] Cannot parse cells from {:?} - skipping",
+                notebook_path
+            );
+            return;
+        }
+    };
+    let external_metadata = parse_metadata_from_ipynb(&json);
+
+    // Check if kernel is running (to preserve outputs)
+    let has_kernel = room.has_kernel().await;
+    let source_claim = match room.persistence.claim_file_checkpoint() {
+        Ok(claim) => claim,
+        Err(_) => {
+            let reason = "external source checkpoint sequence exhausted".to_string();
+            room.durability.mark_degraded(reason.clone());
+            let heads = room.durability.status().durable_heads;
+            room.lifecycle.mark_degraded(reason.clone(), heads, true);
+            return;
+        }
+    };
+    let source_save_sequence = source_claim.sequence();
+    let source_revision = ExternalSourceRevision {
+        fingerprint: observed_fingerprint,
+        canonical_path: notebook_path.to_path_buf(),
+        save_sequence: source_save_sequence,
+        saved_at: std::fs::metadata(notebook_path)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+    };
+
+    // Apply the complete cell+metadata revision under
+    // one NotebookDoc lock and one journal marker.
+    let applied = apply_ipynb_changes_from_source(
+        room,
+        &external_cells,
+        &external_outputs,
+        &external_attachments,
+        external_metadata.as_ref(),
+        has_kernel,
+        source_revision,
+    )
+    .await;
+    let cells_changed = applied.cells_changed;
+    let metadata_changed = applied.metadata_changed;
+
+    // Close the remaining window between the
+    // pre-document revision check and baseline
+    // publication. If a newer edit landed, leave the
+    // prior baseline intact so it cannot be mistaken
+    // for exported content.
+    match tokio::fs::read(notebook_path).await {
+        Ok(current) if super::recovery::source_fingerprint(&current) == observed_fingerprint => {}
+        Ok(_) | Err(_) => return,
+    }
+
+    if room.durability.status().is_degraded() {
+        // `apply_ipynb_changes` rolls the NotebookDoc
+        // back when its journal marker fails. Do not
+        // apply metadata, advance source baselines, or
+        // publish a recovery over that terminal state.
+        return;
+    }
+
+    // Recovery is published only after cells and metadata
+    // both reconcile successfully below. Until then the
+    // Failed generation and persistence guard remain
+    // authoritative.
+    let cells_reconciled = room.doc.read().await.cell_count() == external_cells.len();
+
+    if cells_reconciled {
+        room.clear_load_failed();
+        // Only a fully reconciled and journaled source
+        // revision becomes the autosave staleness
+        // baseline. Failed or partial application keeps
+        // the prior baseline so a later save cannot
+        // silently overwrite unobserved disk truth.
+        let sources = external_cells
+            .iter()
+            .map(|cell| (cell.id.clone(), cell.source.clone()))
+            .collect();
+        let _ = room
+            .persistence
+            .note_primary_save_baseline(source_save_sequence, sources, contents.as_bytes(), false)
+            .await;
+    }
+
+    if cells_changed || metadata_changed {
+        info!(
+            "[notebook-watch] Applied external changes from {:?} (cells={}, metadata={})",
+            notebook_path, cells_changed, metadata_changed,
+        );
+
+        // Notify peers of the change — actual data
+        // arrives via Automerge sync frames
+        let _ = room.broadcasts.changed_tx.send(());
+    }
+
+    // Re-verify trust after external metadata edits.
+    // External edits via uv/editor (e.g. `uv add numpy`
+    // + save) rewrite metadata.runt.*.dependencies,
+    // and the cached trust state was computed against
+    // the old dep list. Trust lives in metadata, so
+    // gate on metadata_changed — cell-only edits
+    // can't affect dependency names.
+    // check_and_update_trust_state only writes when
+    // the status actually flipped and emits
+    // state_changed_tx so the frontend banner reacts.
+    if metadata_changed {
+        check_and_update_trust_state(room).await;
+    }
 }
 
 pub(crate) fn spawn_notebook_file_watcher(
@@ -2289,220 +2547,7 @@ pub(crate) fn spawn_notebook_file_watcher(
                             if !relevant {
                                 continue;
                             }
-
-                            // Check if this is a self-write (within skip window of our last save).
-                            let now = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_millis() as u64)
-                                .unwrap_or(0);
-                            let last_write = room.persistence.last_self_write.load(Ordering::Relaxed);
-                            if now.saturating_sub(last_write) < SELF_WRITE_SKIP_WINDOW_MS {
-                                debug!(
-                                    "[notebook-watch] Skipping self-write event for {:?}",
-                                    notebook_path
-                                );
-                                continue;
-                            }
-
-                            // Read and parse the file
-                            let contents = match tokio::fs::read_to_string(&notebook_path).await {
-                                Ok(c) => c,
-                                Err(e) => {
-                                    // File may be deleted or being written
-                                    debug!(
-                                        "[notebook-watch] Cannot read {:?}: {}",
-                                        notebook_path, e
-                                    );
-                                    continue;
-                                }
-                            };
-                            let observed_fingerprint =
-                                super::recovery::source_fingerprint(contents.as_bytes());
-
-                            // Bytes we already reconciled carry no new disk
-                            // truth. Skipping them here is load-bearing on
-                            // Linux: inotify reports reads (IN_ACCESS), so a
-                            // poller merely reading the file would otherwise
-                            // re-run the merge on every debounce window —
-                            // churning the journal, resetting the autosave
-                            // debounce, and bumping the source generation for
-                            // content the room already ingested. Two sources
-                            // of "already known": the disk baseline recorded
-                            // by saves and watcher merges, and the durability
-                            // manifest fingerprint recorded by the initial
-                            // load (which never sets the save baseline).
-                            if (room.persistence.known_disk_hash().is_some()
-                                && !room.persistence.disk_content_diverged(contents.as_bytes()))
-                                || observed_fingerprint
-                                    == room.durability.manifest().source_fingerprint
-                            {
-                                debug!(
-                                    "[notebook-watch] Disk content unchanged for {:?}; skipping",
-                                    notebook_path
-                                );
-                                continue;
-                            }
-
-                            // A journal with heads newer than its causal file
-                            // checkpoint represents unsaved collaborative
-                            // truth. If disk changed to different bytes, keep
-                            // both versions and require explicit reconciliation
-                            // instead of merging or choosing a winner.
-                            if mark_external_source_conflict_if_needed(
-                                &room,
-                                &notebook_path,
-                                contents.as_bytes(),
-                            )
-                            .await
-                            {
-                                continue;
-                            }
-
-                            let json: serde_json::Value = match serde_json::from_str(&contents) {
-                                Ok(j) => j,
-                                Err(e) => {
-                                    // Partial write or invalid JSON - try again next event
-                                    debug!(
-                                        "[notebook-watch] Cannot parse {:?}: {}",
-                                        notebook_path, e
-                                    );
-                                    continue;
-                                }
-                            };
-
-                            // Parse cells from the .ipynb
-                            // None = parse failure (missing cells key), Some([]) = valid empty notebook
-                            let ParsedIpynbCells {
-                                cells: external_cells,
-                                outputs_by_cell: external_outputs,
-                                attachments: external_attachments,
-                            } = match parse_cells_from_ipynb_for_notebook(&json, room.id) {
-                                Some(parsed) => parsed,
-                                None => {
-                                    warn!(
-                                        "[notebook-watch] Cannot parse cells from {:?} - skipping",
-                                        notebook_path
-                                    );
-                                    continue;
-                                }
-                            };
-                            let external_metadata = parse_metadata_from_ipynb(&json);
-
-                            // Check if kernel is running (to preserve outputs)
-                            let has_kernel = room.has_kernel().await;
-                            let source_claim = match room.persistence.claim_file_checkpoint() {
-                                Ok(claim) => claim,
-                                Err(_) => {
-                                    let reason = "external source checkpoint sequence exhausted"
-                                        .to_string();
-                                    room.durability.mark_degraded(reason.clone());
-                                    let heads = room.durability.status().durable_heads;
-                                    room.lifecycle.mark_degraded(
-                                        reason.clone(),
-                                        heads,
-                                        true,
-                                    );
-                                    continue;
-                                }
-                            };
-                            let source_save_sequence = source_claim.sequence();
-                            let source_revision = ExternalSourceRevision {
-                                fingerprint: observed_fingerprint,
-                                canonical_path: notebook_path.clone(),
-                                save_sequence: source_save_sequence,
-                                saved_at: std::fs::metadata(&notebook_path)
-                                    .and_then(|metadata| metadata.modified())
-                                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
-                            };
-
-                            // Apply the complete cell+metadata revision under
-                            // one NotebookDoc lock and one journal marker.
-                            let applied = apply_ipynb_changes_from_source(
-                                &room,
-                                &external_cells,
-                                &external_outputs,
-                                &external_attachments,
-                                external_metadata.as_ref(),
-                                has_kernel,
-                                source_revision,
-                            )
-                            .await;
-                            let cells_changed = applied.cells_changed;
-                            let metadata_changed = applied.metadata_changed;
-
-                            // Close the remaining window between the
-                            // pre-document revision check and baseline
-                            // publication. If a newer edit landed, leave the
-                            // prior baseline intact so it cannot be mistaken
-                            // for exported content.
-                            match tokio::fs::read(&notebook_path).await {
-                                Ok(current)
-                                    if super::recovery::source_fingerprint(&current)
-                                        == observed_fingerprint => {}
-                                Ok(_) | Err(_) => continue,
-                            }
-
-                            if room.durability.status().is_degraded() {
-                                // `apply_ipynb_changes` rolls the NotebookDoc
-                                // back when its journal marker fails. Do not
-                                // apply metadata, advance source baselines, or
-                                // publish a recovery over that terminal state.
-                                continue;
-                            }
-
-                            // Recovery is published only after cells and metadata
-                            // both reconcile successfully below. Until then the
-                            // Failed generation and persistence guard remain
-                            // authoritative.
-                            let cells_reconciled =
-                                room.doc.read().await.cell_count() == external_cells.len();
-
-                            if cells_reconciled {
-                                room.clear_load_failed();
-                                // Only a fully reconciled and journaled source
-                                // revision becomes the autosave staleness
-                                // baseline. Failed or partial application keeps
-                                // the prior baseline so a later save cannot
-                                // silently overwrite unobserved disk truth.
-                                let sources = external_cells
-                                    .iter()
-                                    .map(|cell| (cell.id.clone(), cell.source.clone()))
-                                    .collect();
-                                let _ = room
-                                    .persistence
-                                    .note_primary_save_baseline(
-                                        source_save_sequence,
-                                        sources,
-                                        contents.as_bytes(),
-                                        false,
-                                    )
-                                    .await;
-                            }
-
-                            if cells_changed || metadata_changed {
-                                info!(
-                                    "[notebook-watch] Applied external changes from {:?} (cells={}, metadata={})",
-                                    notebook_path, cells_changed, metadata_changed,
-                                );
-
-                                // Notify peers of the change — actual data
-                                // arrives via Automerge sync frames
-                                let _ = room.broadcasts.changed_tx.send(());
-                            }
-
-                            // Re-verify trust after external metadata edits.
-                            // External edits via uv/editor (e.g. `uv add numpy`
-                            // + save) rewrite metadata.runt.*.dependencies,
-                            // and the cached trust state was computed against
-                            // the old dep list. Trust lives in metadata, so
-                            // gate on metadata_changed — cell-only edits
-                            // can't affect dependency names.
-                            // check_and_update_trust_state only writes when
-                            // the status actually flipped and emits
-                            // state_changed_tx so the frontend banner reacts.
-                            if metadata_changed {
-                                check_and_update_trust_state(&room).await;
-                            }
+                            process_watcher_event(&room, &notebook_path).await;
                         }
                         Err(errs) => {
                             warn!("[notebook-watch] Watch error for {:?}: {:?}", notebook_path, errs);

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -364,9 +364,8 @@ pub struct RoomPersistence {
     pub last_save_sources: RwLock<HashMap<String, String>>,
     /// Highest committed save sequence allowed to update the primary-path
     /// watcher baselines. Post-`spawn_blocking` save continuations may resume
-    /// out of order, so the sources, disk hash, and self-write timestamp are
-    /// advanced together under `last_save_sources` only when this sequence is
-    /// not stale.
+    /// out of order, so the sources and disk hash are advanced together under
+    /// `last_save_sources` only when this sequence is not stale.
     primary_save_baseline_sequence: AtomicU64,
     /// Previous visible execution_id per cell, captured just before a new
     /// execution pointer replaces it. This is intentionally daemon-local
@@ -374,9 +373,6 @@ pub struct RoomPersistence {
     /// the last visible outputs on disk while a re-execution is still queued
     /// or running with no outputs yet.
     previous_visible_executions: std::sync::Mutex<HashMap<String, String>>,
-    /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
-    /// Used to skip file watcher events triggered by our own saves.
-    pub last_self_write: AtomicU64,
     /// SHA-256 of the `.ipynb` bytes as this daemon last saw them on disk:
     /// seeded at load, refreshed after every self-write and every file-watcher
     /// read. `save_notebook_to_disk` refuses a primary-path save when the
@@ -417,7 +413,6 @@ impl RoomPersistence {
             last_save_sources: RwLock::new(HashMap::new()),
             primary_save_baseline_sequence: AtomicU64::new(0),
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
-            last_self_write: AtomicU64::new(0),
             last_known_disk_hash: std::sync::Mutex::new(None),
             load_failed: AtomicBool::new(false),
         }
@@ -437,7 +432,6 @@ impl RoomPersistence {
             last_save_sources: RwLock::new(HashMap::new()),
             primary_save_baseline_sequence: AtomicU64::new(0),
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
-            last_self_write: AtomicU64::new(0),
             last_known_disk_hash: std::sync::Mutex::new(None),
             load_failed: AtomicBool::new(false),
         }
@@ -464,7 +458,6 @@ impl RoomPersistence {
         save_sequence: u64,
         sources: HashMap<String, String>,
         bytes: &[u8],
-        self_write: bool,
     ) -> bool {
         let mut saved = self.last_save_sources.write().await;
         if self.primary_save_baseline_sequence.load(Ordering::Acquire) > save_sequence {
@@ -472,13 +465,6 @@ impl RoomPersistence {
         }
         *saved = sources;
         self.note_disk_content(bytes);
-        if self_write {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_millis() as u64)
-                .unwrap_or(0);
-            self.last_self_write.store(now, Ordering::Release);
-        }
         self.primary_save_baseline_sequence
             .store(save_sequence, Ordering::Release);
         true

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3989,16 +3989,12 @@ fn watcher_test_ipynb_bytes(cell_id: &str, source: &str) -> Vec<u8> {
 
 fn watcher_observation_for_test(
     observed: &[u8],
-    now_ms: u64,
-    last_self_write_ms: u64,
     known_disk: Option<&[u8]>,
     manifest: &[u8],
     pending: Option<&[u8]>,
 ) -> WatcherObservation {
     WatcherObservation {
         observed: super::recovery::source_fingerprint(observed),
-        now_ms,
-        last_self_write_ms,
         known_disk_hash: known_disk
             .map(|bytes| *super::recovery::source_fingerprint(bytes).as_bytes()),
         manifest_fingerprint: super::recovery::source_fingerprint(manifest),
@@ -4012,10 +4008,6 @@ fn watcher_observation_from_room(room: &NotebookRoom, disk_bytes: &[u8]) -> Watc
     let manifest = room.durability.manifest();
     WatcherObservation {
         observed: super::recovery::source_fingerprint(disk_bytes),
-        // Far outside any self-write window: the fingerprint guards must
-        // carry the decision on their own.
-        now_ms: 1_000_000,
-        last_self_write_ms: 0,
         known_disk_hash: room.persistence.known_disk_hash(),
         manifest_fingerprint: manifest.source_fingerprint,
         pending_checkpoint_fingerprint: manifest
@@ -4031,135 +4023,51 @@ fn classify_watcher_observation_table() {
 
     const OBSERVED: &[u8] = b"observed notebook bytes";
     const OTHER: &[u8] = b"some other notebook bytes";
-    // Timestamps outside the self-write window.
-    const QUIET_NOW: u64 = 1_000_000;
-    const QUIET_LAST: u64 = 0;
-    // Timestamps inside the self-write window.
-    const RECENT_NOW: u64 = 1_000_000;
-    const RECENT_LAST: u64 = RECENT_NOW - SELF_WRITE_SKIP_WINDOW_MS + 1;
 
     let cases: Vec<(&str, WatcherObservation, WatcherIngestDecision)> = vec![
         (
-            "self-write window only",
-            watcher_observation_for_test(OBSERVED, RECENT_NOW, RECENT_LAST, None, OTHER, None),
-            Skip(SelfWriteWindow),
-        ),
-        (
-            "window boundary is exclusive",
-            watcher_observation_for_test(
-                OBSERVED,
-                RECENT_NOW,
-                RECENT_NOW - SELF_WRITE_SKIP_WINDOW_MS,
-                None,
-                OTHER,
-                None,
-            ),
-            Ingest,
-        ),
-        (
             "known disk hash only",
-            watcher_observation_for_test(
-                OBSERVED,
-                QUIET_NOW,
-                QUIET_LAST,
-                Some(OBSERVED),
-                OTHER,
-                None,
-            ),
+            watcher_observation_for_test(OBSERVED, Some(OBSERVED), OTHER, None),
             Skip(KnownDiskContent),
         ),
         (
             "manifest fingerprint only, diverged baseline",
-            watcher_observation_for_test(
-                OBSERVED,
-                QUIET_NOW,
-                QUIET_LAST,
-                Some(OTHER),
-                OBSERVED,
-                None,
-            ),
+            watcher_observation_for_test(OBSERVED, Some(OTHER), OBSERVED, None),
             Skip(ManifestFingerprint),
         ),
         (
             "manifest fingerprint only, no baseline",
-            watcher_observation_for_test(OBSERVED, QUIET_NOW, QUIET_LAST, None, OBSERVED, None),
+            watcher_observation_for_test(OBSERVED, None, OBSERVED, None),
             Skip(ManifestFingerprint),
         ),
         (
             "pending checkpoint only",
-            watcher_observation_for_test(
-                OBSERVED,
-                QUIET_NOW,
-                QUIET_LAST,
-                Some(OTHER),
-                OTHER,
-                Some(OBSERVED),
-            ),
+            watcher_observation_for_test(OBSERVED, Some(OTHER), OTHER, Some(OBSERVED)),
             Skip(PendingCheckpoint),
         ),
         (
-            "window and known disk hash",
-            watcher_observation_for_test(
-                OBSERVED,
-                RECENT_NOW,
-                RECENT_LAST,
-                Some(OBSERVED),
-                OTHER,
-                None,
-            ),
-            Skip(SelfWriteWindow),
-        ),
-        (
             "known disk hash and manifest fingerprint",
-            watcher_observation_for_test(
-                OBSERVED,
-                QUIET_NOW,
-                QUIET_LAST,
-                Some(OBSERVED),
-                OBSERVED,
-                None,
-            ),
+            watcher_observation_for_test(OBSERVED, Some(OBSERVED), OBSERVED, None),
             Skip(KnownDiskContent),
         ),
         (
             "manifest fingerprint and pending checkpoint",
-            watcher_observation_for_test(
-                OBSERVED,
-                QUIET_NOW,
-                QUIET_LAST,
-                None,
-                OBSERVED,
-                Some(OBSERVED),
-            ),
+            watcher_observation_for_test(OBSERVED, None, OBSERVED, Some(OBSERVED)),
             Skip(ManifestFingerprint),
         ),
         (
             "all guards at once",
-            watcher_observation_for_test(
-                OBSERVED,
-                RECENT_NOW,
-                RECENT_LAST,
-                Some(OBSERVED),
-                OBSERVED,
-                Some(OBSERVED),
-            ),
-            Skip(SelfWriteWindow),
+            watcher_observation_for_test(OBSERVED, Some(OBSERVED), OBSERVED, Some(OBSERVED)),
+            Skip(KnownDiskContent),
         ),
         (
             "unknown bytes ingest",
-            watcher_observation_for_test(OBSERVED, QUIET_NOW, QUIET_LAST, None, OTHER, None),
+            watcher_observation_for_test(OBSERVED, None, OTHER, None),
             Ingest,
         ),
         (
             "unknown bytes ingest despite stale baselines",
-            watcher_observation_for_test(
-                OBSERVED,
-                QUIET_NOW,
-                QUIET_LAST,
-                Some(OTHER),
-                OTHER,
-                Some(OTHER),
-            ),
+            watcher_observation_for_test(OBSERVED, Some(OTHER), OTHER, Some(OTHER)),
             Ingest,
         ),
     ];
@@ -4231,8 +4139,7 @@ async fn watcher_storm_of_identical_events_is_fully_suppressed() {
 
 /// The commit-to-baseline window: a save's journal commit has landed but its
 /// primary-path baseline install has not run yet. An event observing the new
-/// bytes must skip via the manifest fingerprint, not the self-write window
-/// (`last_self_write` stays untouched here).
+/// bytes must skip via the manifest fingerprint.
 #[tokio::test]
 async fn watcher_event_between_journal_commit_and_baseline_install_skips() {
     let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3969,6 +3969,418 @@ async fn test_persist_debouncer_flush_request_reports_write_failure() {
 // File watcher tests
 // ==========================================================================
 
+/// Serialized single-code-cell notebook bytes for watcher tests.
+fn watcher_test_ipynb_bytes(cell_id: &str, source: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [{
+            "id": cell_id,
+            "cell_type": "code",
+            "source": source,
+            "execution_count": null,
+            "outputs": [],
+            "metadata": {}
+        }]
+    }))
+    .unwrap()
+}
+
+fn watcher_observation_for_test(
+    observed: &[u8],
+    now_ms: u64,
+    last_self_write_ms: u64,
+    known_disk: Option<&[u8]>,
+    manifest: &[u8],
+    pending: Option<&[u8]>,
+) -> WatcherObservation {
+    WatcherObservation {
+        observed: super::recovery::source_fingerprint(observed),
+        now_ms,
+        last_self_write_ms,
+        known_disk_hash: known_disk
+            .map(|bytes| *super::recovery::source_fingerprint(bytes).as_bytes()),
+        manifest_fingerprint: super::recovery::source_fingerprint(manifest),
+        pending_checkpoint_fingerprint: pending.map(super::recovery::source_fingerprint),
+    }
+}
+
+/// A snapshot of the room state a watcher event would build its observation
+/// from, mirroring `process_watcher_event` exactly.
+fn watcher_observation_from_room(room: &NotebookRoom, disk_bytes: &[u8]) -> WatcherObservation {
+    let manifest = room.durability.manifest();
+    WatcherObservation {
+        observed: super::recovery::source_fingerprint(disk_bytes),
+        // Far outside any self-write window: the fingerprint guards must
+        // carry the decision on their own.
+        now_ms: 1_000_000,
+        last_self_write_ms: 0,
+        known_disk_hash: room.persistence.known_disk_hash(),
+        manifest_fingerprint: manifest.source_fingerprint,
+        pending_checkpoint_fingerprint: manifest
+            .pending_file_checkpoint
+            .map(|pending| pending.file_fingerprint),
+    }
+}
+
+#[test]
+fn classify_watcher_observation_table() {
+    use WatcherIngestDecision::{Ingest, Skip};
+    use WatcherSkipReason::*;
+
+    const OBSERVED: &[u8] = b"observed notebook bytes";
+    const OTHER: &[u8] = b"some other notebook bytes";
+    // Timestamps outside the self-write window.
+    const QUIET_NOW: u64 = 1_000_000;
+    const QUIET_LAST: u64 = 0;
+    // Timestamps inside the self-write window.
+    const RECENT_NOW: u64 = 1_000_000;
+    const RECENT_LAST: u64 = RECENT_NOW - SELF_WRITE_SKIP_WINDOW_MS + 1;
+
+    let cases: Vec<(&str, WatcherObservation, WatcherIngestDecision)> = vec![
+        (
+            "self-write window only",
+            watcher_observation_for_test(OBSERVED, RECENT_NOW, RECENT_LAST, None, OTHER, None),
+            Skip(SelfWriteWindow),
+        ),
+        (
+            "window boundary is exclusive",
+            watcher_observation_for_test(
+                OBSERVED,
+                RECENT_NOW,
+                RECENT_NOW - SELF_WRITE_SKIP_WINDOW_MS,
+                None,
+                OTHER,
+                None,
+            ),
+            Ingest,
+        ),
+        (
+            "known disk hash only",
+            watcher_observation_for_test(
+                OBSERVED,
+                QUIET_NOW,
+                QUIET_LAST,
+                Some(OBSERVED),
+                OTHER,
+                None,
+            ),
+            Skip(KnownDiskContent),
+        ),
+        (
+            "manifest fingerprint only, diverged baseline",
+            watcher_observation_for_test(
+                OBSERVED,
+                QUIET_NOW,
+                QUIET_LAST,
+                Some(OTHER),
+                OBSERVED,
+                None,
+            ),
+            Skip(ManifestFingerprint),
+        ),
+        (
+            "manifest fingerprint only, no baseline",
+            watcher_observation_for_test(OBSERVED, QUIET_NOW, QUIET_LAST, None, OBSERVED, None),
+            Skip(ManifestFingerprint),
+        ),
+        (
+            "pending checkpoint only",
+            watcher_observation_for_test(
+                OBSERVED,
+                QUIET_NOW,
+                QUIET_LAST,
+                Some(OTHER),
+                OTHER,
+                Some(OBSERVED),
+            ),
+            Skip(PendingCheckpoint),
+        ),
+        (
+            "window and known disk hash",
+            watcher_observation_for_test(
+                OBSERVED,
+                RECENT_NOW,
+                RECENT_LAST,
+                Some(OBSERVED),
+                OTHER,
+                None,
+            ),
+            Skip(SelfWriteWindow),
+        ),
+        (
+            "known disk hash and manifest fingerprint",
+            watcher_observation_for_test(
+                OBSERVED,
+                QUIET_NOW,
+                QUIET_LAST,
+                Some(OBSERVED),
+                OBSERVED,
+                None,
+            ),
+            Skip(KnownDiskContent),
+        ),
+        (
+            "manifest fingerprint and pending checkpoint",
+            watcher_observation_for_test(
+                OBSERVED,
+                QUIET_NOW,
+                QUIET_LAST,
+                None,
+                OBSERVED,
+                Some(OBSERVED),
+            ),
+            Skip(ManifestFingerprint),
+        ),
+        (
+            "all guards at once",
+            watcher_observation_for_test(
+                OBSERVED,
+                RECENT_NOW,
+                RECENT_LAST,
+                Some(OBSERVED),
+                OBSERVED,
+                Some(OBSERVED),
+            ),
+            Skip(SelfWriteWindow),
+        ),
+        (
+            "unknown bytes ingest",
+            watcher_observation_for_test(OBSERVED, QUIET_NOW, QUIET_LAST, None, OTHER, None),
+            Ingest,
+        ),
+        (
+            "unknown bytes ingest despite stale baselines",
+            watcher_observation_for_test(
+                OBSERVED,
+                QUIET_NOW,
+                QUIET_LAST,
+                Some(OTHER),
+                OTHER,
+                Some(OTHER),
+            ),
+            Ingest,
+        ),
+    ];
+
+    for (name, observation, expected) in cases {
+        assert_eq!(
+            classify_watcher_observation(&observation),
+            expected,
+            "case: {name}"
+        );
+    }
+}
+
+/// Fifty byte-identical debounced events (the inotify IN_ACCESS storm shape)
+/// must be fully suppressed: zero merges, zero checkpoint sequence claims,
+/// zero journal appends, and an unchanged source generation. The room's doc
+/// deliberately differs from the disk bytes so a single misclassified event
+/// would merge the disk cell and move every counter.
+#[tokio::test]
+async fn watcher_storm_of_identical_events_is_fully_suppressed() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "storm.ipynb");
+
+    let disk_bytes = watcher_test_ipynb_bytes("storm-cell", "value = 42");
+    tokio::fs::write(&notebook_path, &disk_bytes).await.unwrap();
+    // The baseline a completed save or watcher merge leaves behind.
+    room.persistence.note_disk_content(&disk_bytes);
+
+    let observation = watcher_observation_from_room(&room, &disk_bytes);
+    assert_eq!(
+        classify_watcher_observation(&observation),
+        WatcherIngestDecision::Skip(WatcherSkipReason::KnownDiskContent),
+    );
+
+    let claimed_before = room
+        .persistence
+        .file_checkpoint_coordinator()
+        .latest_claimed_sequence();
+    let manifest_before = room.durability.manifest();
+    let heads_before = room.doc.write().await.get_heads_hex();
+
+    for _ in 0..50 {
+        process_watcher_event(&room, &notebook_path).await;
+    }
+
+    assert_eq!(
+        room.doc.write().await.get_heads_hex(),
+        heads_before,
+        "storm must not merge anything into the doc"
+    );
+    assert_eq!(room.doc.read().await.cell_count(), 0);
+    assert_eq!(
+        room.persistence
+            .file_checkpoint_coordinator()
+            .latest_claimed_sequence(),
+        claimed_before,
+        "storm must not claim checkpoint sequences"
+    );
+    let manifest_after = room.durability.manifest();
+    assert_eq!(
+        manifest_after.sequence, manifest_before.sequence,
+        "storm must not append journal records"
+    );
+    assert_eq!(
+        manifest_after.source_generation, manifest_before.source_generation,
+        "storm must not advance the source generation"
+    );
+}
+
+/// The commit-to-baseline window: a save's journal commit has landed but its
+/// primary-path baseline install has not run yet. An event observing the new
+/// bytes must skip via the manifest fingerprint, not the self-write window
+/// (`last_self_write` stays untouched here).
+#[tokio::test]
+async fn watcher_event_between_journal_commit_and_baseline_install_skips() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "commit-window.ipynb");
+
+    // The bound content this daemon previously saved and reconciled.
+    let old_bytes = watcher_test_ipynb_bytes("cell-1", "x = 1");
+    tokio::fs::write(&notebook_path, &old_bytes).await.unwrap();
+    room.persistence.note_disk_content(&old_bytes);
+
+    // The in-flight save: doc mutated, journaled, new bytes renamed into
+    // place, checkpoint committed. The baseline install has NOT run.
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "x = 2").unwrap();
+    }
+    commit_test_room_doc(&room).await;
+    let new_bytes = watcher_test_ipynb_bytes("cell-1", "x = 2");
+    tokio::fs::write(&notebook_path, &new_bytes).await.unwrap();
+    let claim = room.persistence.claim_file_checkpoint().unwrap();
+    let heads: Vec<[u8; 32]> = {
+        let mut doc = room.doc.write().await;
+        doc.get_heads().iter().map(|head| head.0).collect()
+    };
+    room.durability
+        .commit_file_checkpoint(
+            notebook_path.clone(),
+            super::recovery::source_fingerprint(&new_bytes),
+            heads,
+            claim.sequence(),
+        )
+        .expect("journal commit for the in-flight save");
+
+    let observation = watcher_observation_from_room(&room, &new_bytes);
+    assert_eq!(
+        classify_watcher_observation(&observation),
+        WatcherIngestDecision::Skip(WatcherSkipReason::ManifestFingerprint),
+        "the committed manifest fingerprint covers the commit-to-baseline window"
+    );
+
+    let claimed_before = room
+        .persistence
+        .file_checkpoint_coordinator()
+        .latest_claimed_sequence();
+    let manifest_before = room.durability.manifest();
+    let heads_before = room.doc.write().await.get_heads_hex();
+
+    process_watcher_event(&room, &notebook_path).await;
+
+    assert_eq!(room.doc.write().await.get_heads_hex(), heads_before);
+    assert_eq!(
+        room.persistence
+            .file_checkpoint_coordinator()
+            .latest_claimed_sequence(),
+        claimed_before
+    );
+    let manifest_after = room.durability.manifest();
+    assert_eq!(manifest_after.sequence, manifest_before.sequence);
+    assert_eq!(
+        manifest_after.source_generation,
+        manifest_before.source_generation
+    );
+    assert!(
+        !matches!(room.lifecycle.availability(), RoomAvailability::Degraded(_)),
+        "our own committed bytes must not degrade the room"
+    );
+}
+
+/// The rename-to-commit window: the new bytes are visible on disk and the
+/// journal holds the prepared checkpoint intent, but the commit marker has
+/// not landed. The pending-checkpoint fingerprint resolves the event; a
+/// misclassification here would manufacture a source conflict because the
+/// journal's durable heads are ahead of its exported heads.
+#[tokio::test]
+async fn watcher_event_in_rename_to_commit_window_skips_via_pending_checkpoint() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "rename-window.ipynb");
+
+    let old_bytes = watcher_test_ipynb_bytes("cell-1", "x = 1");
+    tokio::fs::write(&notebook_path, &old_bytes).await.unwrap();
+    room.persistence.note_disk_content(&old_bytes);
+
+    // The in-flight save: doc mutated and journaled, checkpoint intent
+    // prepared, temp file renamed over the target. The commit marker has
+    // NOT been appended.
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "x = 2").unwrap();
+    }
+    commit_test_room_doc(&room).await;
+    let new_bytes = watcher_test_ipynb_bytes("cell-1", "x = 2");
+    let claim = room.persistence.claim_file_checkpoint().unwrap();
+    let heads: Vec<[u8; 32]> = {
+        let mut doc = room.doc.write().await;
+        doc.get_heads().iter().map(|head| head.0).collect()
+    };
+    room.durability
+        .prepare_file_checkpoint(
+            notebook_path.clone(),
+            super::recovery::source_fingerprint(&new_bytes),
+            heads,
+            claim.sequence(),
+            None,
+        )
+        .expect("checkpoint intent for the in-flight save");
+    tokio::fs::write(&notebook_path, &new_bytes).await.unwrap();
+
+    let observation = watcher_observation_from_room(&room, &new_bytes);
+    assert_eq!(
+        classify_watcher_observation(&observation),
+        WatcherIngestDecision::Skip(WatcherSkipReason::PendingCheckpoint),
+        "the prepared checkpoint fingerprint covers the rename-to-commit window"
+    );
+
+    let claimed_before = room
+        .persistence
+        .file_checkpoint_coordinator()
+        .latest_claimed_sequence();
+    let manifest_before = room.durability.manifest();
+    let heads_before = room.doc.write().await.get_heads_hex();
+
+    process_watcher_event(&room, &notebook_path).await;
+
+    assert_eq!(room.doc.write().await.get_heads_hex(), heads_before);
+    assert_eq!(
+        room.persistence
+            .file_checkpoint_coordinator()
+            .latest_claimed_sequence(),
+        claimed_before
+    );
+    let manifest_after = room.durability.manifest();
+    assert_eq!(manifest_after.sequence, manifest_before.sequence);
+    assert_eq!(
+        manifest_after.source_generation,
+        manifest_before.source_generation
+    );
+    assert!(
+        manifest_after.pending_file_checkpoint.is_some(),
+        "the prepared intent must remain for the save to commit"
+    );
+    assert!(
+        !matches!(room.lifecycle.availability(), RoomAvailability::Degraded(_)),
+        "our own renamed bytes must not be classified as a source conflict"
+    );
+}
+
 #[test]
 fn test_parse_cells_from_ipynb_with_ids() {
     let json = serde_json::json!({

--- a/crates/runtimed/src/requests/reconcile_notebook_source.rs
+++ b/crates/runtimed/src/requests/reconcile_notebook_source.rs
@@ -367,7 +367,6 @@ async fn archive_and_reload_source(
             save_sequence,
             applied.loaded_sources.clone(),
             &applied.source_content,
-            false,
         )
         .await;
     let exported_heads = applied

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -207,9 +207,9 @@ async fn handle_with_intent(
         };
     }
 
-    let (checkpoint_sequence, wrote_file) = match &save_outcome {
-        FileSaveOutcome::Saved { save_sequence, .. } => (*save_sequence, true),
-        FileSaveOutcome::AlreadyCurrent { save_sequence, .. } => (*save_sequence, false),
+    let checkpoint_sequence = match &save_outcome {
+        FileSaveOutcome::Saved { save_sequence, .. }
+        | FileSaveOutcome::AlreadyCurrent { save_sequence, .. } => *save_sequence,
     };
 
     // Post-write canonicalize. Usually matches the pre-write key. If it
@@ -248,7 +248,6 @@ async fn handle_with_intent(
             room,
             std::path::Path::new(&written),
             checkpoint_sequence,
-            wrote_file,
         )
         .await;
     }


### PR DESCRIPTION
Two commits: extract the watcher's skip/ingest decision into a pure classifier with full window coverage, then delete the self-write time window the tests prove redundant.

`classify_watcher_observation` is a pure function over one debounced observation: the disk baseline recorded by saves and watcher merges, the committed manifest fingerprint set at journal-commit time under the coordinator lock, and the prepared-checkpoint fingerprint covering the rename-to-commit window of an in-flight save. `process_watcher_event` carries the rest of the loop body so tests drive the classifier and ingest seams directly instead of through real filesystem notifications. Coverage: a deterministic table over every guard and combination, a 50-event byte-identical storm (zero merges, zero checkpoint sequence claims, zero journal appends, unchanged source generation), and the two windows the deletion needs.

The pending-checkpoint disjunct is the one seam the live loop lacked: only restart recovery compared disk against a prepared intent, so a watcher event landing in the rename-to-commit micro-gap could reach the conflict predicate with our own bytes and manufacture a spurious source conflict. The classifier now names that window explicitly.

With the fingerprint guards carrying the whole skip decision, the 600ms window goes: `last_self_write` was stamped only after rename+commit, so the window never covered the gap it appeared to guard, while it did swallow genuine external edits arriving within 600ms of a save and could wedge autosave. The window, its constant, the write-only field, and the `self_write` plumbing through `note_primary_save_baseline` and `refresh_primary_baseline_from_checkpoint` are deleted; the classifier table and both window-coverage tests pass unchanged.

Verification roadmap item 1 plus consolidation item 1 from `docs/memos/room-lifecycle-simplification-and-verification.md`.
