### PR TITLE
fix(runtimed): reinstate SourceFingerprint::as_bytes for the watcher classifier

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/recovery.rs
+++ b/crates/runtimed/src/notebook_sync_server/recovery.rs
@@ -47,6 +47,12 @@ impl SourceFingerprint {
     pub(crate) fn to_hex(self) -> String {
         hex::encode(self.0)
     }
+
+    /// Raw digest bytes, for comparison against externally tracked disk
+    /// hashes (the watcher classifier's known-disk-hash guard).
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
 }
 
 /// Compute the content fingerprint used to distinguish a matching source file


### PR DESCRIPTION
Main does not compile: #4022 deleted `SourceFingerprint::as_bytes` as caller-less, and #4026 added two new callers written against the pre-#4022 tree (the watcher classifier's known-disk-hash guard at `persist.rs:2217` and its table test). Each PR was green in isolation; the branches were textually disjoint so the merge raised no conflict, and the second PR's CI ran against a base that predated the first.

Reinstate the accessor. It now has a production caller, so it is no longer the dead surface the memo's item-13 deletion targeted.
