### PR TITLE
refactor(runt-mcp): delete dead mcp-client branches

### DIFF
--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -477,7 +477,6 @@ async fn rejoin(
             {
                 Ok(r) => {
                     let handle = r.handle;
-                    let broadcast_rx = r.broadcast_rx;
                     if let Err(e) = handle
                         .await_session_ready_timeout(REJOIN_SESSION_READY_TIMEOUT)
                         .await
@@ -485,7 +484,7 @@ async fn rejoin(
                         Err(e)
                     } else {
                         let cell_count = handle.get_cells().len();
-                        Ok((handle, broadcast_rx, cell_count, r.info.notebook_id))
+                        Ok((handle, cell_count, r.info.notebook_id))
                     }
                 }
                 Err(e) => Err(e),
@@ -500,7 +499,6 @@ async fn rejoin(
             {
                 Ok(r) => {
                     let handle = r.handle;
-                    let broadcast_rx = r.broadcast_rx;
                     if let Err(e) = handle
                         .await_session_ready_timeout(REJOIN_SESSION_READY_TIMEOUT)
                         .await
@@ -508,7 +506,7 @@ async fn rejoin(
                         Err(e)
                     } else {
                         let cell_count = handle.get_cells().len();
-                        Ok((handle, broadcast_rx, cell_count, notebook_id.clone()))
+                        Ok((handle, cell_count, notebook_id.clone()))
                     }
                 }
                 Err(e) => Err(e),
@@ -516,15 +514,11 @@ async fn rejoin(
         };
 
         match result {
-            Ok((handle, broadcast_rx, new_cell_count, new_notebook_id)) => {
+            Ok((handle, new_cell_count, new_notebook_id)) => {
                 crate::presence::announce(&handle, &label).await;
 
-                let new_session = NotebookSession::local(
-                    handle,
-                    broadcast_rx,
-                    new_notebook_id,
-                    notebook_path.clone(),
-                );
+                let new_session =
+                    NotebookSession::local(handle, new_notebook_id, notebook_path.clone());
                 // Hold the publication lock across the check/install. Any
                 // active session is authoritative, even for the same UUID:
                 // an explicit tool activation may carry retained projection
@@ -644,7 +638,6 @@ async fn rejoin_hosted(
 
                 let new_session = NotebookSession::hosted(
                     result.handle,
-                    result.broadcast_rx,
                     notebook_id.clone(),
                     domain_config.base_url.clone(),
                 );

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -47,7 +47,7 @@ pub struct ExecutionResult {
     /// Agents can pass this to `get_cell(execution_id=...)` to read
     /// outputs for this specific execution, bypassing the cell's
     /// current pointer.
-    pub execution_id: Option<String>,
+    pub execution_id: String,
     /// Resolved outputs from the cell after execution.
     pub outputs: Vec<Output>,
     /// Output manifests that produced `outputs` and `resolved_outputs_by_manifest`.
@@ -110,7 +110,7 @@ pub async fn execute_and_wait(
         .await;
 
     let execution_id = match response {
-        Ok(NotebookResponse::CellQueued { execution_id, .. }) => Some(execution_id),
+        Ok(NotebookResponse::CellQueued { execution_id, .. }) => execution_id,
         Ok(NotebookResponse::Error { error })
         | Ok(NotebookResponse::GuardRejected { reason: error }) => {
             return Err(ExecutionDispatchError::not_ready(format!(
@@ -139,54 +139,37 @@ pub async fn execute_and_wait(
     let mut output_manifests: Vec<serde_json::Value> = Vec::new();
     let mut execution_count_from_wait: Option<i64> = None;
 
-    if let Some(ref eid) = execution_id {
-        match await_execution_terminal(handle, eid, timeout, None).await {
-            Ok(ExecutionTerminalState {
-                status,
-                success: s,
-                output_manifests: outs,
-                execution_count,
-            }) => {
-                final_status = status;
-                success = s;
-                output_manifests = outs;
-                execution_count_from_wait = execution_count;
-            }
-            Err(ExecutionTerminalError::Timeout) => {
-                // Leave `running` and fall through — caller can surface
-                // timeout based on the status field.
-            }
-            Err(ExecutionTerminalError::KernelFailed { reason }) => {
-                warn!("kernel failed during execution: {reason}");
-                final_status = "error".to_string();
-            }
+    match await_execution_terminal(handle, &execution_id, timeout, None).await {
+        Ok(ExecutionTerminalState {
+            status,
+            success: s,
+            output_manifests: outs,
+            execution_count,
+        }) => {
+            final_status = status;
+            success = s;
+            output_manifests = outs;
+            execution_count_from_wait = execution_count;
+        }
+        Err(ExecutionTerminalError::Timeout) => {
+            // Leave `running` and fall through — caller can surface
+            // timeout based on the status field.
+        }
+        Err(ExecutionTerminalError::KernelFailed { reason }) => {
+            warn!("kernel failed during execution: {reason}");
+            final_status = "error".to_string();
         }
     }
 
     // Step 4: Collect outputs from CRDT.
     // Prefer output hashes from RuntimeStateDoc (already returned above).
-    // Fall back to handle.get_cell() which reads via execution_id facade.
-    let execution_count = if let Some(count) = execution_count_from_wait {
-        Some(count.to_string())
-    } else if execution_id.is_none() {
-        // Fallback: find most recent execution for this cell with an execution_count
-        let ec = crate::tools::cell_read::get_cell_execution_count_from_runtime(handle, cell_id);
-        if ec.is_empty() {
-            None
-        } else {
-            Some(ec)
-        }
-    } else {
-        None
-    };
+    let execution_count = execution_count_from_wait.map(|count| count.to_string());
 
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let mut execution_cell_map = execution_cell_map(handle);
-    if let Some(eid) = &execution_id {
-        execution_cell_map
-            .entry(eid.clone())
-            .or_insert_with(|| cell_id.to_string());
-    }
+    execution_cell_map
+        .entry(execution_id.clone())
+        .or_insert_with(|| cell_id.to_string());
     // Execute paths (and `and_run` variants) always use preview mode —
     // agents that need unabridged output should call `get_cell(full_output=true)`
     // afterwards rather than paying for it on every run.
@@ -213,12 +196,6 @@ pub async fn execute_and_wait(
         let outputs = aligned.iter().flatten().cloned().collect();
         (outputs, aligned)
     };
-
-    // Determine status from outputs if we didn't get it from RuntimeState
-    if final_status == "idle" && outputs.iter().any(|o| o.output_type == "error") {
-        final_status = "error".to_string();
-        success = false;
-    }
 
     Ok(ExecutionResult {
         cell_id: cell_id.to_string(),

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -6,7 +6,6 @@ use notebook_sync::handle::DocHandle;
 use notebook_sync::status::{
     ConnectionState, InitialLoadPhase, NotebookDocPhase, RuntimeStatePhase,
 };
-use notebook_sync::BroadcastReceiver;
 use runtimed_client::protocol::{
     NotebookAvailabilityPhase, NotebookProjection, NotebookSourcePhase,
 };
@@ -116,7 +115,6 @@ pub struct SessionAccessError {
 }
 
 /// An active notebook session connected via the daemon.
-#[allow(dead_code)] // Fields used by tool handlers as more tools are ported
 pub struct NotebookSession {
     /// The Automerge document handle for this notebook.
     pub handle: DocHandle,
@@ -125,8 +123,6 @@ pub struct NotebookSession {
     /// The file path for file-backed notebooks (opened via `open_notebook`).
     /// `None` for ephemeral notebooks created via `create_notebook`.
     pub notebook_path: Option<String>,
-    /// Broadcast receiver for daemon events (execution done, outputs, etc.)
-    pub broadcast_rx: BroadcastReceiver,
     /// Session source. Hosted sessions do not depend on the local daemon.
     pub source: NotebookSessionSource,
     /// Monotonic MCP activation generation. Daemon rejoin/create legacy paths
@@ -138,16 +134,10 @@ pub struct NotebookSession {
 }
 
 impl NotebookSession {
-    pub fn local(
-        handle: DocHandle,
-        broadcast_rx: BroadcastReceiver,
-        notebook_id: String,
-        notebook_path: Option<String>,
-    ) -> Self {
+    pub fn local(handle: DocHandle, notebook_id: String, notebook_path: Option<String>) -> Self {
         let activation_target = format!("local:id:{notebook_id}");
         Self {
             handle,
-            broadcast_rx,
             notebook_id,
             notebook_path,
             source: NotebookSessionSource::Local,
@@ -159,7 +149,6 @@ impl NotebookSession {
 
     pub fn local_with_projection(
         handle: DocHandle,
-        broadcast_rx: BroadcastReceiver,
         notebook_id: String,
         notebook_path: Option<String>,
         activation_generation: u64,
@@ -168,7 +157,6 @@ impl NotebookSession {
     ) -> Self {
         Self {
             handle,
-            broadcast_rx,
             notebook_id,
             notebook_path,
             source: NotebookSessionSource::Local,
@@ -180,16 +168,10 @@ impl NotebookSession {
         }
     }
 
-    pub fn hosted(
-        handle: DocHandle,
-        broadcast_rx: BroadcastReceiver,
-        notebook_id: String,
-        domain: String,
-    ) -> Self {
+    pub fn hosted(handle: DocHandle, notebook_id: String, domain: String) -> Self {
         let activation_target = crate::cloud::hosted_notebook_url(&domain, &notebook_id);
         Self {
             handle,
-            broadcast_rx,
             notebook_id,
             notebook_path: None,
             source: NotebookSessionSource::Hosted { domain },
@@ -201,7 +183,6 @@ impl NotebookSession {
 
     pub fn hosted_activated(
         handle: DocHandle,
-        broadcast_rx: BroadcastReceiver,
         notebook_id: String,
         domain: String,
         activation_generation: u64,
@@ -209,7 +190,6 @@ impl NotebookSession {
     ) -> Self {
         Self {
             handle,
-            broadcast_rx,
             notebook_id,
             notebook_path: None,
             source: NotebookSessionSource::Hosted { domain },

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -647,7 +647,7 @@ pub async fn build_execution_result(
         "code",
         result.execution_count.as_deref(),
         Some(&result.status),
-        result.execution_id.as_deref(),
+        Some(result.execution_id.as_str()),
     );
 
     let mut items = vec![
@@ -707,12 +707,10 @@ pub async fn build_execution_result(
             );
             // Inject execution_id into structured content so MCP App renderers
             // can associate outputs with a specific execution.
-            if let Some(ref eid) = result.execution_id {
-                cell_obj.insert(
-                    "execution_id".to_string(),
-                    serde_json::Value::String(eid.clone()),
-                );
-            }
+            cell_obj.insert(
+                "execution_id".to_string(),
+                serde_json::Value::String(result.execution_id.clone()),
+            );
         }
     }
     call_result.structured_content = structured_content;

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -1121,7 +1121,6 @@ async fn connect_hosted_notebook(
 
             let session = NotebookSession::hosted_activated(
                 result.handle,
-                result.broadcast_rx,
                 notebook_id.clone(),
                 domain_config.base_url,
                 lease.generation(),
@@ -1182,7 +1181,6 @@ async fn connect_local_path_progressive(
 
     let mut session = NotebookSession::local_with_projection(
         result.handle,
-        result.broadcast_rx,
         notebook_id.clone(),
         Some(abs_path.to_string_lossy().into_owned()),
         lease.generation(),
@@ -1255,7 +1253,6 @@ async fn connect_local_id_progressive(
     }
     let mut session = NotebookSession::local_with_projection(
         result.handle,
-        result.broadcast_rx,
         notebook_id.clone(),
         notebook_path.clone(),
         lease.generation(),
@@ -1485,12 +1482,7 @@ pub async fn create_notebook(
                     )
                 };
 
-                let mut session = NotebookSession::local(
-                    result.handle,
-                    result.broadcast_rx,
-                    notebook_id.clone(),
-                    None,
-                );
+                let mut session = NotebookSession::local(result.handle, notebook_id.clone(), None);
                 session.reactivate(activation_lease.generation(), activation_lease.target());
 
                 let runtime_info = collect_runtime_info(&session.handle).await;


### PR DESCRIPTION
The MCP client tracks the current daemon model directly:

- `NotebookSession` does not consume daemon broadcast events. Execution lifecycle is read by polling RuntimeStateDoc, and the sync task's broadcast sends are best-effort with no receiver requirement, so the session holds no `BroadcastReceiver` and constructors do not take one. The over-broad `#[allow(dead_code)]` on the struct goes with it.
- The daemon always assigns an execution id: `ExecuteCell` is answered with `CellQueued { execution_id }` and every other response is an error, so `ExecutionResult.execution_id` is `String`, not `Option`. The `execution_count` lookup fallback for a missing id was unreachable and is gone.
- Terminal status arrives via `await_execution_terminal` over RuntimeStateDoc and is one of `done`, `error`, or `cancelled` (`running` only on timeout), so no post-hoc `idle` reclassification from outputs is needed.

Delete-now item 9 from `docs/memos/room-lifecycle-simplification-and-verification.md` (net -60 LOC). `ExecutionResult` is runt-mcp-internal (no ts-rs derive); the TS bindings are untouched.
