### PR TITLE
refactor(runtimed): one sync atomic-write core for the non-durable tier

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/comments_store.rs
+++ b/crates/runtimed/src/notebook_sync_server/comments_store.rs
@@ -19,6 +19,8 @@ use sha2::Digest as _;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+use super::persist::write_file_atomic_sync;
+
 const INDEX_FILE: &str = "index.json";
 const INDEX_LOCK_FILE: &str = ".index.lock";
 const INDEX_VERSION: u32 = 1;
@@ -151,7 +153,7 @@ impl CommentsSidecarStore {
                         path.display()
                     );
                     let bytes = doc.save();
-                    write_file_atomic(&path, &bytes).with_context(|| {
+                    write_file_atomic_sync(&path, &bytes).with_context(|| {
                         format!(
                             "repair CommentsDoc {} at {}",
                             comments_doc_id,
@@ -188,7 +190,7 @@ impl CommentsSidecarStore {
             Ok((comments_doc_id, doc.save()))
         })?;
         let path = self.doc_path(&comments_doc_id);
-        write_file_atomic(&path, &bytes).with_context(|| {
+        write_file_atomic_sync(&path, &bytes).with_context(|| {
             format!(
                 "write CommentsDoc {} to {}",
                 comments_doc_id,
@@ -244,7 +246,7 @@ impl CommentsSidecarStore {
     fn save_index(&self, index: &CommentsIndex) -> anyhow::Result<()> {
         let path = self.index_path();
         let bytes = serde_json::to_vec_pretty(index)?;
-        write_file_atomic(&path, &bytes)
+        write_file_atomic_sync(&path, &bytes)
             .with_context(|| format!("write comments index {}", path.display()))
     }
 }
@@ -392,34 +394,6 @@ pub(crate) fn comments_doc_filename(comments_doc_id: &str) -> String {
         "{}.automerge",
         hex::encode(sha2::Sha256::digest(comments_doc_id.as_bytes()))
     )
-}
-
-fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let tmp = sibling_temp_path(path);
-    std::fs::write(&tmp, bytes)?;
-    if let Ok(meta) = std::fs::metadata(path) {
-        let _ = std::fs::set_permissions(&tmp, meta.permissions());
-    }
-    match std::fs::rename(&tmp, path) {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            let _ = std::fs::remove_file(&tmp);
-            Err(err)
-        }
-    }
-}
-
-fn sibling_temp_path(path: &Path) -> PathBuf {
-    static TEMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let n = TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let file_name = path
-        .file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "comments".to_string());
-    path.with_file_name(format!(".{file_name}.{}-{n}.tmp", std::process::id()))
 }
 
 #[cfg(test)]
@@ -688,7 +662,7 @@ mod tests {
         );
         let (tx, _) = broadcast::channel(16);
         let wrong_handle = CommentsDocHandle::new(wrong, tx);
-        write_file_atomic(
+        write_file_atomic_sync(
             &store.doc_path(expected_id),
             &wrong_handle.with_doc(|doc| Ok(doc.save())).unwrap(),
         )
@@ -738,7 +712,7 @@ mod tests {
         sync_pair_without_projection_check(&mut other, &mut base);
 
         let path = store.doc_path(expected_id);
-        write_file_atomic(&path, &base.save()).unwrap();
+        write_file_atomic_sync(&path, &base.save()).unwrap();
 
         let repaired = store.load_or_create(expected_id, &expected_ref).unwrap();
         repaired

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -2096,27 +2096,16 @@ fn do_persist(data: &[u8], path: &Path) -> bool {
 /// path) must check the return value; earlier call sites that only care
 /// about best-effort debounced writes can ignore it.
 pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) -> bool {
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
+    match write_file_atomic_sync(path, data) {
+        Ok(()) => true,
+        Err(e) => {
             warn!(
-                "[notebook-sync] Failed to create parent dir for {:?}: {}",
+                "[notebook-sync] Failed to save notebook doc {:?}: {}",
                 path, e
             );
-            return false;
+            false
         }
     }
-    let tmp = sibling_temp_path(path);
-    if let Err(e) = std::fs::write(&tmp, data) {
-        warn!("[notebook-sync] Failed to save notebook doc: {}", e);
-        let _ = std::fs::remove_file(&tmp);
-        return false;
-    }
-    if let Err(e) = std::fs::rename(&tmp, path) {
-        warn!("[notebook-sync] Failed to save notebook doc: {}", e);
-        let _ = std::fs::remove_file(&tmp);
-        return false;
-    }
-    true
 }
 
 /// A unique same-directory temp path for atomically replacing `path`.
@@ -2133,23 +2122,49 @@ fn sibling_temp_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(".{file_name}.{}-{n}.tmp", std::process::id()))
 }
 
-/// Write `bytes` to `path` through a same-directory temp file + rename so a
-/// reader never observes a torn/partial file: the path always holds either
-/// the previous complete content or the new complete content. Preserves the
-/// destination's permissions when it already exists.
-async fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = sibling_temp_path(path);
-    tokio::fs::write(&tmp, bytes).await?;
-    if let Ok(meta) = tokio::fs::metadata(path).await {
-        let _ = tokio::fs::set_permissions(&tmp, meta.permissions()).await;
+/// Atomic-write core for the non-durable convenience tier (persisted
+/// notebook doc mirrors, autosave owner markers, comments sidecar docs).
+///
+/// Creates the parent directory, writes `bytes` to a same-directory temp
+/// file, preserves the destination's permissions when it already exists,
+/// and renames into place, removing the temp file on failure. A reader
+/// never observes a torn/partial file: the path always holds either the
+/// previous complete content or the new complete content.
+///
+/// Tier split: this core deliberately does not fsync. The durable fsync
+/// tier (`recovery.rs::replace_file_atomically` and
+/// `file_checkpoint.rs::RealCheckpointIo::replace_temp`) carries the
+/// crash-durability guarantees for journals and file checkpoints and must
+/// stay separate; do not merge it into this convenience helper.
+pub(crate) fn write_file_atomic_sync(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
     }
-    match tokio::fs::rename(&tmp, path).await {
+    let tmp = sibling_temp_path(path);
+    if let Err(e) = std::fs::write(&tmp, bytes) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    if let Ok(meta) = std::fs::metadata(path) {
+        let _ = std::fs::set_permissions(&tmp, meta.permissions());
+    }
+    match std::fs::rename(&tmp, path) {
         Ok(()) => Ok(()),
         Err(e) => {
-            let _ = tokio::fs::remove_file(&tmp).await;
+            let _ = std::fs::remove_file(&tmp);
             Err(e)
         }
     }
+}
+
+/// Async adapter over [`write_file_atomic_sync`] for callers already on the
+/// async save path; the blocking file I/O runs on the blocking pool.
+async fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let path = path.to_path_buf();
+    let bytes = bytes.to_vec();
+    tokio::task::spawn_blocking(move || write_file_atomic_sync(&path, &bytes))
+        .await
+        .map_err(std::io::Error::other)?
 }
 
 // =============================================================================


### PR DESCRIPTION
persist.rs and comments_store.rs each carry their own temp-write-rename helper with slightly different semantics. One sync core now owns the sequence: create the parent directory, write to a same-directory temp file, preserve the destination's permissions when it already exists, rename into place, and remove the temp file on failure.

persist_notebook_bytes is a bool-and-log adapter over the core. The async write_file_atomic (autosave owner marker refresh) wraps the core in spawn_blocking, matching the file's existing blocking-pool convention. comments_store calls the core directly and drops its duplicated helper and sibling_temp_path copy.

Tier-split invariant: the core is the non-durable convenience tier (persisted doc mirrors, autosave owner markers, comments sidecars) and deliberately does not fsync. The durable fsync tier in recovery.rs::replace_file_atomically and file_checkpoint's RealCheckpointIo::replace_temp carries crash durability for journals and file checkpoints and stays separate; the core's doc comment names the split.

Behavioral normalizations:
- persist_notebook_bytes preserves an existing destination's permissions (previously the replacement took the umask default).
- comments and marker writes remove the temp file when the initial write fails (previously only rename failure cleaned up).
- the autosave marker write gains parent-directory creation; the parent always exists on that path today.
- persist_notebook_bytes logs one warn naming the path and error instead of two stage-specific messages.
- comments temp paths use the shared fallback stem ("notebook" instead of "comments") in the unreachable no-file-name case.


