### PR TITLE
refactor(runtimed): batch terminal wait for run_all with one trailing grace pass

### DIFF
--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -200,6 +200,112 @@ pub async fn await_execution_terminal(
     Ok(final_state)
 }
 
+/// Outcome of awaiting a batch of executions queued together (run-all).
+///
+/// Timeout and kernel failure map to fields rather than an error because a
+/// batch wait always has a reportable summary; callers read per-execution
+/// statuses from the RuntimeStateDoc afterwards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllExecutionsTerminal {
+    /// The shared deadline elapsed before every execution reached terminal
+    /// status.
+    pub timed_out: bool,
+    /// Some execution terminalized as `"error"`, or the kernel failed
+    /// (`error`/`shutdown`) while an execution was still pending.
+    pub has_error: bool,
+}
+
+/// Wait for every execution in `execution_ids` to reach terminal status
+/// against one shared deadline, then run one trailing output-sync grace pass.
+///
+/// The per-execution waits use zero output-sync grace: with the default
+/// grace, N output-free executions would serialize into N x
+/// [`DEFAULT_OUTPUT_SYNC_GRACE`] of sleep on large notebooks. Output settling
+/// is instead deferred to a single trailing pass that re-awaits the
+/// non-cancelled executions concurrently under the default grace rules, so
+/// trailing executions with empty manifests or still-settling stream outputs
+/// share one grace window (bounded by the time remaining until the deadline)
+/// before this returns.
+///
+/// Error mappings:
+///
+/// * [`ExecutionTerminalError::Timeout`] on any execution sets `timed_out`
+///   and stops waiting — the deadline is shared, so it has elapsed for the
+///   remaining executions too, and no time remains for a grace pass.
+/// * [`ExecutionTerminalError::KernelFailed`] sets `has_error` and stops
+///   waiting for new terminal transitions — the kernel is gone, so pending
+///   executions cannot run. Executions that did reach terminal state still
+///   get the trailing grace pass, so their durable outputs sync before the
+///   batch reports.
+pub async fn await_all_executions_terminal(
+    handle: &DocHandle,
+    execution_ids: &[String],
+    timeout: Duration,
+) -> AllExecutionsTerminal {
+    let deadline = Instant::now() + timeout;
+    let mut has_error = false;
+
+    // ── Phase 1: all-terminal, zero grace, one shared deadline ──────────
+    let mut terminal: Vec<(&str, ExecutionTerminalState)> = Vec::with_capacity(execution_ids.len());
+    for execution_id in execution_ids {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match await_execution_terminal(handle, execution_id, remaining, Some(Duration::ZERO)).await
+        {
+            Ok(state) => {
+                has_error |= state.status == "error";
+                terminal.push((execution_id, state));
+            }
+            Err(ExecutionTerminalError::Timeout) => {
+                return AllExecutionsTerminal {
+                    timed_out: true,
+                    has_error,
+                };
+            }
+            // The kernel is gone, so this execution can never terminalize.
+            // Record the failure and keep sweeping: with the kernel in a
+            // failed lifecycle the remaining awaits return on their first
+            // poll — either an already-terminal state (collected for the
+            // trailing grace pass below) or another immediate KernelFailed —
+            // so the batch stops waiting for new terminal transitions while
+            // executions that did terminalize still get their grace window.
+            Err(ExecutionTerminalError::KernelFailed { .. }) => {
+                has_error = true;
+            }
+        }
+    }
+
+    // ── Phase 2: one trailing output-sync grace pass ─────────────────────
+    //
+    // Terminal status is written after outputs, but this replica can be a
+    // sync tick behind (see the module docs). Re-await the executions
+    // concurrently with the default grace rules; `await_execution_terminal`
+    // returns immediately for executions whose outputs are already settled,
+    // so the settle predicate stays in one place and the pass costs one
+    // grace window of wall clock, not one per execution.
+    let mut settle = tokio::task::JoinSet::new();
+    for (execution_id, state) in terminal {
+        // Cancelled executions never receive outputs; waiting on them would
+        // spend the full grace window for nothing.
+        if state.status == "cancelled" {
+            continue;
+        }
+        let handle = handle.clone();
+        let execution_id = execution_id.to_string();
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        settle.spawn(async move {
+            // Best-effort: statuses are already terminal, so a grace pass
+            // cut short by the deadline does not change the outcome.
+            let _ = await_execution_terminal(&handle, &execution_id, remaining, None).await;
+        });
+    }
+    while settle.join_next().await.is_some() {}
+
+    AllExecutionsTerminal {
+        timed_out: false,
+        has_error,
+    }
+}
+
 fn stream_output_settle_window(outputs: &[serde_json::Value]) -> Option<(Duration, Duration)> {
     let has_blob_stream = outputs.iter().any(|output| {
         output.get("output_type").and_then(|t| t.as_str()) == Some("stream")

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -68,8 +68,8 @@ pub mod sync_task;
 pub use broadcast::BroadcastReceiver;
 pub use error::SyncError;
 pub use execution_wait::{
-    await_execution_terminal, ExecutionTerminalError, ExecutionTerminalState,
-    DEFAULT_OUTPUT_SYNC_GRACE,
+    await_all_executions_terminal, await_execution_terminal, AllExecutionsTerminal,
+    ExecutionTerminalError, ExecutionTerminalState, DEFAULT_OUTPUT_SYNC_GRACE,
 };
 pub use execution_watch::{ExecutionProgressState, ExecutionTerminalReason, ExecutionWatcher};
 pub use handle::{DocHandle, SnapshotPairBytes};

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -1226,6 +1226,203 @@ mod tests {
             .unwrap();
         assert_eq!(text, "final");
     }
+
+    #[tokio::test]
+    async fn await_all_executions_terminal_trailing_grace_catches_late_outputs() {
+        // The batch wait uses zero per-execution grace, so an execution whose
+        // manifests are still empty when it terminalizes must be covered by
+        // the trailing grace pass before the function returns.
+        use crate::execution_wait::{await_all_executions_terminal, AllExecutionsTerminal};
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(
+            &shared,
+            "exec-1",
+            "cell-1",
+            "done",
+            &[stream_output("all-done-output", "hello")],
+            Some(1),
+        );
+        set_execution(&shared, "exec-2", "cell-2", "done", &[], Some(2));
+
+        let shared_for_task = shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            let mut st = shared_for_task.lock().unwrap();
+            st.state_doc
+                .append_output(
+                    "exec-2",
+                    &serde_json::json!({
+                        "output_type": "execute_result",
+                        "output_id": "all-late-output",
+                        "data": {"text/plain": {"inline": "late"}},
+                    }),
+                )
+                .unwrap();
+        });
+
+        let execution_ids = vec!["exec-1".to_string(), "exec-2".to_string()];
+        let outcome = await_all_executions_terminal(
+            &handle,
+            &execution_ids,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            AllExecutionsTerminal {
+                timed_out: false,
+                has_error: false,
+            }
+        );
+        // The late output must be visible by the time the batch wait returns.
+        let state = handle.get_runtime_state().unwrap();
+        assert_eq!(state.executions["exec-2"].outputs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn await_all_executions_terminal_reports_error_status() {
+        use crate::execution_wait::await_all_executions_terminal;
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(
+            &shared,
+            "exec-1",
+            "cell-1",
+            "done",
+            &[stream_output("all-ok-output", "ok")],
+            Some(1),
+        );
+        set_execution(
+            &shared,
+            "exec-2",
+            "cell-2",
+            "error",
+            &[serde_json::json!({
+                "output_type": "error",
+                "output_id": "all-error-output",
+                "ename": "ValueError",
+                "evalue": "boom",
+                "traceback": [],
+            })],
+            Some(2),
+        );
+
+        let execution_ids = vec!["exec-1".to_string(), "exec-2".to_string()];
+        let outcome = await_all_executions_terminal(
+            &handle,
+            &execution_ids,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(outcome.has_error);
+        assert!(!outcome.timed_out);
+    }
+
+    #[tokio::test]
+    async fn await_all_executions_terminal_kernel_failure_marks_error_and_stops() {
+        // When the kernel dies while an execution is still pending, the batch
+        // wait must report has_error and return promptly instead of spinning
+        // until the shared deadline: the kernel is gone, so pending cells
+        // cannot run. Executions that reached terminal state — collected
+        // before or after the failing one in sweep order — must still get
+        // the trailing grace pass, so outputs that are in flight when the
+        // kernel dies are visible by the time the batch reports the error.
+        use crate::execution_wait::{await_all_executions_terminal, AllExecutionsTerminal};
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(&shared, "exec-1", "cell-1", "done", &[], Some(1));
+        set_execution(&shared, "exec-2", "cell-2", "running", &[], None);
+        set_execution(&shared, "exec-3", "cell-3", "done", &[], Some(2));
+        {
+            let mut st = shared.lock().unwrap();
+            st.state_doc
+                .set_lifecycle(&runtime_doc::RuntimeLifecycle::Error)
+                .unwrap();
+        }
+
+        // Outputs for the terminal executions land only during the grace
+        // window, after the kernel has already failed.
+        let shared_for_task = shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            let mut st = shared_for_task.lock().unwrap();
+            for (execution_id, output_id) in [
+                ("exec-1", "all-kernel-late-1"),
+                ("exec-3", "all-kernel-late-3"),
+            ] {
+                st.state_doc
+                    .append_output(
+                        execution_id,
+                        &serde_json::json!({
+                            "output_type": "execute_result",
+                            "output_id": output_id,
+                            "data": {"text/plain": {"inline": "late"}},
+                        }),
+                    )
+                    .unwrap();
+            }
+        });
+
+        let start = std::time::Instant::now();
+        let execution_ids = vec![
+            "exec-1".to_string(),
+            "exec-2".to_string(),
+            "exec-3".to_string(),
+        ];
+        let outcome = await_all_executions_terminal(
+            &handle,
+            &execution_ids,
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            AllExecutionsTerminal {
+                timed_out: false,
+                has_error: true,
+            }
+        );
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "kernel failure must stop the wait well before the 30s deadline"
+        );
+        // The trailing grace pass ran despite the kernel failure: the late
+        // outputs are visible by the time the batch wait returns.
+        let state = handle.get_runtime_state().unwrap();
+        assert_eq!(state.executions["exec-1"].outputs.len(), 1);
+        assert_eq!(state.executions["exec-3"].outputs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn await_all_executions_terminal_times_out_on_shared_deadline() {
+        use crate::execution_wait::await_all_executions_terminal;
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(
+            &shared,
+            "exec-1",
+            "cell-1",
+            "done",
+            &[stream_output("all-timeout-output", "ok")],
+            Some(1),
+        );
+        set_execution(&shared, "exec-2", "cell-2", "running", &[], None);
+
+        let execution_ids = vec!["exec-1".to_string(), "exec-2".to_string()];
+        let outcome = await_all_executions_terminal(
+            &handle,
+            &execution_ids,
+            std::time::Duration::from_millis(300),
+        )
+        .await;
+
+        assert!(outcome.timed_out);
+        assert!(!outcome.has_error);
+    }
 }
 
 // =========================================================================

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -5,12 +5,13 @@
 //! Automerge CRDT) for execution lifecycle state, using the CRDT as the
 //! source of truth instead of relying on broadcast hints.
 
-use std::collections::{HashMap, HashSet};
-use std::time::{Duration, Instant};
+use std::collections::HashMap;
+use std::time::Duration;
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 use notebook_sync::execution_wait::{
-    await_execution_terminal, ExecutionTerminalError, ExecutionTerminalState,
+    await_all_executions_terminal, await_execution_terminal, ExecutionTerminalError,
+    ExecutionTerminalState,
 };
 use notebook_sync::handle::DocHandle;
 use runtimed_outputs::output_resolver;
@@ -281,8 +282,12 @@ pub async fn run_all_and_queue(handle: &DocHandle) -> Result<RunAllResult, Execu
 
 /// Run all cells and wait for completion.
 ///
-/// Composes `run_all_and_queue` with a polling phase that waits for all
-/// queued execution IDs to reach terminal status in the RuntimeStateDoc.
+/// Composes `run_all_and_queue` with `await_all_executions_terminal`, which
+/// waits for every queued execution ID to reach terminal status in the
+/// RuntimeStateDoc against one shared deadline, then runs a single trailing
+/// output-sync grace pass. Kernel failure while executions are still pending
+/// maps to `status: "error"` (the kernel is gone, so later cells cannot
+/// run); hitting the deadline maps to `status: "timed_out"`.
 ///
 /// Returns a lightweight `RunAllResult` with overall status. The caller should
 /// read the full notebook state after this returns to build the summary view.
@@ -296,51 +301,13 @@ pub async fn run_all_and_wait(
         return Ok(result);
     }
 
-    let execution_ids: HashSet<&str> = result
-        .cell_execution_ids
-        .values()
-        .map(|s| s.as_str())
-        .collect();
+    let execution_ids: Vec<String> = result.cell_execution_ids.values().cloned().collect();
+    let outcome = await_all_executions_terminal(handle, &execution_ids, timeout).await;
 
-    // Poll RuntimeStateDoc for all execution IDs to reach terminal status.
-    let deadline = Instant::now() + timeout;
-    let mut all_terminal = false;
-
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-
-        if let Ok(state) = handle.get_runtime_state() {
-            all_terminal = execution_ids.iter().all(|eid| {
-                state.executions.get(*eid).is_some_and(|exec| {
-                    exec.status == "done" || exec.status == "error" || exec.status == "cancelled"
-                })
-            });
-            if all_terminal {
-                break;
-            }
-        }
-
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
-    // Derive overall status.
-    let timed_out = !all_terminal;
-    let has_error = handle.get_runtime_state().ok().is_some_and(|state| {
-        execution_ids.iter().any(|eid| {
-            state
-                .executions
-                .get(*eid)
-                .is_some_and(|exec| exec.status == "error")
-        })
-    });
-
-    result.timed_out = timed_out;
-    result.status = if timed_out {
+    result.timed_out = outcome.timed_out;
+    result.status = if outcome.timed_out {
         "timed_out"
-    } else if has_error {
+    } else if outcome.has_error {
         "error"
     } else {
         "completed"


### PR DESCRIPTION
run_all_and_wait carried its own copy of the terminal-status predicate (done/error/cancelled) next to the shared helper in notebook-sync::execution_wait. Replace it with a new batch sibling, await_all_executions_terminal, so the predicate and the output-settle rules live in one place.

Wait discipline: each execution is awaited with zero output-sync grace against one shared deadline, then a single trailing grace pass re-awaits the non-cancelled executions concurrently under the default grace rules. The helper returns immediately for executions whose outputs are already settled, so trailing executions with empty manifests or in-flight stream outputs share one grace window instead of serializing N default windows. Terminal status still follows durable output state for the last cell and for any cell whose outputs are in flight when it terminalizes.

Mappings: Timeout on any execution keeps the current run_all contract (timed_out: true, status "timed_out"). KernelFailed marks has_error and stops waiting for new terminal transitions (status "error"); the kernel is gone, so pending cells cannot run, and the remaining sweep returns without polling. Executions that did reach terminal state still get the trailing grace pass, so their durable outputs sync before the batch reports the error. Previously a dead kernel with a never-terminal execution spun until the deadline and reported "timed_out".

MCP callers see the same result shape, per-cell statuses, and has_error semantics. What changes is wall clock: one shared deadline instead of per-cell deadlines, and no serial per-cell grace.


