### PR TITLE
refactor(runtimed): collapse no-dependencies TrustState literals into a constructor

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -11,6 +11,33 @@ pub struct TrustState {
     pub pending_launch: bool,
 }
 
+impl TrustState {
+    /// Trust state for a notebook that declares no dependency metadata:
+    /// nothing needs approval and kernel launch is not gated. This is a
+    /// deliberate verdict, not a default; construct other states explicitly.
+    pub(crate) fn no_dependencies() -> Self {
+        TrustState {
+            status: runt_trust::TrustStatus::NoDependencies,
+            info: runt_trust::TrustInfo {
+                status: runt_trust::TrustStatus::NoDependencies,
+                uv_dependencies: vec![],
+                approved_uv_dependencies: vec![],
+                conda_dependencies: vec![],
+                approved_conda_dependencies: vec![],
+                conda_channels: vec![],
+                approved_conda_channels: vec![],
+                pixi_dependencies: vec![],
+                approved_pixi_dependencies: vec![],
+                pixi_pypi_dependencies: vec![],
+                approved_pixi_pypi_dependencies: vec![],
+                pixi_channels: vec![],
+                approved_pixi_channels: vec![],
+            },
+            pending_launch: false,
+        }
+    }
+}
+
 fn enrich_trust_info(room: &NotebookRoom, trust: &mut TrustState) {
     if let Err(error) = room.trusted_packages.enrich_info(&mut trust.info) {
         warn!(

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1294,47 +1294,11 @@ impl NotebookRoom {
             // in the persisted Automerge doc we just loaded.
             None => match doc.get_metadata_snapshot() {
                 Some(snapshot) => verify_trust_from_snapshot(&snapshot, &trusted_packages),
-                None => TrustState {
-                    status: runt_trust::TrustStatus::NoDependencies,
-                    info: runt_trust::TrustInfo {
-                        status: runt_trust::TrustStatus::NoDependencies,
-                        uv_dependencies: vec![],
-                        approved_uv_dependencies: vec![],
-                        conda_dependencies: vec![],
-                        approved_conda_dependencies: vec![],
-                        conda_channels: vec![],
-                        approved_conda_channels: vec![],
-                        pixi_dependencies: vec![],
-                        approved_pixi_dependencies: vec![],
-                        pixi_pypi_dependencies: vec![],
-                        approved_pixi_pypi_dependencies: vec![],
-                        pixi_channels: vec![],
-                        approved_pixi_channels: vec![],
-                    },
-                    pending_launch: false,
-                },
+                None => TrustState::no_dependencies(),
             },
             Some(_) if recovered_record.is_some() => match doc.get_metadata_snapshot() {
                 Some(snapshot) => verify_trust_from_snapshot(&snapshot, &trusted_packages),
-                None => TrustState {
-                    status: runt_trust::TrustStatus::NoDependencies,
-                    info: runt_trust::TrustInfo {
-                        status: runt_trust::TrustStatus::NoDependencies,
-                        uv_dependencies: vec![],
-                        approved_uv_dependencies: vec![],
-                        conda_dependencies: vec![],
-                        approved_conda_dependencies: vec![],
-                        conda_channels: vec![],
-                        approved_conda_channels: vec![],
-                        pixi_dependencies: vec![],
-                        approved_pixi_dependencies: vec![],
-                        pixi_pypi_dependencies: vec![],
-                        approved_pixi_pypi_dependencies: vec![],
-                        pixi_channels: vec![],
-                        approved_pixi_channels: vec![],
-                    },
-                    pending_launch: false,
-                },
+                None => TrustState::no_dependencies(),
             },
             Some(p) => {
                 let mut initial = verify_trust_from_file(p, &trusted_packages);
@@ -1651,25 +1615,7 @@ impl NotebookRoom {
         let trust_state = match &path {
             None => match doc.get_metadata_snapshot() {
                 Some(snapshot) => verify_trust_from_snapshot(&snapshot, &trusted_packages),
-                None => TrustState {
-                    status: runt_trust::TrustStatus::NoDependencies,
-                    info: runt_trust::TrustInfo {
-                        status: runt_trust::TrustStatus::NoDependencies,
-                        uv_dependencies: vec![],
-                        approved_uv_dependencies: vec![],
-                        conda_dependencies: vec![],
-                        approved_conda_dependencies: vec![],
-                        conda_channels: vec![],
-                        approved_conda_channels: vec![],
-                        pixi_dependencies: vec![],
-                        approved_pixi_dependencies: vec![],
-                        pixi_pypi_dependencies: vec![],
-                        approved_pixi_pypi_dependencies: vec![],
-                        pixi_channels: vec![],
-                        approved_pixi_channels: vec![],
-                    },
-                    pending_launch: false,
-                },
+                None => TrustState::no_dependencies(),
             },
             Some(p) => {
                 let mut initial = verify_trust_from_file(p, &trusted_packages);


### PR DESCRIPTION
Three verbatim TrustState literals in room.rs (untitled load, recovered-record load, and the test-only constructor path) spell out the same no-dependencies verdict field by field. Replace them with TrustState::no_dependencies() in metadata.rs, next to the struct.

The constructor is deliberately not a Default impl. NoDependencies is a trust verdict, and the explicit name keeps every other state spelled out at the call site.

Consolidation item 11 from docs/memos/room-lifecycle-simplification-and-verification.md.


