### PR TITLE
refactor(runtimed): deduplicate eviction generation fence into one closure

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -93,6 +93,24 @@ pub(super) async fn handle_peer_disconnect(
         );
 
         spawn_best_effort("room-kernel-teardown", async move {
+            // Generation fence: teardown may proceed only while the room
+            // has no peers AND the connection generation still matches
+            // the snapshot taken at scheduling time. A fast reconnect
+            // bumps the generation, so a stale teardown never shoots a
+            // kernel the reconnected peer now owns. Evaluate this only
+            // inside a `serialize_with` critical section so the reads
+            // are consistent with connect-path mutations.
+            let teardown_fence_holds = || {
+                let no_peers = room_for_teardown
+                    .connections
+                    .active_peers
+                    .load(Ordering::Relaxed)
+                    == 0;
+                let same_generation =
+                    room_for_teardown.connections.connection_generation() == teardown_generation;
+                no_peers && same_generation
+            };
+
             // Outer loop wraps the teardown attempt so a flush timeout can
             // back off and retry rather than leak the kernel indefinitely.
             // Exits either by cancelling (peers reconnected) or by
@@ -183,16 +201,7 @@ pub(super) async fn handle_peer_disconnect(
             // kernel-side teardown on "no peers AND no reconnect since
             // scheduling."
             let should_teardown = rooms_for_teardown
-                .serialize_with(|| {
-                    let no_peers = room_for_teardown
-                        .connections
-                        .active_peers
-                        .load(Ordering::Relaxed)
-                        == 0;
-                    let same_generation = room_for_teardown.connections.connection_generation()
-                        == teardown_generation;
-                    no_peers && same_generation
-                })
+                .serialize_with(&teardown_fence_holds)
                 .await;
 
             if !should_teardown {
@@ -231,14 +240,7 @@ pub(super) async fn handle_peer_disconnect(
             // state if (and only if) we will actually proceed below.
             let still_valid = rooms_for_teardown
                 .serialize_with(|| {
-                    let no_peers = room_for_teardown
-                        .connections
-                        .active_peers
-                        .load(Ordering::Relaxed)
-                        == 0;
-                    let same_generation = room_for_teardown.connections.connection_generation()
-                        == teardown_generation;
-                    let ok = no_peers && same_generation;
+                    let ok = teardown_fence_holds();
                     if ok {
                         room_for_teardown
                             .connections
@@ -357,16 +359,7 @@ pub(super) async fn handle_peer_disconnect(
             // may now be a new session. A changed generation aborts this stale
             // teardown even if that peer has already disconnected again.
             let still_current_after_load_wait = rooms_for_teardown
-                .serialize_with(|| {
-                    let no_peers = room_for_teardown
-                        .connections
-                        .active_peers
-                        .load(Ordering::Relaxed)
-                        == 0;
-                    let same_generation = room_for_teardown.connections.connection_generation()
-                        == teardown_generation;
-                    no_peers && same_generation
-                })
+                .serialize_with(&teardown_fence_holds)
                 .await;
             if !still_current_after_load_wait {
                 debug!(
@@ -517,16 +510,7 @@ pub(super) async fn handle_peer_disconnect(
             // would orphan the resumed kernel. The room stays
             // resident, so aborting is the right move.
             let still_valid = rooms_for_teardown
-                .serialize_with(|| {
-                    let no_peers = room_for_teardown
-                        .connections
-                        .active_peers
-                        .load(Ordering::Relaxed)
-                        == 0;
-                    let same_generation = room_for_teardown.connections.connection_generation()
-                        == teardown_generation;
-                    no_peers && same_generation
-                })
+                .serialize_with(&teardown_fence_holds)
                 .await;
             if !still_valid {
                 debug!(


### PR DESCRIPTION
The teardown task in peer_eviction.rs checks the same invariant at four points: proceed only while the room has no peers and the connection generation still matches the snapshot taken at scheduling time. This is the generation fence that keeps a stale teardown from shooting a kernel a fast reconnect now owns. The four inline copies become one local closure, teardown_fence_holds, evaluated inside each serialize_with critical section.

Shape-preserving: same checks, same order, same critical sections. The ShutdownKernel site keeps its fence check fused with the kernel_teardown_destructive latch flip in a single serialize_with block, so the connect path still observes a consistent destructive-teardown state if and only if teardown proceeds. registry.rs is untouched; serialize_with remains the lock primitive.

Consolidation item 12 from docs/memos/room-lifecycle-simplification-and-verification.md.


