### PR TITLE
refactor(runtimed): remove cfg(test) apply_ipynb_changes wrapper

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1870,40 +1870,6 @@ fn degrade_external_source_revision(room: &NotebookRoom, reason: String) {
     warn!("[notebook-watch] {reason}");
 }
 
-/// Apply external .ipynb changes to the Automerge doc.
-///
-/// Compares cells by ID and:
-/// - Adds new cells
-/// - Removes deleted cells
-/// - Updates source, execution_count, and outputs for modified cells
-/// - Handles cell reordering by rebuilding the cell list
-///
-/// When a kernel is running, outputs and execution counts are preserved
-/// to avoid losing in-progress execution results.
-///
-/// Returns true only after changed NotebookDoc heads have a durable journal
-/// marker. Journal failure rolls the live document back before returning.
-#[cfg(test)]
-pub(crate) async fn apply_ipynb_changes(
-    room: &NotebookRoom,
-    external_cells: &[CellSnapshot],
-    external_outputs: &HashMap<String, Vec<serde_json::Value>>,
-    external_attachments: &HashMap<String, serde_json::Value>,
-    has_running_kernel: bool,
-) -> bool {
-    apply_ipynb_changes_inner(
-        room,
-        external_cells,
-        external_outputs,
-        external_attachments,
-        has_running_kernel,
-        None,
-        None,
-    )
-    .await
-    .changed()
-}
-
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct AppliedIpynbChanges {
     pub(crate) cells_changed: bool,
@@ -1918,7 +1884,7 @@ pub(crate) struct ExternalSourceRevision {
 }
 
 impl AppliedIpynbChanges {
-    fn changed(self) -> bool {
+    pub(crate) fn changed(self) -> bool {
         self.cells_changed || self.metadata_changed
     }
 }
@@ -1946,7 +1912,25 @@ pub(crate) async fn apply_ipynb_changes_from_source(
     .await
 }
 
-async fn apply_ipynb_changes_inner(
+/// Apply external .ipynb changes to the Automerge doc.
+///
+/// Compares cells by ID and:
+/// - Adds new cells
+/// - Removes deleted cells
+/// - Updates source, execution_count, and outputs for modified cells
+/// - Handles cell reordering by rebuilding the cell list
+///
+/// When a kernel is running, outputs and execution counts are preserved
+/// to avoid losing in-progress execution results.
+///
+/// A `None` source revision applies the changes without binding them to a
+/// source fingerprint; production file-watcher ingest goes through
+/// [`apply_ipynb_changes_from_source`] instead.
+///
+/// Reports changes only after changed NotebookDoc heads have a durable
+/// journal marker. Journal failure rolls the live document back before
+/// returning.
+pub(crate) async fn apply_ipynb_changes_inner(
     room: &NotebookRoom,
     external_cells: &[CellSnapshot],
     external_outputs: &HashMap<String, Vec<serde_json::Value>>,

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -536,7 +536,7 @@ mod tests {
     use super::*;
     use crate::blob_store::BlobStore;
     use crate::notebook_sync_server::{
-        apply_ipynb_changes, save_notebook_to_disk, RoomInitialLoad, RoomInitialLoadStart,
+        apply_ipynb_changes_inner, save_notebook_to_disk, RoomInitialLoad, RoomInitialLoadStart,
     };
 
     #[derive(Default)]
@@ -1742,14 +1742,17 @@ mod tests {
             attachments: HashMap::new(),
         }];
 
-        let changed = apply_ipynb_changes(
+        let changed = apply_ipynb_changes_inner(
             &room,
             &external_cells,
             &HashMap::new(),
             &HashMap::new(),
             true,
+            None, // external_metadata
+            None, // source_revision: exercise the no-source-revision path
         )
-        .await;
+        .await
+        .changed();
         assert!(
             !changed,
             "unchanged disk contents should not roll back an immediate live edit"

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -2393,7 +2393,7 @@ pub(crate) async fn process_watcher_event(room: &NotebookRoom, notebook_path: &P
     }
 
     if room.durability.status().is_degraded() {
-        // `apply_ipynb_changes` rolls the NotebookDoc
+        // `apply_ipynb_changes_inner` rolls the NotebookDoc
         // back when its journal marker fails. Do not
         // apply metadata, advance source baselines, or
         // publish a recovery over that terminal state.

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -4686,14 +4686,17 @@ async fn test_apply_ipynb_changes_clears_all_cells() {
     // Apply empty external cells - should delete all cells (we have
     // a save baseline confirming cell-1 was on disk before)
     let external_cells = vec![];
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &HashMap::new(),
         false,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed, "Should apply changes to clear all cells");
 
     // Verify all cells were deleted
@@ -4727,14 +4730,17 @@ async fn test_apply_ipynb_changes_updates_execution_count() {
         attachments: std::collections::HashMap::new(),
     }];
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &HashMap::new(),
         false,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed, "Should detect execution_count change");
 
     // Live execution_count is resolved from RuntimeStateDoc via synthetic execution_id.
@@ -4912,14 +4918,17 @@ async fn test_apply_ipynb_changes_updates_existing_cell_attachments() {
         }),
     )]);
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &external_attachments,
         false,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed, "Should detect attachment changes");
 
     let cells = room.doc.read().await.get_cells();
@@ -4968,14 +4977,17 @@ async fn test_apply_ipynb_changes_preserves_execution_count_when_kernel_running(
         attachments: std::collections::HashMap::new(),
     }];
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &HashMap::new(),
         true,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed, "Should apply source change");
 
     let cells = {
@@ -5031,14 +5043,17 @@ async fn test_apply_ipynb_changes_new_cell_with_outputs_while_kernel_running() {
         vec![serde_json::json!({"output_type":"execute_result"})],
     );
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &external_outputs,
         &HashMap::new(),
         true,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed, "Should add new cell");
 
     let cells = {
@@ -5118,14 +5133,17 @@ async fn test_apply_ipynb_changes_wholesale_replacement() {
         },
     ];
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &HashMap::new(),
         false,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed, "Should detect wholesale replacement");
 
     let cells = {
@@ -5182,14 +5200,17 @@ async fn test_apply_ipynb_changes_partial_overlap_preserves_unsaved() {
         attachments: std::collections::HashMap::new(),
     }];
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &HashMap::new(),
         false,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     assert!(changed);
 
     let cells = {
@@ -5239,14 +5260,17 @@ async fn test_apply_ipynb_changes_no_save_snapshot_preserves_crdt_cells() {
     // External file has 0 cells (the autosave wrote an empty notebook)
     let external_cells: Vec<CellSnapshot> = vec![];
 
-    let changed = apply_ipynb_changes(
+    let changed = apply_ipynb_changes_inner(
         &room,
         &external_cells,
         &HashMap::new(),
         &HashMap::new(),
         false,
+        None, // external_metadata
+        None, // source_revision: exercise the no-source-revision path
     )
-    .await;
+    .await
+    .changed();
     // No changes should be applied — cells preserved
     assert!(
         !changed,


### PR DESCRIPTION
Tests now call apply_ipynb_changes_inner directly and pass the external_metadata and source_revision arguments themselves, so each test names that it exercises the no-source-revision path instead of hiding that choice behind a test-only wrapper.

Promotes apply_ipynb_changes_inner and AppliedIpynbChanges::changed to pub(crate) and moves the .changed() collapse to the nine test call sites (eight in tests.rs, one in peer_session.rs). The wrapper's doc comment moves onto the inner function with a note pointing production file-watcher ingest at apply_ipynb_changes_from_source.

Consolidation item 10 from docs/memos/room-lifecycle-simplification-and-verification.md.


