### PR TITLE
fix(notebook-sync): gate the convergence fault switch out of release builds

### DIFF
--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -186,8 +186,12 @@ impl ReactorState {
             next_confirm_sync_attempt: Instant::now(),
             sync_generation: 0,
             acked_sync_generation: 0,
-            stall_notebook_convergence: std::env::var(NOTEBOOK_SYNC_FAULT_ENV)
-                .is_ok_and(|value| value == STALL_NOTEBOOK_CONVERGENCE_FAULT),
+            // The fault switch is harness-only: release builds never read the
+            // env var, so a stray NTERACT_NOTEBOOK_SYNC_FAULT in a user
+            // environment cannot stall convergence.
+            stall_notebook_convergence: cfg!(any(test, debug_assertions))
+                && std::env::var(NOTEBOOK_SYNC_FAULT_ENV)
+                    .is_ok_and(|value| value == STALL_NOTEBOOK_CONVERGENCE_FAULT),
         }
     }
 }


### PR DESCRIPTION
The stall-notebook-convergence fault is a harness-only seam for proving projections stay useful while a replica cannot converge. The reactor now reads `NTERACT_NOTEBOOK_SYNC_FAULT` only under `cfg(any(test, debug_assertions))`, so a stray environment variable in a user install cannot withhold NotebookDoc frames.

Deferred finding from #4018. Verified with the notebook-sync lib suite (the fault-injection tests still exercise the seam under cfg(test)) plus a release-profile build.
