### PR TITLE
fix(runtimed): make external metadata apply idempotent

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -813,6 +813,32 @@ impl NotebookDoc {
         Ok(())
     }
 
+    /// True when writing `snapshot` via [`Self::set_metadata_snapshot`] would
+    /// leave the readable metadata unchanged.
+    ///
+    /// Raw `snapshot == doc.get_metadata_snapshot()` comparisons are not
+    /// idempotence-safe because a write+read round trip normalizes the
+    /// snapshot in two ways:
+    ///
+    /// - an all-empty snapshot (a vanilla `.ipynb` with `"metadata": {}`)
+    ///   reads back as `None`, not `Some(default)` — the doc's metadata map
+    ///   may hold only internal reserved keys (`runtime`, `ephemeral`) that
+    ///   the snapshot never models
+    /// - extras entries under reserved keys are dropped on write and skipped
+    ///   on read, so they never surface in the doc's readable form
+    ///
+    /// External-apply paths (file watcher, recovery replay) must use this to
+    /// decide whether an incoming snapshot is a real change; comparing
+    /// unnormalized forms reports a permanent spurious delta for identical
+    /// input (issue #4015).
+    pub fn metadata_snapshot_matches(&self, snapshot: &metadata::NotebookMetadataSnapshot) -> bool {
+        let mut incoming = snapshot.clone();
+        incoming
+            .extras
+            .retain(|key, _| !is_snapshot_reserved_metadata_key(key));
+        self.get_metadata_snapshot().unwrap_or_default() == incoming
+    }
+
     /// Detect the notebook runtime from metadata (kernelspec + language_info).
     ///
     /// Returns `"python"`, `"deno"`, or `None` for unknown runtimes.
@@ -6646,6 +6672,50 @@ mod tests {
             !after_second.extras.contains_key("colab"),
             "stale extras key must be deleted when absent from replacement"
         );
+    }
+
+    #[test]
+    fn metadata_snapshot_matches_normalizes_the_doc_round_trip() {
+        use crate::metadata::{KernelspecSnapshot, NotebookMetadataSnapshot};
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+        // An all-empty snapshot matches a doc with no readable metadata,
+        // even though get_metadata_snapshot() returns None for that doc.
+        let empty = NotebookMetadataSnapshot::default();
+        assert!(doc.metadata_snapshot_matches(&empty));
+
+        // Internal reserved keys on the doc don't break the match: they
+        // never surface in the readable snapshot.
+        let meta_id = doc
+            .doc
+            .put_object(automerge::ROOT, "metadata", ObjType::Map)
+            .unwrap();
+        doc.doc.put(&meta_id, "runtime", "python").unwrap();
+        assert!(doc.metadata_snapshot_matches(&empty));
+
+        // Reserved keys in the incoming extras are dropped on write, so
+        // they don't count as a difference either.
+        let mut reserved_extras = NotebookMetadataSnapshot::default();
+        reserved_extras
+            .extras
+            .insert("runtime".to_string(), serde_json::json!("python"));
+        assert!(doc.metadata_snapshot_matches(&reserved_extras));
+
+        // A genuine difference still reports as one, and matches after
+        // the write lands.
+        let real = NotebookMetadataSnapshot {
+            kernelspec: Some(KernelspecSnapshot {
+                name: "python3".to_string(),
+                display_name: "Python 3".to_string(),
+                language: Some("python".to_string()),
+                extras: Default::default(),
+            }),
+            ..Default::default()
+        };
+        assert!(!doc.metadata_snapshot_matches(&real));
+        doc.set_metadata_snapshot(&real).unwrap();
+        assert!(doc.metadata_snapshot_matches(&real));
+        assert!(!doc.metadata_snapshot_matches(&empty));
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -2180,9 +2180,8 @@ pub(crate) async fn apply_ipynb_changes_inner(
                         }
                     }
 
-                    let metadata_changed = external_metadata.is_some_and(|metadata| {
-                        doc.get_metadata_snapshot().as_ref() != Some(metadata)
-                    });
+                    let metadata_changed = external_metadata
+                        .is_some_and(|metadata| !doc.metadata_snapshot_matches(metadata));
                     if let Some(metadata) = external_metadata.filter(|_| metadata_changed) {
                         doc.set_metadata_snapshot(metadata)?;
                     }
@@ -2502,9 +2501,8 @@ pub(crate) async fn apply_ipynb_changes_inner(
                 }
 
                 let cells_changed = changed;
-                let metadata_changed = external_metadata.is_some_and(|metadata| {
-                    doc.get_metadata_snapshot().as_ref() != Some(metadata)
-                });
+                let metadata_changed = external_metadata
+                    .is_some_and(|metadata| !doc.metadata_snapshot_matches(metadata));
                 if let Some(metadata) = external_metadata.filter(|_| metadata_changed) {
                     doc.set_metadata_snapshot(metadata)?;
                 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5264,6 +5264,189 @@ async fn test_apply_ipynb_changes_no_save_snapshot_preserves_crdt_cells() {
     );
 }
 
+/// Applying identical external content twice is a no-op the second time:
+/// no reported change AND no new Automerge changes (issue #4015). A
+/// spurious metadata_changed fires changed_tx (resetting the autosave
+/// debounce), commits a journal marker, and wakes the persist debouncer.
+///
+/// Exercises both suspect shapes:
+/// - a file whose metadata is empty while the doc carries internal keys
+///   (`runtime` scalar, `runt.env_id`) the .ipynb omits — the untitled
+///   autosave scenario from the issue's watcher log
+/// - a file with kernelspec, language_info, and an unknown top-level key
+#[tokio::test]
+async fn test_apply_ipynb_changes_identical_metadata_is_idempotent() {
+    let empty_metadata_fixture = br#"{
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {"id": "cell-1", "cell_type": "code", "source": "x = 1",
+             "execution_count": null, "metadata": {}, "outputs": []}
+        ]
+    }"# as &[u8];
+    let rich_metadata_fixture = br#"{
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {
+            "kernelspec": {"name": "python3", "display_name": "Python 3",
+                           "language": "python"},
+            "language_info": {"name": "python", "version": "3.12.1",
+                              "codemirror_mode": {"name": "ipython", "version": 3}},
+            "jupytext": {"formats": "ipynb,md"}
+        },
+        "cells": [
+            {"id": "cell-1", "cell_type": "code", "source": "x = 1",
+             "execution_count": null, "metadata": {}, "outputs": []}
+        ]
+    }"# as &[u8];
+
+    for (label, fixture) in [
+        ("empty-metadata", empty_metadata_fixture),
+        ("rich-metadata", rich_metadata_fixture),
+    ] {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+        // The doc carries keys the .ipynb never has: the internal
+        // `runtime` scalar (stamped at bootstrap) and a runt-namespaced
+        // env_id. These must not make identical external content look
+        // permanently different.
+        {
+            let mut doc = room.doc.write().await;
+            doc.set_metadata("runtime", "python").unwrap();
+            doc.with_metadata(|snap| {
+                snap.runt.env_id = Some("11111111-2222-3333-4444-555555555555".to_string());
+            })
+            .unwrap();
+        }
+
+        let parsed = parse_notebook_jiter_for_notebook(fixture, room.id).expect("fixture parses");
+        let external_metadata = parsed.metadata.expect("fixture has metadata");
+        let (external_cells, external_outputs) = streaming_cells_into_snapshots(parsed.cells);
+
+        let first = apply_ipynb_changes_inner(
+            &room,
+            &external_cells,
+            &external_outputs,
+            &parsed.attachments,
+            false,
+            Some(&external_metadata),
+            None,
+        )
+        .await;
+        assert!(
+            first.changed(),
+            "[{label}] first apply reconciles the doc to the external file"
+        );
+
+        let heads_after_first = room.doc.write().await.get_heads();
+
+        let second = apply_ipynb_changes_inner(
+            &room,
+            &external_cells,
+            &external_outputs,
+            &parsed.attachments,
+            false,
+            Some(&external_metadata),
+            None,
+        )
+        .await;
+        assert!(
+            !second.cells_changed,
+            "[{label}] second apply of identical content must report cells=false"
+        );
+        assert!(
+            !second.metadata_changed,
+            "[{label}] second apply of identical content must report metadata=false"
+        );
+
+        let heads_after_second = room.doc.write().await.get_heads();
+        assert_eq!(
+            heads_after_first, heads_after_second,
+            "[{label}] idempotent re-apply must produce zero new Automerge changes"
+        );
+    }
+}
+
+/// Companion to the idempotence test: a genuinely different metadata
+/// snapshot must still report metadata_changed=true and land in the doc.
+/// The idempotence fix normalizes the comparison; it must not swallow
+/// real deltas.
+#[tokio::test]
+async fn test_apply_ipynb_changes_genuine_metadata_change_still_reports() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+    let before = br#"{
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {
+            "kernelspec": {"name": "python3", "display_name": "Python 3",
+                           "language": "python"},
+            "jupytext": {"formats": "ipynb,md"}
+        },
+        "cells": [
+            {"id": "cell-1", "cell_type": "code", "source": "x = 1",
+             "execution_count": null, "metadata": {}, "outputs": []}
+        ]
+    }"#;
+    let after = br#"{
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {
+            "kernelspec": {"name": "deno", "display_name": "Deno",
+                           "language": "typescript"},
+            "custom_extension": {"enabled": true}
+        },
+        "cells": [
+            {"id": "cell-1", "cell_type": "code", "source": "x = 1",
+             "execution_count": null, "metadata": {}, "outputs": []}
+        ]
+    }"#;
+
+    let parsed_before = parse_notebook_jiter_for_notebook(before, room.id).expect("before parses");
+    let metadata_before = parsed_before.metadata.expect("before has metadata");
+    let (cells_before, outputs_before) = streaming_cells_into_snapshots(parsed_before.cells);
+    apply_ipynb_changes_inner(
+        &room,
+        &cells_before,
+        &outputs_before,
+        &parsed_before.attachments,
+        false,
+        Some(&metadata_before),
+        None,
+    )
+    .await;
+
+    let parsed_after = parse_notebook_jiter_for_notebook(after, room.id).expect("after parses");
+    let metadata_after = parsed_after.metadata.expect("after has metadata");
+    let (cells_after, outputs_after) = streaming_cells_into_snapshots(parsed_after.cells);
+    let applied = apply_ipynb_changes_inner(
+        &room,
+        &cells_after,
+        &outputs_after,
+        &parsed_after.attachments,
+        false,
+        Some(&metadata_after),
+        None,
+    )
+    .await;
+
+    assert!(
+        applied.metadata_changed,
+        "genuinely different metadata must report metadata=true"
+    );
+    let doc = room.doc.read().await;
+    let snapshot = doc.get_metadata_snapshot().expect("metadata present");
+    assert_eq!(snapshot.kernelspec.as_ref().unwrap().name, "deno");
+    assert!(snapshot.extras.contains_key("custom_extension"));
+    assert!(
+        !snapshot.extras.contains_key("jupytext"),
+        "stale extras key must be replaced by the new snapshot"
+    );
+}
+
 #[tokio::test]
 async fn test_initial_load_routes_outputs_through_blob_store() {
     let tmp = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
Applying identical external content twice is a no-op: the second application reports no change and produces no new Automerge changes. Before this, apply_ipynb_changes_inner reported metadata_changed=true on every pass over the same on-disk bytes, which fires changed_tx (resetting the autosave debounce), commits a journal marker, and wakes the persist debouncer for no new information (#4015).

Root cause: the apply path compared unnormalized forms, i.e. `doc.get_metadata_snapshot().as_ref() != Some(metadata)`. A doc write+read round trip normalizes the snapshot in two ways the raw comparison misses. First, get_metadata_snapshot returns None when the doc's metadata map holds nothing beyond internal reserved keys (`runtime`, `ephemeral`), so a vanilla .ipynb with `"metadata": {}` parses to Some(NotebookMetadataSnapshot::default()) yet reads back as None, and None != Some(default) fires forever. This is exactly the untitled-autosave shape from the watcher log: the doc carries the bootstrap `runtime` scalar while the saved file has empty metadata. Second, extras entries under reserved keys are dropped by set_metadata_snapshot and skipped by the read-side extras scan, so a file carrying one would never round-trip either.

The fix adds NotebookDoc::metadata_snapshot_matches, which compares the doc's readable form (get_metadata_snapshot().unwrap_or_default()) against the incoming snapshot with reserved extras keys stripped - the exact form a write+read round trip produces. Both apply sites in load.rs (the order-change and in-place paths) now gate the metadata write on that check. Genuine changes still normalize to different snapshots, so nothing real is suppressed, and because the write is gated on the same predicate, a matched snapshot produces zero new doc ops rather than a masked flag.

Tests: a runtimed unit test applies the same parsed .ipynb twice (both the empty-metadata and rich kernelspec/language_info/unknown-key fixtures, with the doc pre-seeded with `runtime` and runt.env_id) and asserts the second application reports cells=false, metadata=false with unchanged doc heads; a companion test asserts a genuinely different snapshot still reports metadata=true and replaces stale extras; a notebook-doc unit test pins the normalization semantics of metadata_snapshot_matches directly.

Fixes #4015.
