### PR TITLE
refactor(notebook-sync): collapse create-notebook ladder into CreateNotebookSpec

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -18,8 +18,9 @@ pub use framing::{
 };
 
 pub use handshake::{
-    recv_typed_bootstrap_frame, send_typed_bootstrap_frame, ConnectionBootstrap, Handshake,
-    NotebookConnectionInfo, ProtocolCapabilities, PutBlobCapability, PROTOCOL_V4, PROTOCOL_VERSION,
+    recv_typed_bootstrap_frame, send_typed_bootstrap_frame, ConnectionBootstrap,
+    CreateNotebookRequest, Handshake, NotebookConnectionInfo, ProtocolCapabilities,
+    PutBlobCapability, PROTOCOL_V4, PROTOCOL_VERSION,
 };
 
 #[cfg(windows)]
@@ -233,32 +234,17 @@ mod tests {
         );
 
         // CreateNotebook without working_dir
-        let json = serde_json::to_string(&Handshake::CreateNotebook {
-            runtime: "python".into(),
-            working_dir: None,
-            notebook_id: None,
-            ephemeral: None,
-            package_manager: None,
-            environment_mode: None,
-            dependencies: vec![],
-            typed_bootstrap: None,
-            operator: None,
-        })
+        let json = serde_json::to_string(&Handshake::CreateNotebook(CreateNotebookRequest::new(
+            "python",
+        )))
         .unwrap();
         assert_eq!(json, r#"{"channel":"create_notebook","runtime":"python"}"#);
 
         // CreateNotebook with working_dir
-        let json = serde_json::to_string(&Handshake::CreateNotebook {
-            runtime: "deno".into(),
+        let json = serde_json::to_string(&Handshake::CreateNotebook(CreateNotebookRequest {
             working_dir: Some("/home/user/project".into()),
-            notebook_id: None,
-            ephemeral: None,
-            package_manager: None,
-            environment_mode: None,
-            dependencies: vec![],
-            typed_bootstrap: None,
-            operator: None,
-        })
+            ..CreateNotebookRequest::new("deno")
+        }))
         .unwrap();
         assert_eq!(
             json,
@@ -266,39 +252,45 @@ mod tests {
         );
 
         // CreateNotebook with notebook_id hint (session restore)
-        let json = serde_json::to_string(&Handshake::CreateNotebook {
-            runtime: "python".into(),
-            working_dir: None,
+        let json = serde_json::to_string(&Handshake::CreateNotebook(CreateNotebookRequest {
             notebook_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
-            ephemeral: None,
-            package_manager: None,
-            environment_mode: None,
-            dependencies: vec![],
-            typed_bootstrap: None,
-            operator: None,
-        })
+            ..CreateNotebookRequest::new("python")
+        }))
         .unwrap();
         assert_eq!(
             json,
             r#"{"channel":"create_notebook","runtime":"python","notebook_id":"550e8400-e29b-41d4-a716-446655440000"}"#
         );
 
-        let json = serde_json::to_string(&Handshake::CreateNotebook {
-            runtime: "python".into(),
+        let json = serde_json::to_string(&Handshake::CreateNotebook(CreateNotebookRequest {
             working_dir: Some("/home/user/project".into()),
-            notebook_id: None,
-            ephemeral: None,
-            package_manager: None,
             environment_mode: Some(CreateNotebookEnvironmentMode::Notebook),
-            dependencies: vec![],
-            typed_bootstrap: None,
-            operator: None,
-        })
+            ..CreateNotebookRequest::new("python")
+        }))
         .unwrap();
         assert_eq!(
             json,
             r#"{"channel":"create_notebook","runtime":"python","working_dir":"/home/user/project","environment_mode":"notebook"}"#
         );
+
+        // CreateNotebook deserializes from minimal JSON (all optional fields
+        // absent), the shape older clients send.
+        let parsed: Handshake =
+            serde_json::from_str(r#"{"channel":"create_notebook","runtime":"python"}"#).unwrap();
+        match parsed {
+            Handshake::CreateNotebook(req) => {
+                assert_eq!(req.runtime, "python");
+                assert!(req.working_dir.is_none());
+                assert!(req.notebook_id.is_none());
+                assert!(req.ephemeral.is_none());
+                assert!(req.package_manager.is_none());
+                assert!(req.environment_mode.is_none());
+                assert!(req.dependencies.is_empty());
+                assert!(req.typed_bootstrap.is_none());
+                assert!(req.operator.is_none());
+            }
+            other => panic!("expected CreateNotebook, got {other:?}"),
+        }
 
         let json = serde_json::to_string(&Handshake::OpenNotebook {
             path: "/home/user/notebook.ipynb".into(),

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -97,43 +97,75 @@ pub enum Handshake {
     ///
     /// The daemon returns `NotebookConnectionInfo` before starting sync.
     /// After that, the connection becomes a normal notebook sync connection.
-    CreateNotebook {
-        /// Runtime type: "python" or "deno".
-        runtime: String,
-        /// Working directory for project file detection (pyproject.toml, pixi.toml, environment.yml).
-        /// Used since untitled notebooks have no path to derive working_dir from.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        working_dir: Option<String>,
-        /// Optional notebook_id hint for restoring an untitled notebook from a previous session.
-        /// If provided and the daemon has a persisted Automerge doc for this ID, the room is
-        /// reused instead of creating a fresh empty notebook. If the persisted doc doesn't exist,
-        /// a new notebook is created and this ID is used as the notebook_id/env_id.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        notebook_id: Option<String>,
-        /// When true, the notebook exists only in memory — no .automerge persisted to disk.
-        /// Defaults to false (backward compat). MCP agents use true for scratch compute.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        ephemeral: Option<bool>,
-        /// Package manager preference: uv, conda, or pixi.
-        /// When set, the daemon creates only this manager's metadata section.
-        /// When None, the daemon uses its default_python_env setting.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        package_manager: Option<PackageManager>,
-        /// Environment inheritance mode: auto, project, or notebook.
-        /// Defaults to auto.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        environment_mode: Option<CreateNotebookEnvironmentMode>,
-        /// Dependencies to seed into notebook metadata before auto-launch.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        dependencies: Vec<String>,
-        /// When true, the daemon sends `NotebookConnectionInfo` as a typed
-        /// SessionControl frame instead of a standalone untyped JSON frame.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        typed_bootstrap: Option<bool>,
-        /// Self-declared operator suffix for the authenticated actor label.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        operator: Option<String>,
-    },
+    ///
+    /// The newtype body serializes flattened next to the `channel` tag, so
+    /// the wire shape is identical to inline variant fields.
+    CreateNotebook(CreateNotebookRequest),
+}
+
+/// Request body of the `CreateNotebook` handshake.
+///
+/// [`CreateNotebookRequest::new`] covers the common case: a non-ephemeral
+/// notebook with no seeded dependencies, a daemon-chosen notebook id, the
+/// daemon's default package manager, and auto environment mode.
+///
+/// Field order is the wire serialization order; keep it stable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateNotebookRequest {
+    /// Runtime type: "python" or "deno".
+    pub runtime: String,
+    /// Working directory for project file detection (pyproject.toml, pixi.toml, environment.yml).
+    /// Used since untitled notebooks have no path to derive working_dir from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+    /// Optional notebook_id hint for restoring an untitled notebook from a previous session.
+    /// If provided and the daemon has a persisted Automerge doc for this ID, the room is
+    /// reused instead of creating a fresh empty notebook. If the persisted doc doesn't exist,
+    /// a new notebook is created and this ID is used as the notebook_id/env_id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notebook_id: Option<String>,
+    /// When true, the notebook exists only in memory; no .automerge is persisted to disk.
+    /// Defaults to false (backward compat). MCP agents use true for scratch compute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ephemeral: Option<bool>,
+    /// Package manager preference: uv, conda, or pixi.
+    /// When set, the daemon creates only this manager's metadata section.
+    /// When None, the daemon uses its default_python_env setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_manager: Option<PackageManager>,
+    /// Environment inheritance mode: auto, project, or notebook.
+    /// Defaults to auto.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_mode: Option<CreateNotebookEnvironmentMode>,
+    /// Dependencies to seed into notebook metadata before auto-launch.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<String>,
+    /// When true, the daemon sends `NotebookConnectionInfo` as a typed
+    /// SessionControl frame instead of a standalone untyped JSON frame.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub typed_bootstrap: Option<bool>,
+    /// Self-declared operator suffix for the authenticated actor label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator: Option<String>,
+}
+
+impl CreateNotebookRequest {
+    /// Request for `runtime` with every optional field unset: non-ephemeral,
+    /// no seeded dependencies, daemon-chosen notebook id, daemon-default
+    /// package manager, auto environment mode.
+    pub fn new(runtime: impl Into<String>) -> Self {
+        Self {
+            runtime: runtime.into(),
+            working_dir: None,
+            notebook_id: None,
+            ephemeral: None,
+            package_manager: None,
+            environment_mode: None,
+            dependencies: Vec::new(),
+            typed_bootstrap: None,
+            operator: None,
+        }
+    }
 }
 
 pub const PROTOCOL_V4: &str = "v4";

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -25,8 +25,9 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
 
 use notebook_protocol::connection::{
-    self, ConnectionBootstrap, FrameSink, FrameSource, Handshake, NotebookConnectionInfo,
-    ProtocolCapabilities, PROTOCOL_V4,
+    self, ConnectionBootstrap, CreateNotebookEnvironmentMode, CreateNotebookRequest, FrameSink,
+    FrameSource, Handshake, NotebookConnectionInfo, PackageManager, ProtocolCapabilities,
+    PROTOCOL_V4,
 };
 use notebook_protocol::protocol::NotebookBroadcast;
 
@@ -91,6 +92,85 @@ pub struct RelayCreateResult {
 
     /// Connection info from the daemon (notebook_id, trust status, etc).
     pub info: NotebookConnectionInfo,
+}
+
+/// What to create when connecting via the `CreateNotebook` handshake.
+///
+/// [`CreateNotebookSpec::new`] describes the common case: a non-ephemeral
+/// notebook with no seeded dependencies, a daemon-chosen notebook id, the
+/// daemon's default package manager, auto environment mode, and an anonymous
+/// actor. Override individual fields (struct update syntax reads well) for
+/// the exceptions. The spec converts into the wire
+/// [`CreateNotebookRequest`] in one place; `typed_bootstrap` and the wire
+/// `operator` are owned by the connect functions, not by callers.
+#[derive(Debug, Clone)]
+pub struct CreateNotebookSpec {
+    /// Runtime type, e.g. "python" or "deno".
+    pub runtime: String,
+
+    /// Working directory for project file detection (pyproject.toml,
+    /// pixi.toml, environment.yml). Untitled notebooks have no path to
+    /// derive it from.
+    pub working_dir: Option<PathBuf>,
+
+    /// Notebook id hint for restoring an untitled notebook from a previous
+    /// session. `None` lets the daemon generate a fresh UUID.
+    pub notebook_id: Option<String>,
+
+    /// Actor label for this peer (e.g. `"local:kyle/desktop:window"`).
+    /// The wire `operator` suffix is derived from it: the text after the
+    /// first `/`, or the whole label when it contains none, so a bare
+    /// operator string passes through unchanged. [`connect_create`] also
+    /// uses it as the local Automerge actor until the daemon returns the
+    /// assembled authenticated label. Empty means anonymous.
+    pub actor_label: String,
+
+    /// When true the room lives only in memory; no .automerge is persisted
+    /// to disk. MCP agents use this for scratch compute.
+    pub ephemeral: bool,
+
+    /// Package manager preference. `None` uses the daemon's
+    /// default_python_env setting.
+    pub package_manager: Option<PackageManager>,
+
+    /// Dependencies seeded into notebook metadata before kernel auto-launch.
+    pub dependencies: Vec<String>,
+
+    /// Environment inheritance mode. `None` lets the daemon default to auto.
+    pub environment_mode: Option<CreateNotebookEnvironmentMode>,
+}
+
+impl CreateNotebookSpec {
+    /// Spec for `runtime` with every other field at its default (see the
+    /// type-level docs for what the defaults mean).
+    pub fn new(runtime: impl Into<String>) -> Self {
+        Self {
+            runtime: runtime.into(),
+            working_dir: None,
+            notebook_id: None,
+            actor_label: String::new(),
+            ephemeral: false,
+            package_manager: None,
+            dependencies: Vec::new(),
+            environment_mode: None,
+        }
+    }
+
+    /// Wire request for the `CreateNotebook` handshake. Always requests a
+    /// typed bootstrap; the operator suffix comes from `actor_label`.
+    fn into_request(self) -> CreateNotebookRequest {
+        CreateNotebookRequest {
+            runtime: self.runtime,
+            working_dir: self.working_dir.map(|p| p.to_string_lossy().to_string()),
+            notebook_id: self.notebook_id,
+            ephemeral: if self.ephemeral { Some(true) } else { None },
+            package_manager: self.package_manager,
+            environment_mode: self.environment_mode,
+            dependencies: self.dependencies,
+            typed_bootstrap: Some(true),
+            operator: operator_from_actor_label(&self.actor_label),
+        }
+    }
 }
 
 /// Platform-specific helper macro to connect to the daemon socket.
@@ -335,70 +415,16 @@ pub async fn connect_open_hosted(
         })
 }
 
-/// Connect and create a new notebook.
+/// Connect and create a new notebook described by `spec`.
 ///
 /// The daemon creates an empty notebook room with one code cell and
 /// returns connection info with a generated UUID as the notebook_id.
-#[allow(clippy::too_many_arguments)]
 pub async fn connect_create(
     socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    actor_label: &str,
-    ephemeral: bool,
-    package_manager: Option<notebook_protocol::connection::PackageManager>,
-    dependencies: Vec<String>,
+    spec: CreateNotebookSpec,
 ) -> Result<CreateResult, SyncError> {
-    connect_create_with_environment_mode(
-        socket_path,
-        runtime,
-        working_dir,
-        actor_label,
-        ephemeral,
-        package_manager,
-        dependencies,
-        None,
-    )
-    .await
-}
+    let actor_label = spec.actor_label.clone();
 
-#[allow(clippy::too_many_arguments)]
-pub async fn connect_create_with_environment_mode(
-    socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    actor_label: &str,
-    ephemeral: bool,
-    package_manager: Option<notebook_protocol::connection::PackageManager>,
-    dependencies: Vec<String>,
-    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
-) -> Result<CreateResult, SyncError> {
-    connect_create_inner(
-        socket_path,
-        runtime,
-        working_dir,
-        None,
-        actor_label,
-        ephemeral,
-        package_manager,
-        dependencies,
-        environment_mode,
-    )
-    .await
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn connect_create_inner(
-    socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    notebook_id: Option<String>,
-    actor_label: &str,
-    ephemeral: bool,
-    package_manager: Option<notebook_protocol::connection::PackageManager>,
-    dependencies: Vec<String>,
-    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
-) -> Result<CreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -408,19 +434,7 @@ async fn connect_create_inner(
     connection::send_preamble(&mut writer).await?;
 
     // Send create handshake
-    let handshake = Handshake::CreateNotebook {
-        runtime: runtime.to_string(),
-        working_dir: working_dir
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string()),
-        notebook_id,
-        ephemeral: if ephemeral { Some(true) } else { None },
-        package_manager,
-        environment_mode,
-        dependencies,
-        typed_bootstrap: Some(true),
-        operator: operator_from_actor_label(actor_label),
-    };
+    let handshake = Handshake::CreateNotebook(spec.into_request());
     connection::send_json_frame(&mut writer, &handshake)
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
@@ -441,7 +455,7 @@ async fn connect_create_inner(
         info.capabilities
             .actor_label
             .as_deref()
-            .unwrap_or(actor_label),
+            .unwrap_or(&actor_label),
     );
     let doc = bootstrap.into_inner();
     let peer_state = sync::State::new();
@@ -731,47 +745,13 @@ pub async fn connect_open_hosted_relay_with_operator(
 /// Create a notebook as a relay — transparent byte pipe, no local document.
 ///
 /// Same as `connect_open_relay` but for new notebooks. Performs the
-/// CreateNotebook handshake, then immediately starts piping.
-#[allow(clippy::too_many_arguments)]
+/// CreateNotebook handshake, then immediately starts piping. The relay has
+/// no local document, so only the operator derived from `spec.actor_label`
+/// matters for identity; the frontend WASM peer owns the sync protocol.
 pub async fn connect_create_relay(
     socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    notebook_id: Option<String>,
+    spec: CreateNotebookSpec,
     frame_tx: mpsc::UnboundedSender<Vec<u8>>,
-    ephemeral: bool,
-    package_manager: Option<notebook_protocol::connection::PackageManager>,
-    dependencies: Vec<String>,
-    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
-) -> Result<RelayCreateResult, SyncError> {
-    connect_create_relay_with_operator(
-        socket_path,
-        runtime,
-        working_dir,
-        notebook_id,
-        frame_tx,
-        ephemeral,
-        package_manager,
-        dependencies,
-        environment_mode,
-        None,
-    )
-    .await
-}
-
-/// Create a notebook as a relay with a self-declared operator label.
-#[allow(clippy::too_many_arguments)]
-pub async fn connect_create_relay_with_operator(
-    socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    notebook_id: Option<String>,
-    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
-    ephemeral: bool,
-    package_manager: Option<notebook_protocol::connection::PackageManager>,
-    dependencies: Vec<String>,
-    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
-    operator: Option<String>,
 ) -> Result<RelayCreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -782,19 +762,7 @@ pub async fn connect_create_relay_with_operator(
     connection::send_preamble(&mut writer).await?;
 
     // Send create handshake
-    let handshake = Handshake::CreateNotebook {
-        runtime: runtime.to_string(),
-        working_dir: working_dir
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string()),
-        notebook_id,
-        ephemeral: if ephemeral { Some(true) } else { None },
-        package_manager,
-        environment_mode,
-        dependencies,
-        typed_bootstrap: Some(true),
-        operator,
-    };
+    let handshake = Handshake::CreateNotebook(spec.into_request());
     connection::send_json_frame(&mut writer, &handshake)
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -826,18 +826,18 @@ async fn initialize_notebook_sync_create(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
+    // A bare operator label (no '/') rides the spec's actor_label field and
+    // reaches the wire as the operator suffix unchanged.
     let operator = desktop_operator_label();
-    let result = notebook_sync::connect::connect_create_relay_with_operator(
+    let result = notebook_sync::connect::connect_create_relay(
         socket_path,
-        &runtime,
-        working_dir,
-        notebook_id_hint,
+        notebook_sync::connect::CreateNotebookSpec {
+            working_dir,
+            notebook_id: notebook_id_hint,
+            actor_label: operator,
+            ..notebook_sync::connect::CreateNotebookSpec::new(runtime.as_str())
+        },
         frame_tx,
-        false,
-        None,
-        vec![],
-        None,
-        Some(operator),
     )
     .await
     .map_err(|e| format!("sync connect (create): {}", e))?;

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -1434,15 +1434,17 @@ pub async fn create_notebook(
     let prev = previous_notebook_id(server).await;
 
     let outcome = async {
-        match notebook_sync::connect::connect_create_with_environment_mode(
+        match notebook_sync::connect::connect_create(
             server.socket_path.clone(),
-            runtime,
-            working_dir,
-            &server.get_peer_label().await,
-            ephemeral,
-            explicit_pkg_manager.clone(),
-            deps.clone(),
-            environment_mode,
+            notebook_sync::connect::CreateNotebookSpec {
+                working_dir,
+                actor_label: server.get_peer_label().await,
+                ephemeral,
+                package_manager: explicit_pkg_manager.clone(),
+                dependencies: deps.clone(),
+                environment_mode,
+                ..notebook_sync::connect::CreateNotebookSpec::new(runtime)
+            },
         )
         .await
         {

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -1255,15 +1255,16 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
     let package_manager = opts.package_manager.map(Into::into);
     let environment_mode = opts.environment_mode.map(Into::into);
 
-    let result = notebook_sync::connect::connect_create_with_environment_mode(
+    let result = notebook_sync::connect::connect_create(
         socket_path.clone(),
-        &runtime,
-        working_dir.clone(),
-        &actor_label,
-        /* ephemeral */ false,
-        package_manager,
-        dependencies,
-        environment_mode,
+        notebook_sync::connect::CreateNotebookSpec {
+            working_dir: working_dir.clone(),
+            actor_label: actor_label.clone(),
+            package_manager,
+            dependencies,
+            environment_mode,
+            ..notebook_sync::connect::CreateNotebookSpec::new(runtime.as_str())
+        },
     )
     .await
     .map_err(to_napi_err)?;

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -160,15 +160,20 @@ impl AsyncSession {
         environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
     ) -> PyResult<Self> {
         let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
-        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+        let actor_label = peer_label
+            .as_deref()
+            .map(session_core::make_actor_label)
+            .unwrap_or_default();
         let (notebook_id, mut state, _info) = session_core::connect_create(
             socket_path,
-            &runtime,
-            working_dir,
-            actor_label.as_deref(),
-            package_manager,
-            dependencies,
-            environment_mode,
+            notebook_sync::connect::CreateNotebookSpec {
+                working_dir,
+                actor_label,
+                package_manager,
+                dependencies,
+                environment_mode,
+                ..notebook_sync::connect::CreateNotebookSpec::new(runtime)
+            },
         )
         .await?;
         state.peer_label = peer_label.clone();

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -479,38 +479,25 @@ pub(crate) async fn connect_open(
     Ok((notebook_id, state, connection_info))
 }
 
-/// Connect and create a new notebook.
+/// Connect and create the notebook described by `spec`.
+///
+/// An empty `spec.actor_label` is replaced with the default label so the
+/// daemon always sees an operator for Python sessions.
 ///
 /// Returns (notebook_id, populated SessionState, NotebookConnectionInfo).
 pub(crate) async fn connect_create(
     socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    actor_label: Option<&str>,
-    package_manager: Option<notebook_protocol::connection::PackageManager>,
-    dependencies: Vec<String>,
-    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
+    mut spec: notebook_sync::connect::CreateNotebookSpec,
 ) -> PyResult<(String, SessionState, NotebookConnectionInfo)> {
-    let default_label;
-    let label = match actor_label {
-        Some(l) => l,
-        None => {
-            default_label = make_actor_label(DEFAULT_ACTOR_LABEL);
-            &default_label
-        }
-    };
-    let result = notebook_sync::connect::connect_create_with_environment_mode(
-        socket_path.clone(),
-        runtime,
-        working_dir.clone(),
-        label,
-        false,
-        package_manager,
-        dependencies,
-        environment_mode,
-    )
-    .await
-    .map_err(to_py_err)?;
+    if spec.actor_label.is_empty() {
+        spec.actor_label = make_actor_label(DEFAULT_ACTOR_LABEL);
+    }
+    let runtime = spec.runtime.clone();
+    let working_dir = spec.working_dir.clone();
+    let actor_label = spec.actor_label.clone();
+    let result = notebook_sync::connect::connect_create(socket_path.clone(), spec)
+        .await
+        .map_err(to_py_err)?;
     result
         .handle
         .await_session_ready()
@@ -530,14 +517,14 @@ pub(crate) async fn connect_create(
         kernel_started: false,
         kernel_type: None,
         env_source: None,
-        runtime: runtime.to_string(),
+        runtime: runtime.clone(),
         blob_base_url,
         blob_store_path,
         connection_info: Some(connection_info.clone()),
         notebook_path: working_dir.map(|p| p.to_string_lossy().to_string()),
         settings,
         peer_label: None, // Set by caller (Session/AsyncSession)
-        actor_label: actor_label.map(String::from),
+        actor_label: Some(actor_label),
     };
 
     hydrate_kernel_state(&mut state);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3030,31 +3030,9 @@ impl Daemon {
                 )
                 .await
             }
-            Handshake::CreateNotebook {
-                runtime,
-                working_dir,
-                notebook_id,
-                ephemeral,
-                package_manager,
-                environment_mode,
-                dependencies,
-                typed_bootstrap,
-                operator,
-            } => {
-                self.handle_create_notebook(
-                    stream,
-                    runtime,
-                    working_dir,
-                    notebook_id,
-                    ephemeral,
-                    package_manager,
-                    environment_mode,
-                    dependencies,
-                    typed_bootstrap.unwrap_or(false),
-                    operator,
-                    client_protocol_version,
-                )
-                .await
+            Handshake::CreateNotebook(request) => {
+                self.handle_create_notebook(stream, request, client_protocol_version)
+                    .await
             }
             Handshake::RuntimeAgent {
                 notebook_id,
@@ -3542,20 +3520,16 @@ impl Daemon {
                     }
                 }
                 let settings = self.settings.read().await.get_all();
-                return self
-                    .handle_create_notebook(
-                        stream,
+                let request = notebook_protocol::connection::CreateNotebookRequest {
+                    working_dir: Some(dir_path),
+                    typed_bootstrap: Some(typed_bootstrap),
+                    operator,
+                    ..notebook_protocol::connection::CreateNotebookRequest::new(
                         settings.default_runtime.to_string(),
-                        Some(dir_path),
-                        None,
-                        None,
-                        None,
-                        None,
-                        vec![],
-                        typed_bootstrap,
-                        operator,
-                        client_protocol_version,
                     )
+                };
+                return self
+                    .handle_create_notebook(stream, request, client_protocol_version)
                     .await;
             }
             Ok(_) => true,
@@ -3901,22 +3875,14 @@ impl Daemon {
 
     /// Handle a CreateNotebook connection.
     ///
+    /// Takes the parsed wire request from the `CreateNotebook` handshake.
     /// Daemon creates a room, seeds fresh notebooks with default metadata and
     /// one starter cell, and generates env_id as notebook_id.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
-    #[allow(clippy::too_many_arguments)]
     async fn handle_create_notebook<S>(
         self: Arc<Self>,
         stream: S,
-        runtime: String,
-        working_dir: Option<String>,
-        notebook_id_hint: Option<String>,
-        ephemeral: Option<bool>,
-        package_manager: Option<notebook_protocol::connection::PackageManager>,
-        environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
-        dependencies: Vec<String>,
-        typed_bootstrap: bool,
-        operator: Option<String>,
+        request: notebook_protocol::connection::CreateNotebookRequest,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
     where
@@ -3924,8 +3890,21 @@ impl Daemon {
     {
         use notebook_protocol::connection::{
             send_json_frame, send_typed_bootstrap_frame, ConnectionBootstrap,
-            NotebookConnectionInfo, ProtocolCapabilities,
+            CreateNotebookRequest, NotebookConnectionInfo, ProtocolCapabilities,
         };
+
+        let CreateNotebookRequest {
+            runtime,
+            working_dir,
+            notebook_id: notebook_id_hint,
+            ephemeral,
+            package_manager,
+            environment_mode,
+            dependencies,
+            typed_bootstrap,
+            operator,
+        } = request;
+        let typed_bootstrap = typed_bootstrap.unwrap_or(false);
 
         info!(
             "[runtimed] CreateNotebook requested (runtime={}, working_dir={:?}, notebook_id_hint={:?}, environment_mode={})",

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -22,6 +22,16 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 
+/// Spec for creating a "python" notebook as `actor_label`, with every other
+/// field at its default: non-ephemeral, no deps, daemon-chosen notebook id.
+/// Tests override individual fields with struct update syntax.
+fn create_spec(actor_label: &str) -> connect::CreateNotebookSpec {
+    connect::CreateNotebookSpec {
+        actor_label: actor_label.to_string(),
+        ..connect::CreateNotebookSpec::new("python")
+    }
+}
+
 /// Write a test .ipynb notebook file with the given cells.
 /// Each cell is a tuple of (id, cell_type, source, outputs_json_strings).
 fn write_test_ipynb(path: &std::path::Path, cells: &[(&str, &str, &str, Vec<&str>)]) {
@@ -740,12 +750,10 @@ async fn test_local_identity_handshake_and_presence_rewrite() {
 
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "agent:codex:s1",
-        true,
-        None,
-        vec![],
+        connect::CreateNotebookSpec {
+            ephemeral: true,
+            ..create_spec("agent:codex:s1")
+        },
     )
     .await
     .expect("client should connect");
@@ -859,12 +867,10 @@ async fn test_local_identity_rejects_foreign_automerge_actor() {
 
     let owner = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "desktop:owner",
-        true,
-        None,
-        vec![],
+        connect::CreateNotebookSpec {
+            ephemeral: true,
+            ..create_spec("desktop:owner")
+        },
     )
     .await
     .expect("owner should connect");
@@ -926,17 +932,9 @@ async fn test_notebook_sync_via_unified_socket() {
     assert!(wait_for_daemon(&pool_client).await);
 
     // Create first notebook via connect_create — should get daemon starter cell
-    let result1 = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .expect("client1 should connect");
+    let result1 = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .expect("client1 should connect");
     assert_eq!(
         result1.info.cell_count, 1,
         "CreateNotebook handshake should report the daemon starter cell"
@@ -990,17 +988,9 @@ async fn test_notebook_sync_via_unified_socket() {
     );
 
     // Create a different notebook — should be independent
-    let result3 = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .expect("client3 should connect");
+    let result3 = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .expect("client3 should connect");
     assert_eq!(
         result3.info.cell_count, 1,
         "second CreateNotebook handshake should report its own daemon starter cell"
@@ -1044,17 +1034,9 @@ async fn test_notebook_sync_cross_window_propagation() {
     assert!(wait_for_daemon(&pool_client).await);
 
     // First client creates a notebook; second client joins it
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .unwrap();
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .unwrap();
     let notebook_id = result.info.notebook_id.clone();
     let client1 = result.handle;
     let client2 = connect::connect(socket_path.clone(), notebook_id, "test")
@@ -1117,17 +1099,9 @@ async fn test_parallel_cell_mutations_same_session_no_disconnect() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .unwrap();
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .unwrap();
     let notebook_id = result.info.notebook_id.clone();
     let handle = result.handle;
 
@@ -1205,17 +1179,9 @@ async fn test_untrusted_launch_and_sync_environment_are_daemon_rejected() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .unwrap();
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .unwrap();
     let handle = result.handle;
 
     assert!(
@@ -1288,15 +1254,13 @@ async fn test_launch_kernel_environment_mode_controls_project_priority() {
         let project_dir = project_dir.clone();
         let notebook_path = notebook_path.clone();
         async move {
-            let result = connect::connect_create_with_environment_mode(
+            let result = connect::connect_create(
                 socket_path,
-                "python",
-                Some(project_dir),
-                label,
-                false,
-                None,
-                vec![],
-                Some(mode),
+                connect::CreateNotebookSpec {
+                    working_dir: Some(project_dir),
+                    environment_mode: Some(mode),
+                    ..create_spec(label)
+                },
             )
             .await
             .unwrap();
@@ -1367,12 +1331,11 @@ async fn test_sync_environment_guard_rejects_stale_observed_dependencies() {
 
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        Some(notebook_protocol::connection::PackageManager::Uv),
-        vec!["pandas".to_string()],
+        connect::CreateNotebookSpec {
+            package_manager: Some(notebook_protocol::connection::PackageManager::Uv),
+            dependencies: vec!["pandas".to_string()],
+            ..create_spec("test")
+        },
     )
     .await
     .unwrap();
@@ -1425,12 +1388,11 @@ async fn test_approve_trust_guard_rejects_stale_observed_dependencies() {
 
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        Some(notebook_protocol::connection::PackageManager::Uv),
-        vec!["pandas".to_string()],
+        connect::CreateNotebookSpec {
+            package_manager: Some(notebook_protocol::connection::PackageManager::Uv),
+            dependencies: vec!["pandas".to_string()],
+            ..create_spec("test")
+        },
     )
     .await
     .unwrap();
@@ -1481,17 +1443,9 @@ async fn test_sync_environment_no_deps_reaches_existing_no_kernel_path() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .unwrap();
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .unwrap();
     let handle = result.handle;
 
     assert!(
@@ -1532,17 +1486,9 @@ async fn test_parallel_daemon_requests_same_session_no_disconnect() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .unwrap();
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .unwrap();
     let handle = result.handle;
 
     assert!(
@@ -1604,17 +1550,9 @@ async fn test_untitled_notebook_persists_through_eviction() {
     // Phase 1: Two clients connect, add cells, then both disconnect
     let notebook_id;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client1 = result.handle;
         let _client2 = connect::connect(socket_path.clone(), notebook_id.clone(), "test")
@@ -1744,17 +1682,9 @@ async fn test_eviction_flushes_before_reconnect() {
     // the `.automerge` debouncer is the only thing keeping content durable.
     let notebook_id;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
 
@@ -1840,17 +1770,9 @@ async fn test_kernel_teardown_keeps_room_resident() {
     // trigger the kernel-teardown task.
     let notebook_id;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
 
@@ -1973,17 +1895,9 @@ async fn test_ghost_reaper_removes_after_ttl() {
 
     let notebook_id;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
@@ -2078,17 +1992,9 @@ async fn test_ghost_reaper_skips_reconnected_room() {
 
     let notebook_id;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
@@ -2167,17 +2073,9 @@ async fn test_peer_reconnect_bumps_generation() {
     let notebook_id;
     let gen_before_disconnect;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
@@ -2247,17 +2145,9 @@ async fn test_resident_room_reaper_lru_cap_evicts_oldest() {
     // creation order (oldest first).
     let mut notebook_ids: Vec<String> = Vec::new();
     for tag in ["a", "b", "c"] {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            tag,
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec(tag))
+            .await
+            .unwrap();
         let notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
@@ -2368,17 +2258,9 @@ async fn test_resident_room_reaper_lru_cap_exempts_active() {
     let mut clients = Vec::new();
     let mut notebook_ids = Vec::new();
     for tag in ["a", "b", "c"] {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            tag,
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec(tag))
+            .await
+            .unwrap();
         notebook_ids.push(result.info.notebook_id.clone());
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
@@ -2444,17 +2326,9 @@ async fn test_resident_room_reaper_skips_reserved_room() {
 
     let notebook_id;
     {
-        let result = connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![],
-        )
-        .await
-        .unwrap();
+        let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+            .await
+            .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
@@ -2541,17 +2415,9 @@ async fn test_notebook_cell_delete_propagation() {
     assert!(wait_for_daemon(&pool_client).await);
 
     // Client1 creates a notebook with three cells
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .unwrap();
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .unwrap();
     let notebook_id = result.info.notebook_id.clone();
     let client1 = result.handle;
 
@@ -2652,33 +2518,9 @@ async fn test_multiple_notebooks_concurrent_isolation() {
 
     // Create three notebooks concurrently via connect_create
     let (nb_a, nb_b, nb_c) = tokio::join!(
-        connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![]
-        ),
-        connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![]
-        ),
-        connect::connect_create(
-            socket_path.clone(),
-            "python",
-            None,
-            "test",
-            false,
-            None,
-            vec![]
-        ),
+        connect::connect_create(socket_path.clone(), create_spec("test"),),
+        connect::connect_create(socket_path.clone(), create_spec("test"),),
+        connect::connect_create(socket_path.clone(), create_spec("test"),),
     );
     let nb_a = nb_a.unwrap();
     let nb_b = nb_b.unwrap();
@@ -3218,20 +3060,10 @@ async fn test_uuid_joiner_receives_frontend_authored_relay_cells() {
     assert!(wait_for_daemon(&pool_client).await);
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-    let relay = connect::connect_create_relay_with_operator(
-        socket_path.clone(),
-        "python",
-        None,
-        None,
-        frame_tx,
-        false,
-        None,
-        vec![],
-        None,
-        Some("desktop".to_string()),
-    )
-    .await
-    .expect("desktop relay create should connect");
+    let relay =
+        connect::connect_create_relay(socket_path.clone(), create_spec("desktop"), frame_tx)
+            .await
+            .expect("desktop relay create should connect");
     let notebook_id = relay.info.notebook_id.clone();
     let relay_handle = relay.handle;
 
@@ -3424,12 +3256,10 @@ async fn seed_pipe_room(
 ) -> (notebook_sync::connect::CreateResult, String) {
     let seed = connect::connect_create(
         socket_path.to_path_buf(),
-        "python",
-        None,
-        "test:seed",
-        true,
-        None,
-        vec![],
+        connect::CreateNotebookSpec {
+            ephemeral: true,
+            ..create_spec("test:seed")
+        },
     )
     .await
     .expect("seed room create should succeed");
@@ -4072,12 +3902,11 @@ async fn test_create_notebook_with_deps() {
     // Create notebook with conda + two deps
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        Some(notebook_protocol::connection::PackageManager::Conda),
-        vec!["pandas".to_string(), "numpy".to_string()],
+        connect::CreateNotebookSpec {
+            package_manager: Some(notebook_protocol::connection::PackageManager::Conda),
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            ..create_spec("test")
+        },
     )
     .await
     .expect("should create notebook with deps");
@@ -4140,12 +3969,10 @@ async fn test_create_notebook_with_explicit_manager_no_deps() {
     // Create notebook with pixi manager, no deps
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        Some(notebook_protocol::connection::PackageManager::Pixi),
-        vec![],
+        connect::CreateNotebookSpec {
+            package_manager: Some(notebook_protocol::connection::PackageManager::Pixi),
+            ..create_spec("test")
+        },
     )
     .await
     .expect("should create notebook with pixi manager");
@@ -4211,12 +4038,10 @@ async fn test_create_notebook_default_manager_with_deps() {
     // Create notebook with deps but no explicit package manager
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec!["requests".to_string()],
+        connect::CreateNotebookSpec {
+            dependencies: vec!["requests".to_string()],
+            ..create_spec("test")
+        },
     )
     .await
     .expect("should create notebook with default manager + deps");
@@ -4280,12 +4105,10 @@ async fn test_create_notebook_with_deps_reports_no_trust_approval_needed() {
 
     let result = connect::connect_create(
         socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec!["scipy".to_string()],
+        connect::CreateNotebookSpec {
+            dependencies: vec!["scipy".to_string()],
+            ..create_spec("test")
+        },
     )
     .await
     .expect("create with explicit deps should succeed");
@@ -4318,17 +4141,9 @@ async fn test_create_notebook_with_no_deps_reports_no_trust_approval_needed() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "test",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .expect("create with no deps should succeed");
+    let result = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .expect("create with no deps should succeed");
 
     assert!(
         !result.info.needs_trust_approval,
@@ -4362,17 +4177,9 @@ async fn test_auto_heartbeat_keeps_idle_peer_connected() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    let result = connect::connect_create(
-        socket_path.clone(),
-        "python",
-        None,
-        "heartbeat-peer",
-        false,
-        None,
-        vec![],
-    )
-    .await
-    .expect("client should connect");
+    let result = connect::connect_create(socket_path.clone(), create_spec("heartbeat-peer"))
+        .await
+        .expect("client should connect");
     let client = result.handle;
     assert_session_ready(&client, "heartbeat client").await;
 


### PR DESCRIPTION
One spec type, one create path per transport, wire format unchanged.

CreateNotebookSpec (notebook-sync) is the client face of the recurring create blob: runtime, working_dir, notebook_id hint, actor_label, ephemeral, package_manager, dependencies, environment_mode. Its default is the common case: non-ephemeral, no deps, daemon-chosen id, daemon-default package manager, auto environment mode, anonymous actor. The spec converts into the wire request in one place; the connect functions own typed_bootstrap and derive the wire operator from actor_label.

CreateNotebookRequest (notebook-protocol) is the CreateNotebook handshake body, extracted from inline enum-variant fields into a named struct. The internally tagged serde representation flattens the newtype body next to the channel tag, so the JSON on the socket is byte identical; the pinned serialization tests prove it, and a new test pins deserialization of the minimal legacy shape.

connect_create(socket_path, spec) and connect_create_relay(socket_path, spec, frame_tx) replace the five-function ladder (connect_create, connect_create_with_environment_mode, connect_create_inner, connect_create_relay, connect_create_relay_with_operator). The daemon's handle_create_notebook takes the parsed CreateNotebookRequest instead of twelve positional args. Every caller builds the spec at the edge: runt-mcp, runtimed-node, runtimed-py (Python kwargs unchanged; the spec is built internally), the desktop relay path, and the integration tests. Every #[allow(clippy::too_many_arguments)] in the create family is gone; the PyO3 create_notebook keeps its allow because Python keyword arguments are public API.

