### PR TITLE
feat(runt-mcp): audience annotations and rich-output legibility for the agent channel

### DIFF
--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -2,11 +2,34 @@
 //!
 //! Converts notebook outputs to text for LLM consumption, with ANSI stripping
 //! and MIME type priority. Matches the Python MCP server's formatting behavior.
+//!
+//! # Two channels, two audiences
+//!
+//! MCP tool results serve two audiences. Content blocks are the AGENT channel:
+//! minimal tokens, maximal contextual understanding, navigable (pointers to
+//! fetch more). `structuredContent` is the HUMAN RENDER contract consumed by
+//! the MCP App renderer: complete and URL-rich, never token-optimized.
+//! Everything in this module shapes the agent channel; the human contract
+//! lives in `crate::structured`.
 
 use regex::Regex;
 use std::sync::LazyLock;
 
+use rmcp::model::{Content, Role};
+use runtimed_outputs::output_resolver::{content_ref_meta, CONTENT_PRIORITY};
 use runtimed_outputs::resolved_output::{DataValue, Output};
+
+/// Build a text `Content` block annotated `audience: [assistant]`.
+///
+/// Content blocks are the agent channel: minimal tokens, maximal contextual
+/// understanding, navigable pointers to fetch more. `structuredContent` is the
+/// human render contract (MCP App renderer): complete and URL-rich, never
+/// token-optimized. Annotating agent-channel text with the assistant audience
+/// lets renderers drop it from human views without guessing. Resource-link
+/// content items stay unannotated — both audiences navigate by them.
+pub fn assistant_text(text: impl Into<String>) -> Content {
+    Content::text(text.into()).with_audience(vec![Role::Assistant])
+}
 
 /// ANSI escape code regex — matches color codes, cursor movement, OSC sequences.
 #[allow(clippy::expect_used)] // Static regex, always valid
@@ -118,6 +141,8 @@ pub fn format_outputs_text(outputs: &[Output]) -> String {
 /// This gives MCP clients richer structure than a single concatenated string.
 /// When outputs exist but have no text representation, appends a summary
 /// so agents know execution produced output they can't see.
+///
+/// All text items are agent-channel content, annotated `audience: [assistant]`.
 pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<rmcp::model::Content> {
     let mut items: Vec<rmcp::model::Content> = Vec::new();
     let mut omitted_count = 0usize;
@@ -125,7 +150,7 @@ pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<rmcp::model::Content>
 
     for output in outputs {
         if let Some(text) = format_output_text(output) {
-            items.push(rmcp::model::Content::text(text));
+            items.push(assistant_text(text));
         } else if output.output_type == "display_data" || output.output_type == "execute_result" {
             omitted_count += 1;
             if let Some(data) = &output.data {
@@ -147,7 +172,7 @@ pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<rmcp::model::Content>
         } else {
             format!(" ({})", omitted_mimes.join("; "))
         };
-        items.push(rmcp::model::Content::text(format!(
+        items.push(assistant_text(format!(
             "[{omitted_count} output(s) with non-text content{detail} — visible in the notebook UI]"
         )));
     }
@@ -167,6 +192,110 @@ pub fn format_outputs_summary_lines(outputs: &[Output], preview_chars: usize) ->
         .enumerate()
         .map(|(index, output)| format_output_summary_line(index, output, preview_chars))
         .collect()
+}
+
+/// Format summary lines from manifest-aligned resolved outputs.
+///
+/// Emits the same lines as [`format_outputs_summary_lines`], plus at most one
+/// [`rich_blob_note`] legibility line per output when its manifest carries
+/// blob-stored rich MIMEs. `resolved_by_manifest` and `manifests` are the
+/// parallel slices produced by `resolve_cell_outputs_for_llm_aligned`;
+/// unresolved manifests (`None`) get no summary line, so `out[index]`
+/// numbering matches the flattened output list used for content items.
+pub fn format_outputs_summary_lines_aligned(
+    resolved_by_manifest: &[Option<Output>],
+    manifests: &[serde_json::Value],
+    preview_chars: usize,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut index = 0usize;
+    for (resolved, manifest) in resolved_by_manifest.iter().zip(manifests) {
+        let Some(output) = resolved else { continue };
+        lines.push(format_output_summary_line(index, output, preview_chars));
+        if let Some(note) = rich_blob_note(manifest) {
+            lines.push(note);
+        }
+        index += 1;
+    }
+    lines
+}
+
+/// Legibility line for an output manifest's blob-stored rich MIMEs.
+///
+/// Rich representations (arrow streams, html, images, viz specs — anything
+/// stored as a blob and rendered as a blob URL on the human channel) never
+/// arrive inline on the agent channel. This returns ONE compact line naming
+/// them with sizes so the agent knows the human already sees a full render
+/// and can fetch by URL only when it truly needs the bytes. The inline text
+/// MIMEs in `CONTENT_PRIORITY` are skipped — those arrive as agent text.
+///
+/// Returns `None` when the output has no blob-stored rich MIME, so the line
+/// appears at most once per output and only when it carries information.
+pub fn rich_blob_note(manifest: &serde_json::Value) -> Option<String> {
+    let data = manifest.get("data")?.as_object()?;
+    let mut entries: Vec<(&str, u64)> = data
+        .iter()
+        .filter(|(mime, _)| !CONTENT_PRIORITY.contains(&mime.as_str()))
+        .filter_map(|(mime, content_ref)| {
+            let meta = content_ref_meta(content_ref);
+            meta.blob_hash.map(|_| (mime.as_str(), meta.size))
+        })
+        .collect();
+    if entries.is_empty() {
+        return None;
+    }
+    entries.sort_unstable_by_key(|(mime, _)| *mime);
+    let listed = entries
+        .iter()
+        .map(|(mime, size)| format!("{} {}", short_mime_label(mime), format_compact_size(*size)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "Rendered for humans in the notebook; fetch by URL only if needed: {listed}"
+    ))
+}
+
+/// Compact label for a MIME type in the legibility line.
+///
+/// `text/html` → `html`, `image/png` → `png`, `image/svg+xml` → `svg`,
+/// `application/vnd.plotly.v1+json` → `plotly.v1`. Arrow stream MIMEs get a
+/// fixed `apache-arrow` label because the generic subtype rule would keep
+/// the unhelpful `nteract.arrow-stream-manifest` spelling.
+fn short_mime_label(mime: &str) -> String {
+    if mime == notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME
+        || mime == notebook_doc::mime::ARROW_STREAM_MIME
+    {
+        return "apache-arrow".to_string();
+    }
+    let subtype = mime.rsplit('/').next().unwrap_or(mime);
+    let subtype = subtype.strip_prefix("vnd.").unwrap_or(subtype);
+    let subtype = subtype.split('+').next().unwrap_or(subtype);
+    subtype.to_string()
+}
+
+/// Format a byte count compactly: `512B`, `20KB`, `1.5MB`.
+///
+/// One decimal max; a trailing `.0` is dropped.
+pub fn format_compact_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    let value = bytes as f64;
+    if value < KB {
+        format!("{bytes}B")
+    } else if value < MB {
+        format_scaled(value / KB, "KB")
+    } else {
+        format_scaled(value / MB, "MB")
+    }
+}
+
+fn format_scaled(value: f64, unit: &str) -> String {
+    let rounded = (value * 10.0).round() / 10.0;
+    if rounded.fract() == 0.0 {
+        format!("{rounded:.0}{unit}")
+    } else {
+        format!("{rounded:.1}{unit}")
+    }
 }
 
 fn format_output_summary_line(index: usize, output: &Output, preview_chars: usize) -> String {
@@ -566,6 +695,167 @@ mod tests {
         assert_eq!(items.len(), 1);
         let rendered = format!("{:?}", items[0]);
         assert!(rendered.contains("hidden"));
+    }
+
+    fn manifest(entries: &[(&str, serde_json::Value)]) -> serde_json::Value {
+        let data: serde_json::Map<String, serde_json::Value> = entries
+            .iter()
+            .map(|(mime, content_ref)| (mime.to_string(), content_ref.clone()))
+            .collect();
+        serde_json::json!({ "output_type": "display_data", "data": data })
+    }
+
+    fn blob_ref(size: u64) -> serde_json::Value {
+        serde_json::json!({ "blob": "sha256:abc", "size": size })
+    }
+
+    fn inline_ref(text: &str) -> serde_json::Value {
+        serde_json::json!({ "inline": text })
+    }
+
+    // ── agent-channel audience annotations ──────────────────────
+
+    #[test]
+    fn assistant_text_sets_assistant_audience() {
+        let item = assistant_text("hello");
+        assert_eq!(item.audience(), Some(&vec![Role::Assistant]));
+        assert_eq!(item.as_text().expect("text content").text, "hello");
+    }
+
+    #[test]
+    fn outputs_to_content_items_annotates_every_text_item_for_assistant() {
+        // Both resolved output text and the omitted-content footer are
+        // agent-channel items; renderers may drop them from human views.
+        let outputs = vec![
+            Output::stream("stdout", "hello"),
+            Output::display_data(data(&[("image/png", DataValue::Binary(vec![0; 10]))])),
+        ];
+        let items = outputs_to_content_items(&outputs);
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert_eq!(item.audience(), Some(&vec![Role::Assistant]));
+        }
+    }
+
+    // ── compact byte sizes ──────────────────────────────────────
+
+    #[test]
+    fn format_compact_size_scales_b_kb_mb() {
+        assert_eq!(format_compact_size(0), "0B");
+        assert_eq!(format_compact_size(512), "512B");
+        assert_eq!(format_compact_size(20 * 1024), "20KB");
+        assert_eq!(format_compact_size(500 * 1024), "500KB");
+        // One decimal max; kept only when it carries information.
+        assert_eq!(format_compact_size(84_480), "82.5KB");
+        assert_eq!(format_compact_size(1024 * 1024), "1MB");
+        assert_eq!(format_compact_size(1024 * 1024 + 512 * 1024), "1.5MB");
+    }
+
+    // ── legibility line for blob-stored rich MIMEs ──────────────
+
+    #[test]
+    fn rich_blob_note_lists_blob_mimes_with_sizes() {
+        let m = manifest(&[
+            ("text/plain", inline_ref("df")),
+            ("text/html", blob_ref(20 * 1024)),
+            ("image/png", blob_ref(84_480)),
+            (
+                notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME,
+                blob_ref(500 * 1024),
+            ),
+        ]);
+        let note = rich_blob_note(&m).expect("rich blobs present");
+        assert_eq!(
+            note,
+            "Rendered for humans in the notebook; fetch by URL only if needed: \
+             apache-arrow 500KB, png 82.5KB, html 20KB"
+        );
+    }
+
+    #[test]
+    fn rich_blob_note_skips_content_priority_text_mimes() {
+        // The CONTENT_PRIORITY text MIMEs arrive inline on the agent channel
+        // even when blob-stored, so the note must not point at them.
+        let m = manifest(&[
+            ("text/llm+plain", blob_ref(1024)),
+            ("text/latex", blob_ref(1024)),
+            ("text/markdown", blob_ref(5 * 1024)),
+            ("text/plain", blob_ref(100 * 1024)),
+        ]);
+        assert_eq!(rich_blob_note(&m), None);
+    }
+
+    #[test]
+    fn rich_blob_note_ignores_inline_rich_mimes() {
+        // Inline payloads have no blob URL to fetch; nothing to point at.
+        let m = manifest(&[("application/json", inline_ref("{\"a\":1}"))]);
+        assert_eq!(rich_blob_note(&m), None);
+
+        let stream = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": { "inline": "hi" },
+        });
+        assert_eq!(rich_blob_note(&stream), None);
+    }
+
+    #[test]
+    fn aligned_summary_appends_note_at_most_once_per_output() {
+        let manifests = vec![
+            manifest(&[
+                ("text/html", blob_ref(20 * 1024)),
+                ("image/png", blob_ref(2 * 1024)),
+            ]),
+            serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": { "inline": "hi" },
+            }),
+        ];
+        let resolved = vec![
+            Some(Output::display_data(data(&[(
+                "text/plain",
+                DataValue::Text("chart".into()),
+            )]))),
+            Some(Output::stream("stdout", "hi")),
+        ];
+
+        let lines = format_outputs_summary_lines_aligned(&resolved, &manifests, 20);
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("out[0]: display_data"));
+        assert_eq!(
+            lines[1],
+            "Rendered for humans in the notebook; fetch by URL only if needed: \
+             png 2KB, html 20KB"
+        );
+        assert!(lines[2].starts_with("out[1]: stream(stdout)"));
+        // Two rich blobs on one output still produce exactly one line.
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|line| line.contains("Rendered for humans"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn aligned_summary_skips_unresolved_manifests_and_keeps_numbering() {
+        let manifests = vec![
+            manifest(&[("image/png", blob_ref(1024))]),
+            serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": { "inline": "hi" },
+            }),
+        ];
+        let resolved = vec![None, Some(Output::stream("stdout", "hi"))];
+
+        let lines = format_outputs_summary_lines_aligned(&resolved, &manifests, 20);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].starts_with("out[0]: stream(stdout)"));
+        // The unresolved manifest contributes neither a summary nor a note.
+        assert!(!lines[0].contains("Rendered for humans"));
     }
 
     #[test]

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -403,7 +403,7 @@ fn cell_resource_success(
     cell_id: &str,
 ) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![
-        Content::text(message),
+        crate::formatting::assistant_text(message),
         Content::resource_link(crate::resources::notebook_cell_resource_link(
             notebook_id,
             cell_id,
@@ -417,7 +417,9 @@ fn cell_resource_json_success(
     cell_id: &str,
 ) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![
-        Content::text(serde_json::to_string_pretty(&result).unwrap_or_default()),
+        crate::formatting::assistant_text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        ),
         Content::resource_link(crate::resources::notebook_cell_resource_link(
             notebook_id,
             cell_id,
@@ -430,7 +432,9 @@ fn cells_resource_json_success(
     notebook_id: &str,
 ) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![
-        Content::text(serde_json::to_string_pretty(&result).unwrap_or_default()),
+        crate::formatting::assistant_text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        ),
         Content::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
     ]))
 }

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -1,6 +1,6 @@
 //! Read-only cell tools: get_cell, get_all_cells.
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -102,7 +102,7 @@ pub async fn get_cell(
             },
             "readiness": access.readiness,
         });
-        let mut result = CallToolResult::success(vec![Content::text(
+        let mut result = CallToolResult::success(vec![formatting::assistant_text(
             serde_json::to_string_pretty(&details).unwrap_or_default(),
         )]);
         result.structured_content = Some(details);
@@ -190,18 +190,18 @@ pub async fn get_cell(
     let mut items = Vec::new();
 
     if !cell.source.is_empty() {
-        items.push(Content::text(format!(
+        items.push(formatting::assistant_text(format!(
             "{header_with_tags}\n\n{}",
             cell.source
         )));
     } else {
-        items.push(Content::text(header_with_tags));
+        items.push(formatting::assistant_text(header_with_tags));
     }
 
     // Each output as a separate Content item (matches Python _cell_to_content)
     let output_summaries = output_summary_lines(&outputs, &raw_outputs, 120);
     if !output_summaries.is_empty() {
-        items.push(Content::text(format!(
+        items.push(formatting::assistant_text(format!(
             "Output summary:\n{}",
             output_summaries.join("\n")
         )));
@@ -315,7 +315,7 @@ pub async fn get_all_cells(
                 serde_json::to_string_pretty(&details).unwrap_or_default()
             }
         };
-        let mut result = CallToolResult::success(vec![Content::text(text)]);
+        let mut result = CallToolResult::success(vec![formatting::assistant_text(text)]);
         result.structured_content = Some(details);
         return Ok(result);
     }
@@ -391,7 +391,9 @@ pub async fn get_all_cells(
                 }));
             }
             let text = serde_json::to_string_pretty(&json_cells).unwrap_or_default();
-            Ok(CallToolResult::success(vec![Content::text(text)]))
+            Ok(CallToolResult::success(vec![formatting::assistant_text(
+                text,
+            )]))
         }
         GetAllCellsFormat::Rich => {
             let mut items = Vec::new();
@@ -431,10 +433,10 @@ pub async fn get_all_cells(
                 } else {
                     header
                 };
-                items.push(Content::text(text));
+                items.push(formatting::assistant_text(text));
                 let output_summaries = output_summary_lines(&outputs, raw_outputs, 120);
                 if !output_summaries.is_empty() {
-                    items.push(Content::text(format!(
+                    items.push(formatting::assistant_text(format!(
                         "Output summary:\n{}",
                         output_summaries.join("\n")
                     )));

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -141,7 +141,9 @@ pub async fn replace_match(
     // Return diff
     let old_text = &source[span.start..span.end];
     let diff = format_edit_diff(cell_id, old_text, content);
-    Ok(CallToolResult::success(vec![Content::text(diff)]))
+    Ok(CallToolResult::success(vec![
+        crate::formatting::assistant_text(diff),
+    ]))
 }
 
 /// Replace a regex-matched span in a cell.
@@ -228,7 +230,9 @@ pub async fn replace_regex(
     // Return diff
     let old_text = &source[span.start..span.end];
     let diff = format_edit_diff(cell_id, old_text, content);
-    Ok(CallToolResult::success(vec![Content::text(diff)]))
+    Ok(CallToolResult::success(vec![
+        crate::formatting::assistant_text(diff),
+    ]))
 }
 
 /// Format a unified diff for an edit operation.

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -16,7 +16,7 @@ use super::{arg_bool, arg_str, assert_cell_exists, tool_error};
 
 fn cells_resource_result(message: String, notebook_id: &str) -> CallToolResult {
     CallToolResult::success(vec![
-        Content::text(message),
+        formatting::assistant_text(message),
         Content::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
     ])
 }
@@ -240,7 +240,7 @@ pub async fn run_all_cells(
     // Build per-cell output content.
     let comms = runtime_state.as_ref().map(|rs| &rs.comms);
     let mut content_items = vec![
-        rmcp::model::Content::text(header.clone()),
+        formatting::assistant_text(header.clone()),
         rmcp::model::Content::resource_link(crate::resources::notebook_cells_resource_link(
             handle.notebook_id(),
         )),
@@ -290,10 +290,14 @@ pub async fn run_all_cells(
             Some(display_status),
             eid,
         );
-        content_items.push(rmcp::model::Content::text(cell_header));
-        let output_summaries = formatting::format_outputs_summary_lines(&outputs, 120);
+        content_items.push(formatting::assistant_text(cell_header));
+        let output_summaries = formatting::format_outputs_summary_lines_aligned(
+            &resolved_outputs_by_manifest,
+            output_manifests,
+            120,
+        );
         if !output_summaries.is_empty() {
-            content_items.push(rmcp::model::Content::text(format!(
+            content_items.push(formatting::assistant_text(format!(
                 "Output summary:\n{}",
                 output_summaries.join("\n")
             )));
@@ -503,14 +507,16 @@ async fn render_execution_result(
         (Vec::new(), Vec::new())
     };
 
-    let mut items = vec![rmcp::model::Content::text(header)];
-    let output_summaries = formatting::format_outputs_summary_lines(&outputs, 120);
+    let mut items = vec![formatting::assistant_text(header)];
+    let output_summaries = formatting::format_outputs_summary_lines_aligned(
+        &resolved_outputs_by_manifest,
+        &exec.outputs,
+        120,
+    );
     if output_summaries.is_empty() {
-        items.push(rmcp::model::Content::text(
-            "Output summary: 0 outputs".to_string(),
-        ));
+        items.push(formatting::assistant_text("Output summary: 0 outputs"));
     } else {
-        items.push(rmcp::model::Content::text(format!(
+        items.push(formatting::assistant_text(format!(
             "Output summary:\n{}",
             output_summaries.join("\n")
         )));
@@ -518,11 +524,11 @@ async fn render_execution_result(
 
     if !is_terminal && outputs.is_empty() {
         // No outputs yet — make it crystal clear
-        items.push(rmcp::model::Content::text(format!(
+        items.push(formatting::assistant_text(format!(
             "Status: {display_status}. No outputs available yet."
         )));
     } else if !is_terminal {
-        items.push(rmcp::model::Content::text(format!(
+        items.push(formatting::assistant_text(format!(
             "⚠ Status: {display_status}. Outputs below may be incomplete."
         )));
         items.extend(formatting::outputs_to_content_items(&outputs));

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -593,8 +593,13 @@ pub fn assert_cell_exists(
 }
 
 /// Helper: create a text error result.
+///
+/// Error text is agent-channel content (`audience: [assistant]`): the agent
+/// recovers from it; the human render comes from `structuredContent`.
 pub fn tool_error(msg: &str) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::error(vec![Content::text(msg.to_string())]))
+    Ok(CallToolResult::error(vec![
+        crate::formatting::assistant_text(msg),
+    ]))
 }
 
 /// Convert a centralized session capability failure into a structured tool
@@ -609,7 +614,8 @@ pub fn session_access_error(
         },
         "session": error.readiness,
     });
-    let mut result = CallToolResult::error(vec![Content::text(details.to_string())]);
+    let mut result =
+        CallToolResult::error(vec![crate::formatting::assistant_text(details.to_string())]);
     result.structured_content = Some(details);
     Ok(result)
 }
@@ -623,20 +629,28 @@ pub fn execution_dispatch_error(
             "message": error.message,
         }
     });
-    let mut result = CallToolResult::error(vec![Content::text(details.to_string())]);
+    let mut result =
+        CallToolResult::error(vec![crate::formatting::assistant_text(details.to_string())]);
     result.structured_content = Some(details);
     Ok(result)
 }
 
 /// Helper: create a text success result.
+///
+/// Status text is agent-channel content (`audience: [assistant]`); the human
+/// render comes from `structuredContent` or the notebook itself.
 pub fn tool_success(msg: &str) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![Content::text(
-        msg.to_string(),
-    )]))
+    Ok(CallToolResult::success(vec![
+        crate::formatting::assistant_text(msg),
+    ]))
 }
 
 /// Build a `CallToolResult` from an execution result, including structured content
 /// for the MCP Apps widget. Shared by cell_crud, editing, and execution tools.
+///
+/// Text content blocks are the agent channel (annotated `audience:
+/// [assistant]`, compact, with legibility pointers to blob-stored renders);
+/// `structured_content` is the complete, URL-rich human render contract.
 pub async fn build_execution_result(
     result: &crate::execution::ExecutionResult,
     handle: &notebook_sync::handle::DocHandle,
@@ -651,14 +665,20 @@ pub async fn build_execution_result(
     );
 
     let mut items = vec![
-        Content::text(header),
+        crate::formatting::assistant_text(header),
         cell_resource_content(handle.notebook_id(), &result.cell_id),
     ];
-    let output_summaries = crate::formatting::format_outputs_summary_lines(&result.outputs, 120);
+    let output_summaries = crate::formatting::format_outputs_summary_lines_aligned(
+        &result.resolved_outputs_by_manifest,
+        &result.output_manifests,
+        120,
+    );
     if output_summaries.is_empty() {
-        items.push(Content::text("Output summary: 0 outputs".to_string()));
+        items.push(crate::formatting::assistant_text(
+            "Output summary: 0 outputs",
+        ));
     } else {
-        items.push(Content::text(format!(
+        items.push(crate::formatting::assistant_text(format!(
             "Output summary:\n{}",
             output_summaries.join("\n")
         )));
@@ -955,6 +975,29 @@ mod tests {
         let link = decoded.as_resource_link().expect("resource link");
         assert_eq!(link.uri, expected_uri);
         assert_eq!(link.mime_type.as_deref(), Some("application/json"));
+    }
+
+    #[test]
+    fn tool_text_results_carry_assistant_audience() {
+        // Error/status text is agent-channel content; the assistant audience
+        // annotation lets renderers drop it from human views.
+        let ok = tool_success("done").unwrap();
+        assert_eq!(
+            ok.content[0].audience(),
+            Some(&vec![rmcp::model::Role::Assistant])
+        );
+
+        let err = tool_error("boom").unwrap();
+        assert_eq!(
+            err.content[0].audience(),
+            Some(&vec![rmcp::model::Role::Assistant])
+        );
+    }
+
+    #[test]
+    fn resource_links_stay_unannotated_for_both_audiences() {
+        let content = cell_resource_content("nb", "cell");
+        assert!(content.annotations.is_none());
     }
 
     #[test]


### PR DESCRIPTION
MCP tool results serve two audiences, and the result format now says so on the wire. Content blocks are the agent channel: minimal tokens, maximal contextual understanding, navigable pointers to fetch more. structuredContent is the human render contract consumed by the MCP App renderer: complete and URL-rich, never token-optimized. A new formatting::assistant_text helper builds text content annotated audience [assistant], and every agent-facing text item across tool results uses it: cell headers, output summary blocks, resolved output text from outputs_to_content_items, execution status lines, edit diffs, and the shared tool_error/tool_success/session-error helpers. Resource-link content stays unannotated because both audiences navigate by it. Renderers can now drop agent-channel text from human views without guessing.

When an output's manifest carries blob-stored rich MIMEs (arrow streams, html, images, viz specs; anything that renders as a blob URL), the output summary gains one compact legibility line, for example "Rendered for humans in the notebook; fetch by URL only if needed: apache-arrow 500KB, html 20KB, png 82.5KB". Sizes come from content_ref_meta on the manifest ContentRefs, formatted B/KB/MB with at most one decimal. The CONTENT_PRIORITY text MIMEs are skipped since those already arrive inline for the agent, and the line appears at most once per output, only when a rich blob exists. The seam is formatting::format_outputs_summary_lines_aligned, which pairs the manifest-aligned resolved outputs from resolve_cell_outputs_for_llm_aligned with their source manifests; build_execution_result, run_all_cells, and get_results all route through it, so execute_cell, create_cell(and_run), set_cell(and_run), replace_match/replace_regex(and_run), run_all_cells, and get_results emit the line uniformly.

