### PR TITLE
refactor(runtimed): bundle peer-connection context and handshake phases

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2985,20 +2985,24 @@ impl Daemon {
                 crate::notebook_sync_server::handle_notebook_sync_connection(
                     reader,
                     writer,
-                    room,
-                    self.notebook_rooms.clone(),
-                    notebook_id,
-                    default_runtime,
-                    default_python_env,
-                    self.clone(),
-                    working_dir_path,
+                    crate::notebook_sync_server::PeerConnectionContext {
+                        room,
+                        rooms: self.notebook_rooms.clone(),
+                        notebook_id,
+                        daemon: self.clone(),
+                        peer_id: uuid::Uuid::new_v4().to_string(),
+                        connection_identity,
+                        client_protocol_version,
+                        default_runtime,
+                        default_python_env,
+                        working_dir: working_dir_path,
+                        // No streaming load for direct NotebookSync handshake.
+                        needs_load: None,
+                    },
                     initial_metadata,
                     false, // Send ProtocolCapabilities for direct NotebookSync handshake
                     typed_bootstrap.unwrap_or(false),
-                    None,  // No streaming load for direct NotebookSync handshake
                     false, // Not a newly-created notebook at path
-                    connection_identity,
-                    client_protocol_version,
                 )
                 .await
             }
@@ -3439,20 +3443,25 @@ impl Daemon {
         crate::notebook_sync_server::handle_notebook_sync_connection(
             reader,
             writer,
-            room,
-            self.notebook_rooms.clone(),
-            notebook_id,
-            default_runtime,
-            default_python_env,
-            self.clone(),
-            None,  // working_dir: hosted rooms have no local project context
+            crate::notebook_sync_server::PeerConnectionContext {
+                room,
+                rooms: self.notebook_rooms.clone(),
+                notebook_id,
+                daemon: self.clone(),
+                peer_id: uuid::Uuid::new_v4().to_string(),
+                connection_identity,
+                client_protocol_version,
+                default_runtime,
+                default_python_env,
+                // Hosted rooms have no local project context.
+                working_dir: None,
+                // No streaming load; content arrives via the bridge.
+                needs_load: None,
+            },
             None,  // initial_metadata: the cloud room owns metadata
             true,  // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             false, // typed_capabilities unused when skipped
-            None,  // No streaming load; content arrives via the bridge
             false, // Not a newly-created notebook at a path
-            connection_identity,
-            client_protocol_version,
         )
         .await
     }
@@ -3881,20 +3890,23 @@ impl Daemon {
         crate::notebook_sync_server::handle_notebook_sync_connection(
             reader,
             writer,
-            room,
-            self.notebook_rooms.clone(),
-            notebook_id,
-            default_runtime,
-            default_python_env,
-            self.clone(),
-            working_dir_path,
+            crate::notebook_sync_server::PeerConnectionContext {
+                room,
+                rooms: self.notebook_rooms.clone(),
+                notebook_id,
+                daemon: self.clone(),
+                peer_id: uuid::Uuid::new_v4().to_string(),
+                connection_identity,
+                client_protocol_version,
+                default_runtime,
+                default_python_env,
+                working_dir: working_dir_path,
+                needs_load,
+            },
             None, // No initial_metadata - doc is already populated
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             false,
-            needs_load,
             created_new_at_path, // Enable auto-launch for notebooks created at non-existent paths
-            connection_identity,
-            client_protocol_version,
         )
         .await
     }
@@ -4147,20 +4159,24 @@ impl Daemon {
         crate::notebook_sync_server::handle_notebook_sync_connection(
             reader,
             writer,
-            room,
-            self.notebook_rooms.clone(),
-            notebook_id,
-            requested_runtime,
-            default_python_env,
-            self.clone(),
-            working_dir_path,
+            crate::notebook_sync_server::PeerConnectionContext {
+                room,
+                rooms: self.notebook_rooms.clone(),
+                notebook_id,
+                daemon: self.clone(),
+                peer_id: uuid::Uuid::new_v4().to_string(),
+                connection_identity,
+                client_protocol_version,
+                default_runtime: requested_runtime,
+                default_python_env,
+                working_dir: working_dir_path,
+                // No streaming load - doc was just created with empty cell.
+                needs_load: None,
+            },
             None, // No initial_metadata - doc is already populated
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             false,
-            None,  // No streaming load - doc was just created with empty cell
             false, // UUID-based new notebook, handled by is_new_notebook check
-            connection_identity,
-            client_protocol_version,
         )
         .await
     }

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -5,6 +5,42 @@ use super::*;
 use anyhow::Context;
 use runtime_doc::RuntimeLifecycle;
 
+/// Identity and environment facts that are immutable for the lifetime of one
+/// peer connection. The handshake handler that resolved the room constructs
+/// this once, and the whole sync-loop call chain reads it as a single value.
+/// Per-call state (readers, writers, Automerge `peer_state`) stays in plain
+/// parameters.
+pub(crate) struct PeerConnectionContext {
+    pub(crate) room: Arc<NotebookRoom>,
+    pub(crate) rooms: NotebookRooms,
+    pub(crate) notebook_id: String,
+    pub(crate) daemon: std::sync::Arc<crate::daemon::Daemon>,
+    /// Unique id for this peer connection, minted at handshake time so
+    /// presence registration and disconnect cleanup name the same peer.
+    pub(crate) peer_id: String,
+    pub(crate) connection_identity: RoomConnectionIdentity,
+    /// Protocol version from the client preamble. v4 is required at
+    /// connection setup, so SessionControl frames are always supported.
+    pub(crate) client_protocol_version: u8,
+    /// Runtime used for kernel auto-launch. Usually the user's default;
+    /// CreateNotebook overrides it with the explicitly requested runtime.
+    pub(crate) default_runtime: crate::runtime::Runtime,
+    pub(crate) default_python_env: crate::settings_doc::PythonEnvType,
+    /// Project context for untitled-notebook detection; also published as the
+    /// local workstation attachment for non-hosted rooms.
+    pub(crate) working_dir: Option<PathBuf>,
+    /// File to stream into a fresh room before steady-state sync.
+    pub(crate) needs_load: Option<PathBuf>,
+}
+
+impl PeerConnectionContext {
+    /// Execution-store directory for this connection. Derived from the
+    /// daemon the context already carries so the two cannot disagree.
+    pub(crate) fn execution_store_dir(&self) -> &Path {
+        &self.daemon.config.execution_store_dir
+    }
+}
+
 /// Handle a single notebook sync client connection.
 ///
 /// The caller has already consumed the handshake frame and resolved the room.
@@ -21,33 +57,23 @@ use runtime_doc::RuntimeLifecycle;
 /// is already communicated in the NotebookConnectionInfo response.
 /// If `typed_capabilities` is true, the capabilities bootstrap is carried in a
 /// typed SessionControl frame instead of a standalone untyped JSON frame.
-#[allow(clippy::too_many_arguments)]
-pub async fn handle_notebook_sync_connection<R, W>(
+pub(crate) async fn handle_notebook_sync_connection<R, W>(
     reader: R,
     mut writer: W,
-    room: Arc<NotebookRoom>,
-    rooms: NotebookRooms,
-    notebook_id: String,
-    default_runtime: crate::runtime::Runtime,
-    default_python_env: crate::settings_doc::PythonEnvType,
-    daemon: std::sync::Arc<crate::daemon::Daemon>,
-    working_dir: Option<PathBuf>,
+    ctx: PeerConnectionContext,
     initial_metadata: Option<String>,
     skip_capabilities: bool,
     typed_capabilities: bool,
-    needs_load: Option<PathBuf>,
     // True if this is a newly-created notebook at a non-existent path.
     // Used to enable auto-launch for notebooks created via `runt notebook newfile.ipynb`.
     created_new_at_path: bool,
-    connection_identity: RoomConnectionIdentity,
-    // Protocol version from the client preamble. v4 is required at connection
-    // setup, so SessionControl frames are always supported.
-    client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
+    let room = &ctx.room;
+    let notebook_id = ctx.notebook_id.as_str();
     // Claim the room for this peer before any other await. Bumping the
     // generation here protects against two ghost-room reaper races:
     //   1. The reaper has already snapshotted candidates and is between
@@ -64,7 +90,7 @@ where
     room.connections.clear_kernel_torn_down();
 
     // Set working_dir on the room if provided (for untitled notebook project detection)
-    if let Some(wd) = working_dir {
+    if let Some(wd) = &ctx.working_dir {
         let update_workstation_directory = room.file_binding.path().await.is_none();
         {
             let mut room_wd = room.identity.working_dir.write().await;
@@ -95,7 +121,7 @@ where
                     match doc.set_metadata_snapshot(&snapshot) {
                         Ok(()) => {
                             super::durability::commit_daemon_notebook_mutation(
-                                &room,
+                                room,
                                 &mut doc,
                                 &baseline_heads,
                                 &rollback_snapshot,
@@ -138,12 +164,12 @@ where
     // write lock (deadlock prevention: no lock held across `.await`).
     {
         let trust_state = room.trust_state.read().await;
-        write_trust_to_runtime_state(&room, &trust_state);
+        write_trust_to_runtime_state(room, &trust_state);
     }
     // Re-verify trust from doc metadata — picks up trust signatures that were
     // written to the Automerge doc (e.g., from a previous approval or from
     // initial_metadata seeded above).
-    check_and_update_trust_state(&room).await;
+    check_and_update_trust_state(room).await;
 
     room.connections
         .active_peers
@@ -172,7 +198,7 @@ where
         // Check if notebook_id is a UUID (new unsaved notebook) vs a file path
         let path_snapshot = room.file_binding.path().await;
         let is_new_notebook = path_snapshot.as_ref().is_none_or(|p| !p.exists())
-            && uuid::Uuid::parse_str(&notebook_id).is_ok();
+            && uuid::Uuid::parse_str(notebook_id).is_ok();
 
         // Scope the trust_state read guard so it drops before
         // `has_kernel()` which acquires another lock (deadlock prevention).
@@ -225,8 +251,10 @@ where
             // Spawn auto-launch in background so we don't block sync
             let room_clone = room.clone();
             let panic_room = room.clone();
-            let notebook_id_clone = notebook_id.clone();
-            let daemon_clone = daemon.clone();
+            let notebook_id_clone = notebook_id.to_string();
+            let daemon_clone = ctx.daemon.clone();
+            let default_runtime = ctx.default_runtime.clone();
+            let default_python_env = ctx.default_python_env.clone();
             spawn_supervised(
                 "auto-launch-kernel",
                 async move {
@@ -293,8 +321,8 @@ where
             .context("serialize comments notebook ref for notebook sync capabilities")?;
         let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
             .with_identity(
-                connection_identity.actor_label().as_str(),
-                connection_identity.scope().as_str(),
+                ctx.connection_identity.actor_label().as_str(),
+                ctx.connection_identity.scope().as_str(),
             )
             .with_comments_doc_identity(comments_doc_id, comments_notebook_ref);
         if typed_capabilities {
@@ -308,32 +336,23 @@ where
         }
     }
 
-    // Generate peer_id here so it's available for cleanup regardless of
-    // whether the sync loop exits with Ok or Err.
-    let peer_id = uuid::Uuid::new_v4().to_string();
-
-    let result = run_sync_loop_v2(
-        reader,
-        writer,
-        &room,
-        rooms.clone(),
-        notebook_id.clone(),
-        daemon.clone(),
-        needs_load.as_deref(),
-        &peer_id,
-        &connection_identity,
-        client_protocol_version,
-    )
-    .await;
+    let result = run_sync_loop_v2(reader, writer, &ctx).await;
 
     // Always clean up presence on disconnect, whether the sync loop
-    // exited cleanly (Ok) or with an error (Err). The peer_id was
-    // generated before starting the sync loop, so it is always
+    // exited cleanly (Ok) or with an error (Err). The peer_id is a
+    // connection-lifetime fact on the context, so it is always
     // available here. remove_peer is a no-op for unknown peers
     // (e.g. error before any presence was registered).
-    cleanup_presence_on_disconnect(&room, &peer_id).await;
+    cleanup_presence_on_disconnect(room, &ctx.peer_id).await;
 
-    handle_peer_disconnect(&room, rooms.clone(), &notebook_id, &peer_id, &daemon).await;
+    handle_peer_disconnect(
+        room,
+        ctx.rooms.clone(),
+        notebook_id,
+        &ctx.peer_id,
+        &ctx.daemon,
+    )
+    .await;
 
     result
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -19,7 +19,7 @@ use super::peer_presence::{
 use super::peer_runtime_sync::{forward_runtime_state_broadcast, handle_runtime_state_frame};
 use super::peer_session::{
     send_initial_notebook_doc_sync, send_initial_runtime_state_sync, send_session_status,
-    stream_initial_load_with_frame_drain, InitialSyncState,
+    stream_initial_load_with_frame_drain, HandshakePhases, InitialSyncState, PeerSessionContext,
 };
 use super::peer_writer::{
     enqueue_notebook_request, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
@@ -46,23 +46,22 @@ async fn next_peer_frame(
 /// Takes `reader` by value because the post-streaming-load main loop
 /// hands it to a `FramedReader` actor; from that point the read half
 /// belongs to the dedicated reader task, not this select loop.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_sync_loop_v2<R, W>(
     reader: R,
     mut writer: W,
-    room: &Arc<NotebookRoom>,
-    _rooms: NotebookRooms,
-    notebook_id: String,
-    daemon: std::sync::Arc<crate::daemon::Daemon>,
-    needs_load: Option<&Path>,
-    peer_id: &str,
-    connection_identity: &RoomConnectionIdentity,
-    client_protocol_version: u8,
+    ctx: &PeerConnectionContext,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
+    let room = &ctx.room;
+    let daemon = &ctx.daemon;
+    let notebook_id = ctx.notebook_id.as_str();
+    let peer_id = ctx.peer_id.as_str();
+    let connection_identity = &ctx.connection_identity;
+    let client_protocol_version = ctx.client_protocol_version;
+
     // Hand the reader off to a dedicated FramedReader actor before bootstrap.
     // The initial file-backed load can then safely wait for client sync replies
     // between batches without risking partial-frame cancellation.
@@ -81,32 +80,29 @@ where
     // PoolDoc — global daemon pool state (UV/Conda availability, errors).
     let mut pool_changed_rx = daemon.pool_doc_changed.subscribe();
 
-    let mut notebook_doc_phase = notebook_protocol::protocol::NotebookDocPhaseWire::Pending;
-    let mut runtime_state_phase = notebook_protocol::protocol::RuntimeStatePhaseWire::Pending;
+    let needs_load = ctx.needs_load.as_deref();
     let room_load_state = room.initial_load.state();
     let room_load_in_progress = room_load_state.is_loading();
-    let mut initial_load_phase = match &room_load_state {
-        RoomInitialLoadState::Loading { .. } | RoomInitialLoadState::Failed { .. } => {
-            notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
-        }
-        RoomInitialLoadState::NotNeeded { .. } | RoomInitialLoadState::Ready { .. }
-            if needs_load.is_some() =>
-        {
-            notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
-        }
-        RoomInitialLoadState::NotNeeded { .. } | RoomInitialLoadState::Ready { .. } => {
-            notebook_protocol::protocol::InitialLoadPhaseWire::NotNeeded
-        }
+    let mut phases = HandshakePhases {
+        notebook_doc: notebook_protocol::protocol::NotebookDocPhaseWire::Pending,
+        runtime_state: notebook_protocol::protocol::RuntimeStatePhaseWire::Pending,
+        initial_load: match &room_load_state {
+            RoomInitialLoadState::Loading { .. } | RoomInitialLoadState::Failed { .. } => {
+                notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
+            }
+            RoomInitialLoadState::NotNeeded { .. } | RoomInitialLoadState::Ready { .. }
+                if needs_load.is_some() =>
+            {
+                notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
+            }
+            RoomInitialLoadState::NotNeeded { .. } | RoomInitialLoadState::Ready { .. } => {
+                notebook_protocol::protocol::InitialLoadPhaseWire::NotNeeded
+            }
+        },
     };
 
     if client_protocol_version >= 3 {
-        send_session_status(
-            &mut writer,
-            notebook_doc_phase,
-            runtime_state_phase,
-            initial_load_phase.clone(),
-        )
-        .await?;
+        send_session_status(&mut writer, &phases).await?;
     }
 
     // Fresh file-backed rooms stream the file itself as the initial doc sync.
@@ -123,15 +119,9 @@ where
     } else {
         send_initial_notebook_doc_sync(&mut writer, room).await?
     };
-    notebook_doc_phase = notebook_protocol::protocol::NotebookDocPhaseWire::Syncing;
+    phases.notebook_doc = notebook_protocol::protocol::NotebookDocPhaseWire::Syncing;
     if client_protocol_version >= 3 {
-        send_session_status(
-            &mut writer,
-            notebook_doc_phase,
-            runtime_state_phase,
-            initial_load_phase.clone(),
-        )
-        .await?;
+        send_session_status(&mut writer, &phases).await?;
     }
 
     let mut state_peer_state = sync::State::new();
@@ -143,41 +133,36 @@ where
         runtimed_client::execution_store::ExecutionRecord,
     > = std::collections::HashMap::new();
     let execution_store = runtimed_client::execution_store::ExecutionStore::new(
-        daemon.config.execution_store_dir.clone(),
+        ctx.execution_store_dir().to_path_buf(),
     );
 
     send_initial_runtime_state_sync(&mut writer, room, &mut state_peer_state).await?;
-    runtime_state_phase = notebook_protocol::protocol::RuntimeStatePhaseWire::Syncing;
+    phases.runtime_state = notebook_protocol::protocol::RuntimeStatePhaseWire::Syncing;
     if client_protocol_version >= 3 {
-        send_session_status(
-            &mut writer,
-            notebook_doc_phase,
-            runtime_state_phase,
-            initial_load_phase.clone(),
-        )
-        .await?;
+        send_session_status(&mut writer, &phases).await?;
     }
 
     send_initial_comms_doc_sync(&mut writer, room, &mut comms_peer_state).await?;
     send_initial_comments_doc_sync(&mut writer, room, &mut comments_peer_state).await?;
 
-    initial_load_phase = stream_initial_load_with_frame_drain(
+    let session = PeerSessionContext {
+        room,
+        needs_load,
+        execution_store_dir: ctx.execution_store_dir(),
+        connection_identity,
+        client_protocol_version,
+    };
+    stream_initial_load_with_frame_drain(
         &mut framed_reader,
         &mut writer,
         &mut deferred_frames,
-        room,
-        needs_load,
-        &daemon.config.execution_store_dir,
+        &session,
         &mut peer_state,
-        &mut notebook_doc_phase,
-        runtime_state_phase,
-        initial_load_phase,
-        client_protocol_version,
-        connection_identity,
+        &mut phases,
     )
     .await?;
 
-    send_initial_pool_sync(&mut writer, &daemon, &mut pool_peer_state).await?;
+    send_initial_pool_sync(&mut writer, daemon, &mut pool_peer_state).await?;
 
     // CommSync broadcast is no longer needed. Late joiners receive widget
     // state via RuntimeStateDoc CRDT sync, and the frontend CRDT watcher
@@ -195,14 +180,14 @@ where
     // writer task; the peer loop must keep draining client frames even when the
     // client is temporarily slow to read daemon frames.
     let (peer_writer, mut writer_task) =
-        spawn_peer_writer(writer, notebook_id.clone(), peer_id.to_string());
+        spawn_peer_writer(writer, notebook_id.to_string(), peer_id.to_string());
     let multipart_uploads = MultipartUploadState::new(&room.blob_store);
     let mut request_worker = spawn_peer_request_worker(
         room.clone(),
         daemon.clone(),
         peer_writer.clone(),
         multipart_uploads.clone(),
-        notebook_id.clone(),
+        notebook_id.to_string(),
         peer_id.to_string(),
         connection_identity.actor_label().as_str().to_string(),
     );
@@ -210,7 +195,7 @@ where
         room.blob_store.clone(),
         peer_writer.clone(),
         multipart_uploads,
-        notebook_id.clone(),
+        notebook_id.to_string(),
         peer_id.to_string(),
     );
 
@@ -303,18 +288,13 @@ where
                                 // A queued reply means the joiner has not acknowledged
                                 // the daemon's current NotebookDoc yet.
                                 if !notebook_doc_effects.sync_reply_queued()
-                                    && notebook_doc_phase
+                                    && phases.notebook_doc
                                     != notebook_protocol::protocol::NotebookDocPhaseWire::Interactive
                                 {
-                                    notebook_doc_phase =
+                                    phases.notebook_doc =
                                         notebook_protocol::protocol::NotebookDocPhaseWire::Interactive;
                                     if client_protocol_version >= 3 {
-                                        queue_session_status(
-                                            &peer_writer,
-                                            notebook_doc_phase,
-                                            runtime_state_phase,
-                                            initial_load_phase.clone(),
-                                        )?;
+                                        queue_session_status(&peer_writer, &phases)?;
                                     }
                                 }
 
@@ -328,7 +308,7 @@ where
                                     &request_worker,
                                     &peer_writer,
                                     &frame.payload,
-                                    &notebook_id,
+                                    notebook_id,
                                     peer_id,
                                     connection_identity.scope(),
                                 )?;
@@ -360,18 +340,13 @@ where
                                     continue;
                                 }
 
-                                if runtime_state_phase
+                                if phases.runtime_state
                                     != notebook_protocol::protocol::RuntimeStatePhaseWire::Ready
                                 {
-                                    runtime_state_phase =
+                                    phases.runtime_state =
                                         notebook_protocol::protocol::RuntimeStatePhaseWire::Ready;
                                     if client_protocol_version >= 3 {
-                                        queue_session_status(
-                                            &peer_writer,
-                                            notebook_doc_phase,
-                                            runtime_state_phase,
-                                            initial_load_phase.clone(),
-                                        )?;
+                                        queue_session_status(&peer_writer, &phases)?;
                                     }
                                 }
                             }
@@ -417,7 +392,7 @@ where
 
                             NotebookFrameType::PoolStateSync => {
                                 if !handle_pool_state_frame(
-                                    &daemon,
+                                    daemon,
                                     &mut pool_peer_state,
                                     &peer_writer,
                                     &frame.payload,
@@ -443,7 +418,7 @@ where
                                     &put_blob_worker,
                                     &peer_writer,
                                     frame.payload,
-                                    &notebook_id,
+                                    notebook_id,
                                     peer_id,
                                     connection_identity.scope(),
                                 )?;
@@ -504,7 +479,7 @@ where
             // PoolDoc changed — push update to this client
             result = pool_changed_rx.recv() => {
                 if !forward_pool_state_broadcast(
-                    &daemon,
+                    daemon,
                     peer_id,
                     &mut pool_peer_state,
                     &peer_writer,

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -3,8 +3,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use automerge::sync;
-#[cfg(test)]
-use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 use tracing::{info, warn};
 
@@ -20,6 +18,17 @@ struct InitialLoadFrameDrain<'a> {
     framed_reader: &'a mut connection::FramedReader,
     deferred_frames: &'a mut VecDeque<TypedNotebookFrame>,
     connection_identity: &'a RoomConnectionIdentity,
+}
+
+/// Connection-lifetime facts the initial-load stream reads. Every field is
+/// immutable for the life of the peer connection; per-call state (the writer,
+/// sync `peer_state`, the frame drain) stays in plain parameters.
+pub(crate) struct PeerSessionContext<'a> {
+    pub(crate) room: &'a Arc<NotebookRoom>,
+    pub(crate) needs_load: Option<&'a Path>,
+    pub(crate) execution_store_dir: &'a Path,
+    pub(crate) connection_identity: &'a RoomConnectionIdentity,
+    pub(crate) client_protocol_version: u8,
 }
 
 /// Drain client acknowledgements while the room materializes.
@@ -146,16 +155,19 @@ where
     Ok(sent)
 }
 
-struct InitialLoadSyncOutcome {
-    initial_load_phase: notebook_protocol::protocol::InitialLoadPhaseWire,
-    notebook_doc_phase: notebook_protocol::protocol::NotebookDocPhaseWire,
+/// The three wire phases advertised to the client through SessionControl
+/// SyncStatus frames. They always travel together: every status frame reports
+/// all three, and bootstrap advances them one at a time.
+#[derive(Debug, Clone)]
+pub(crate) struct HandshakePhases {
+    pub(crate) notebook_doc: notebook_protocol::protocol::NotebookDocPhaseWire,
+    pub(crate) runtime_state: notebook_protocol::protocol::RuntimeStatePhaseWire,
+    pub(crate) initial_load: notebook_protocol::protocol::InitialLoadPhaseWire,
 }
 
 pub(crate) async fn send_session_status<W>(
     writer: &mut W,
-    notebook_doc: notebook_protocol::protocol::NotebookDocPhaseWire,
-    runtime_state: notebook_protocol::protocol::RuntimeStatePhaseWire,
-    initial_load: notebook_protocol::protocol::InitialLoadPhaseWire,
+    phases: &HandshakePhases,
 ) -> anyhow::Result<()>
 where
     W: AsyncWrite + Unpin,
@@ -165,9 +177,9 @@ where
         NotebookFrameType::SessionControl,
         &notebook_protocol::protocol::SessionControlMessage::SyncStatus(
             notebook_protocol::protocol::SessionSyncStatusWire {
-                notebook_doc,
-                runtime_state,
-                initial_load,
+                notebook_doc: phases.notebook_doc,
+                runtime_state: phases.runtime_state,
+                initial_load: phases.initial_load.clone(),
             },
         ),
     )
@@ -267,46 +279,38 @@ where
     Ok(())
 }
 
-/// Stream initial notebook file contents into the room before steady-state sync.
-///
-/// The caller passes `peer_state` from the initial notebook-doc sync so each
-/// streamed batch can produce deltas from the same baseline.
-///
-/// Test-only wrapper that supplies an inert frame drain (exhausted framed
-/// reader, no deferred frames, local connection identity) so ordering
-/// invariants can be asserted on the writer side without a live client
-/// stream.
-#[allow(clippy::too_many_arguments)]
+/// Test-only wrapper around [`stream_initial_load_inner`] that supplies an
+/// inert frame drain (exhausted framed reader, no deferred frames, local
+/// connection identity) so ordering invariants can be asserted on the writer
+/// side without a live client stream.
 #[cfg(test)]
-pub(crate) async fn stream_initial_load<R, W>(
-    _reader: &mut R,
+pub(crate) async fn stream_initial_load<W>(
     writer: &mut W,
     room: &Arc<NotebookRoom>,
     needs_load: Option<&Path>,
     execution_store_dir: &Path,
     peer_state: &mut sync::State,
-    notebook_doc_phase: notebook_protocol::protocol::NotebookDocPhaseWire,
-    runtime_state_phase: notebook_protocol::protocol::RuntimeStatePhaseWire,
-    initial_load_phase: notebook_protocol::protocol::InitialLoadPhaseWire,
+    phases: HandshakePhases,
     client_protocol_version: u8,
 ) -> anyhow::Result<notebook_protocol::protocol::InitialLoadPhaseWire>
 where
-    R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
     let mut framed_reader = connection::FramedReader::spawn(tokio::io::empty(), 1);
     let mut deferred_frames = VecDeque::new();
     let connection_identity = RoomConnectionIdentity::local(Some("mcp:test".to_string())).await?;
-    Ok(stream_initial_load_inner(
-        writer,
+    let session = PeerSessionContext {
         room,
         needs_load,
         execution_store_dir,
-        peer_state,
-        notebook_doc_phase,
-        runtime_state_phase,
-        initial_load_phase,
+        connection_identity: &connection_identity,
         client_protocol_version,
+    };
+    Ok(stream_initial_load_inner(
+        writer,
+        &session,
+        peer_state,
+        phases,
         InitialLoadFrameDrain {
             framed_reader: &mut framed_reader,
             deferred_frames: &mut deferred_frames,
@@ -314,85 +318,70 @@ where
         },
     )
     .await?
-    .initial_load_phase)
+    .initial_load)
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Stream initial notebook file contents into the room before steady-state sync.
+///
+/// The caller passes `peer_state` from the initial notebook-doc sync so each
+/// streamed batch can produce deltas from the same baseline. On success the
+/// notebook-doc and initial-load phases are updated in place; the
+/// runtime-state phase passes through untouched.
 pub(crate) async fn stream_initial_load_with_frame_drain<W>(
     framed_reader: &mut connection::FramedReader,
     writer: &mut W,
     deferred_frames: &mut VecDeque<TypedNotebookFrame>,
-    room: &Arc<NotebookRoom>,
-    needs_load: Option<&Path>,
-    execution_store_dir: &Path,
+    session: &PeerSessionContext<'_>,
     peer_state: &mut sync::State,
-    notebook_doc_phase: &mut notebook_protocol::protocol::NotebookDocPhaseWire,
-    runtime_state_phase: notebook_protocol::protocol::RuntimeStatePhaseWire,
-    initial_load_phase: notebook_protocol::protocol::InitialLoadPhaseWire,
-    client_protocol_version: u8,
-    connection_identity: &RoomConnectionIdentity,
-) -> anyhow::Result<notebook_protocol::protocol::InitialLoadPhaseWire>
+    phases: &mut HandshakePhases,
+) -> anyhow::Result<()>
 where
     W: AsyncWrite + Unpin,
 {
-    let outcome = stream_initial_load_inner(
+    *phases = stream_initial_load_inner(
         writer,
-        room,
-        needs_load,
-        execution_store_dir,
+        session,
         peer_state,
-        *notebook_doc_phase,
-        runtime_state_phase,
-        initial_load_phase,
-        client_protocol_version,
+        phases.clone(),
         InitialLoadFrameDrain {
             framed_reader,
             deferred_frames,
-            connection_identity,
+            connection_identity: session.connection_identity,
         },
     )
     .await?;
-    *notebook_doc_phase = outcome.notebook_doc_phase;
-    Ok(outcome.initial_load_phase)
+    Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn stream_initial_load_inner<W>(
     writer: &mut W,
-    room: &Arc<NotebookRoom>,
-    needs_load: Option<&Path>,
-    execution_store_dir: &Path,
+    session: &PeerSessionContext<'_>,
     peer_state: &mut sync::State,
-    mut notebook_doc_phase: notebook_protocol::protocol::NotebookDocPhaseWire,
-    runtime_state_phase: notebook_protocol::protocol::RuntimeStatePhaseWire,
-    initial_load_phase: notebook_protocol::protocol::InitialLoadPhaseWire,
-    client_protocol_version: u8,
+    mut phases: HandshakePhases,
     mut frame_drain: InitialLoadFrameDrain<'_>,
-) -> anyhow::Result<InitialLoadSyncOutcome>
+) -> anyhow::Result<HandshakePhases>
 where
     W: AsyncWrite + Unpin,
 {
+    let room = session.room;
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
-    let mut source_state_rx = if let Some(load_path) = needs_load {
+    let mut source_state_rx = if let Some(load_path) = session.needs_load {
         start_room_initial_load(
             room,
             load_path.to_path_buf(),
-            execution_store_dir.to_path_buf(),
+            session.execution_store_dir.to_path_buf(),
         );
         room.initial_load.subscribe_authoritative()
     } else if room.is_loading()
         || matches!(
-            initial_load_phase,
+            phases.initial_load,
             notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
                 | notebook_protocol::protocol::InitialLoadPhaseWire::Failed { .. }
         )
     {
         room.initial_load.subscribe_authoritative()
     } else {
-        return Ok(InitialLoadSyncOutcome {
-            initial_load_phase,
-            notebook_doc_phase,
-        });
+        return Ok(phases);
     };
 
     let mut generation = source_state_rx.borrow().generation();
@@ -418,23 +407,14 @@ where
                     notebook_doc_converged = converged;
                 }
                 if notebook_doc_converged {
-                    notebook_doc_phase =
+                    phases.notebook_doc =
                         notebook_protocol::protocol::NotebookDocPhaseWire::Interactive;
                 }
-                let phase = notebook_protocol::protocol::InitialLoadPhaseWire::Ready;
-                if client_protocol_version >= 3 {
-                    send_session_status(
-                        writer,
-                        notebook_doc_phase,
-                        runtime_state_phase,
-                        phase.clone(),
-                    )
-                    .await?;
+                phases.initial_load = notebook_protocol::protocol::InitialLoadPhaseWire::Ready;
+                if session.client_protocol_version >= 3 {
+                    send_session_status(writer, &phases).await?;
                 }
-                return Ok(InitialLoadSyncOutcome {
-                    initial_load_phase: phase,
-                    notebook_doc_phase,
-                });
+                return Ok(phases);
             }
             RoomInitialLoadState::Failed {
                 generation: settled_generation,
@@ -459,12 +439,11 @@ where
                     continue;
                 }
                 send_initial_load_doc_delta(writer, room, peer_state).await?;
-                let phase = notebook_protocol::protocol::InitialLoadPhaseWire::Failed {
+                phases.initial_load = notebook_protocol::protocol::InitialLoadPhaseWire::Failed {
                     reason: reason.clone(),
                 };
-                if client_protocol_version >= 3 {
-                    send_session_status(writer, notebook_doc_phase, runtime_state_phase, phase)
-                        .await?;
+                if session.client_protocol_version >= 3 {
+                    send_session_status(writer, &phases).await?;
                 }
                 return Err(anyhow::anyhow!("Initial materialization failed: {reason}"));
             }
@@ -626,6 +605,16 @@ mod tests {
 
         fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
             Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Phases as they stand when bootstrap reaches the initial-load stream:
+    /// both docs syncing, file contents still streaming.
+    fn bootstrap_phases() -> HandshakePhases {
+        HandshakePhases {
+            notebook_doc: NotebookDocPhaseWire::Syncing,
+            runtime_state: RuntimeStatePhaseWire::Syncing,
+            initial_load: InitialLoadPhaseWire::Streaming,
         }
     }
 
@@ -919,19 +908,15 @@ mod tests {
         ));
         assert!(room.initial_load.complete_ready(generation, 0));
 
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
         let phase = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             None,
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -946,20 +931,16 @@ mod tests {
         let room = test_room(&tmp);
         let load_path = tmp.path().join("source.ipynb");
         write_one_cell_notebook(&load_path).await;
-        let mut reader = tokio::io::empty();
         let mut writer = FailFirstWrite::expecting_partial_state(&room);
         let mut peer_state = sync::State::new();
 
         let err = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1002,20 +983,16 @@ mod tests {
         let room = test_room(&tmp);
         let load_path = tmp.path().join("source.ipynb");
         write_one_cell_notebook(&load_path).await;
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         let phase = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             2,
         )
         .await
@@ -1045,20 +1022,16 @@ mod tests {
         let room = test_room(&tmp);
         let load_path = tmp.path().join("source.ipynb");
         write_one_cell_notebook(&load_path).await;
-        let mut reader = tokio::io::empty();
         let mut writer = FailFirstWrite::expecting_partial_state(&room);
         let mut peer_state = sync::State::new();
 
         stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             2,
         )
         .await
@@ -1082,20 +1055,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let room = test_room(&tmp);
         let load_path = tmp.path().join("does-not-exist.ipynb");
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         let err = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1134,19 +1103,15 @@ mod tests {
             .initial_load
             .complete_failed(generation, "source became unreadable".to_string()));
 
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
         let error = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             None,
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1308,20 +1273,21 @@ mod tests {
             .complete_failed(generation, "source batch failed".to_string()));
         room.mark_load_failed();
 
-        let mut notebook_doc_phase = NotebookDocPhaseWire::Syncing;
+        let session = PeerSessionContext {
+            room: &room,
+            needs_load: None,
+            execution_store_dir: tmp.path(),
+            connection_identity: &identity,
+            client_protocol_version: 4,
+        };
+        let mut phases = bootstrap_phases();
         let error = stream_initial_load_with_frame_drain(
             &mut framed_reader,
             &mut writer,
             &mut deferred_frames,
-            &room,
-            None,
-            tmp.path(),
+            &session,
             &mut peer_state,
-            &mut notebook_doc_phase,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
-            4,
-            &identity,
+            &mut phases,
         )
         .await
         .expect_err("the source generation remains terminally failed");
@@ -1376,26 +1342,27 @@ mod tests {
         });
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
-        let mut notebook_doc_phase = NotebookDocPhaseWire::Syncing;
-        let phase = stream_initial_load_with_frame_drain(
+        let session = PeerSessionContext {
+            room: &room,
+            needs_load: None,
+            execution_store_dir: tmp.path(),
+            connection_identity: &identity,
+            client_protocol_version: 4,
+        };
+        let mut phases = bootstrap_phases();
+        stream_initial_load_with_frame_drain(
             &mut framed_reader,
             &mut writer,
             &mut deferred_frames,
-            &room,
-            None,
-            tmp.path(),
+            &session,
             &mut peer_state,
-            &mut notebook_doc_phase,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
-            4,
-            &identity,
+            &mut phases,
         )
         .await
         .expect("waiter should follow the recovered generation");
 
         recovery.await.unwrap();
-        assert_eq!(phase, InitialLoadPhaseWire::Ready);
+        assert_eq!(phases.initial_load, InitialLoadPhaseWire::Ready);
         assert!(matches!(
             room.initial_load.state(),
             RoomInitialLoadState::Ready {
@@ -1433,20 +1400,16 @@ mod tests {
             blob_store,
             false,
         ));
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         let error = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1490,20 +1453,16 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         let phase = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1586,20 +1545,16 @@ mod tests {
         let room = test_room(&tmp);
         let load_path = tmp.path().join("source.ipynb");
         write_one_cell_notebook(&load_path).await;
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         let phase = stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1643,20 +1598,16 @@ mod tests {
         let room = test_room(&tmp);
         let load_path = tmp.path().join("source.ipynb");
         write_one_cell_notebook(&load_path).await;
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await
@@ -1695,20 +1646,16 @@ mod tests {
             blob_store,
             false,
         ));
-        let mut reader = tokio::io::empty();
         let mut writer = CaptureWriter::default();
         let mut peer_state = sync::State::new();
 
         stream_initial_load(
-            &mut reader,
             &mut writer,
             &room,
             Some(&load_path),
             tmp.path(),
             &mut peer_state,
-            NotebookDocPhaseWire::Syncing,
-            RuntimeStatePhaseWire::Syncing,
-            InitialLoadPhaseWire::Streaming,
+            bootstrap_phases(),
             4,
         )
         .await

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -513,17 +513,15 @@ pub(super) fn queue_request_error(
 
 pub(super) fn queue_session_status(
     writer: &PeerWriter,
-    notebook_doc: notebook_protocol::protocol::NotebookDocPhaseWire,
-    runtime_state: notebook_protocol::protocol::RuntimeStatePhaseWire,
-    initial_load: notebook_protocol::protocol::InitialLoadPhaseWire,
+    phases: &super::peer_session::HandshakePhases,
 ) -> anyhow::Result<()> {
     writer.send_json(
         NotebookFrameType::SessionControl,
         &notebook_protocol::protocol::SessionControlMessage::SyncStatus(
             notebook_protocol::protocol::SessionSyncStatusWire {
-                notebook_doc,
-                runtime_state,
-                initial_load,
+                notebook_doc: phases.notebook_doc,
+                runtime_state: phases.runtime_state,
+                initial_load: phases.initial_load.clone(),
             },
         ),
     )
@@ -792,9 +790,11 @@ mod tests {
             .expect("runtime sync should enqueue");
         queue_session_status(
             &writer,
-            notebook_protocol::protocol::NotebookDocPhaseWire::Interactive,
-            notebook_protocol::protocol::RuntimeStatePhaseWire::Ready,
-            notebook_protocol::protocol::InitialLoadPhaseWire::Ready,
+            &crate::notebook_sync_server::peer_session::HandshakePhases {
+                notebook_doc: notebook_protocol::protocol::NotebookDocPhaseWire::Interactive,
+                runtime_state: notebook_protocol::protocol::RuntimeStatePhaseWire::Ready,
+                initial_load: notebook_protocol::protocol::InitialLoadPhaseWire::Ready,
+            },
         )
         .expect("session status should enqueue after runtime sync");
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -316,22 +316,21 @@ async fn notebook_doc_interactive_waits_for_initial_sync_convergence() {
     let (mut client_reader, mut client_writer) = tokio::io::split(client_io);
 
     let server_task = {
-        let room = room.clone();
-        let daemon = daemon.clone();
+        let ctx = PeerConnectionContext {
+            room: room.clone(),
+            rooms,
+            notebook_id,
+            daemon: daemon.clone(),
+            peer_id: "mcp-peer".to_string(),
+            connection_identity: identity,
+            client_protocol_version: notebook_protocol::connection::PROTOCOL_VERSION,
+            default_runtime: Default::default(),
+            default_python_env: Default::default(),
+            working_dir: None,
+            needs_load: None,
+        };
         tokio::spawn(async move {
-            super::peer_loop::run_sync_loop_v2(
-                server_reader,
-                server_writer,
-                &room,
-                rooms,
-                notebook_id,
-                daemon,
-                None,
-                "mcp-peer",
-                &identity,
-                notebook_protocol::connection::PROTOCOL_VERSION,
-            )
-            .await
+            super::peer_loop::run_sync_loop_v2(server_reader, server_writer, &ctx).await
         })
     };
 
@@ -436,23 +435,21 @@ async fn file_backed_initial_load_applies_buffered_replies_before_ready() {
     let (mut client_reader, mut client_writer) = tokio::io::split(client_io);
 
     let server_task = {
-        let room = room.clone();
-        let daemon = daemon.clone();
-        let load_path = load_path.clone();
+        let ctx = PeerConnectionContext {
+            room: room.clone(),
+            rooms,
+            notebook_id,
+            daemon: daemon.clone(),
+            peer_id: "mcp-peer".to_string(),
+            connection_identity: identity,
+            client_protocol_version: notebook_protocol::connection::PROTOCOL_VERSION,
+            default_runtime: Default::default(),
+            default_python_env: Default::default(),
+            working_dir: None,
+            needs_load: Some(load_path.clone()),
+        };
         tokio::spawn(async move {
-            super::peer_loop::run_sync_loop_v2(
-                server_reader,
-                server_writer,
-                &room,
-                rooms,
-                notebook_id,
-                daemon,
-                Some(load_path.as_path()),
-                "mcp-peer",
-                &identity,
-                notebook_protocol::connection::PROTOCOL_VERSION,
-            )
-            .await
+            super::peer_loop::run_sync_loop_v2(server_reader, server_writer, &ctx).await
         })
     };
 
@@ -571,23 +568,21 @@ async fn file_backed_initial_load_reaches_ready_without_streaming_replies() {
     let (mut client_reader, mut client_writer) = tokio::io::split(client_io);
 
     let server_task = {
-        let room = room.clone();
-        let daemon = daemon.clone();
-        let load_path = load_path.clone();
+        let ctx = PeerConnectionContext {
+            room: room.clone(),
+            rooms,
+            notebook_id,
+            daemon: daemon.clone(),
+            peer_id: "mcp-peer".to_string(),
+            connection_identity: identity,
+            client_protocol_version: notebook_protocol::connection::PROTOCOL_VERSION,
+            default_runtime: Default::default(),
+            default_python_env: Default::default(),
+            working_dir: None,
+            needs_load: Some(load_path.clone()),
+        };
         tokio::spawn(async move {
-            super::peer_loop::run_sync_loop_v2(
-                server_reader,
-                server_writer,
-                &room,
-                rooms,
-                notebook_id,
-                daemon,
-                Some(load_path.as_path()),
-                "mcp-peer",
-                &identity,
-                notebook_protocol::connection::PROTOCOL_VERSION,
-            )
-            .await
+            super::peer_loop::run_sync_loop_v2(server_reader, server_writer, &ctx).await
         })
     };
 


### PR DESCRIPTION
The notebook sync chain threaded the same connection facts through every layer: handle_notebook_sync_connection took 16 arguments, run_sync_loop_v2 ten, and the peer_session stream functions eight to twelve, all hiding behind allow(clippy::too_many_arguments).

Connection-lifetime facts now travel as one context. PeerConnectionContext owns room, rooms, notebook_id, daemon, peer_id, connection identity, protocol version, launch defaults, working_dir, and needs_load; the handshake handlers in daemon.rs construct it once and the rest of the chain reads it. The execution-store directory is an accessor derived from the daemon the context carries, so the two cannot disagree. PeerSessionContext is the borrowed, daemon-free view the initial-load stream needs, which keeps the peer_session unit tests constructible without a Daemon.

The three SessionControl wire phases move into HandshakePhases and travel as one value through send_session_status, queue_session_status, and the initial-load stream, which now advances the notebook-doc and initial-load phases in place while the runtime-state phase passes through untouched. Per-call state (readers, writers, Automerge peer_state, the frame drain) stays in plain parameters.

Behavior is unchanged: same wire frames in the same order, same lock scopes, and the same ownership shapes (Arc clones where clones were, borrows where borrows were). peer_id minting moves from the connection handler to context construction, which only changes where the UUID is generated. The cfg(test) stream_initial_load wrapper keeps the inert-drain shape and drops its unused reader parameter. All five allow(clippy::too_many_arguments) in this chain are gone and none were added.

