### PR TITLE
perf(cloud): session diet, GET-first bootstrap with Server-Timing

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1046,30 +1046,68 @@ function withNoStore(response: Response): Response {
   return response;
 }
 
+/**
+ * Server-Timing phase timers for the session endpoint. Cloudflare advances
+ * `Date.now()` only across I/O, so each phase reports the awaited upstream or
+ * database time it wrapped; a near-zero `total` against a slow client-side
+ * trace points at scheduling upstream of the handler. Metric names are stable
+ * so traces stay comparable: `session_read`, `host_bootstrap`, `renew_cookie`
+ * (GET), `auth_validate`, `profile_sync`, `cookie_create` (POST), and `total`
+ * on every method.
+ */
+function appSessionServerTiming(): {
+  time<T>(name: string, op: () => Promise<T>): Promise<T>;
+  apply(response: Response): Response;
+} {
+  const startedAt = Date.now();
+  const phases: string[] = [];
+  return {
+    async time<T>(name: string, op: () => Promise<T>): Promise<T> {
+      const phaseStartedAt = Date.now();
+      try {
+        return await op();
+      } finally {
+        phases.push(`${name};dur=${Date.now() - phaseStartedAt}`);
+      }
+    },
+    apply(response: Response): Response {
+      response.headers.set(
+        "Server-Timing",
+        [...phases, `total;dur=${Date.now() - startedAt}`].join(", "),
+      );
+      return response;
+    },
+  };
+}
+
 async function routeAppSession(
   request: Request,
   env: Env,
   ctx: ExecutionContext,
 ): Promise<Response> {
+  const timing = appSessionServerTiming();
+
   if (request.method === "GET") {
     const existingSession = appSessionConfigured(env)
-      ? await readCloudAppSession(env, request)
+      ? await timing.time("session_read", () => readCloudAppSession(env, request))
       : null;
     const bootstrapped =
       existingSession || !appSessionConfigured(env)
         ? null
-        : await hostSessionAppSessionCookie(request, env);
+        : await timing.time("host_bootstrap", () => hostSessionAppSessionCookie(request, env));
     const session = existingSession ?? bootstrapped?.session ?? null;
-    const response = await withAppSessionRenewalCookie(
-      json({ ok: true, session: session ? appSessionResponse(session) : null }),
-      env,
-      session,
+    const response = await timing.time("renew_cookie", () =>
+      withAppSessionRenewalCookie(
+        json({ ok: true, session: session ? appSessionResponse(session) : null }),
+        env,
+        session,
+      ),
     );
     if (bootstrapped?.cookie) {
       response.headers.append("Set-Cookie", bootstrapped.cookie);
       ctx.waitUntil(syncAuthenticatedProfile(env, bootstrapped.identity));
     }
-    return response;
+    return timing.apply(response);
   }
 
   const originRejection = rejectUntrustedMutationOrigin(request, env);
@@ -1080,7 +1118,7 @@ async function routeAppSession(
   if (request.method === "DELETE") {
     const response = json({ ok: true });
     response.headers.append("Set-Cookie", clearCloudAppSessionCookie());
-    return response;
+    return timing.apply(response);
   }
 
   if (request.method !== "POST") {
@@ -1090,21 +1128,28 @@ async function routeAppSession(
     return json({ error: "app sessions are not configured" }, 503);
   }
 
-  const identity = await authenticateRequestOrResponse(request, env);
+  // Same operations and ordering as `authenticateRequestOrResponse` with its
+  // default profile sync, split so each awaited phase reports its own timing.
+  const identity = await timing.time("auth_validate", () =>
+    authenticateRequestOrResponse(request, env, { syncProfile: false }),
+  );
   if (identity instanceof Response) {
-    return identity;
+    return timing.apply(identity);
   }
+  await timing.time("profile_sync", () => syncAuthenticatedProfile(env, identity));
   if (identity.metadata.provider !== "oidc") {
-    return json({ error: "app sessions require OIDC sign-in" }, 403);
+    return timing.apply(json({ error: "app sessions require OIDC sign-in" }, 403));
   }
 
-  const cookie = await createCloudAppSessionCookie(env, identity);
+  const cookie = await timing.time("cookie_create", () =>
+    createCloudAppSessionCookie(env, identity),
+  );
   const response = json({
     ok: true,
     expires_in: NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
   });
   response.headers.append("Set-Cookie", cookie);
-  return response;
+  return timing.apply(response);
 }
 
 async function hostSessionAppSessionCookie(

--- a/apps/notebook-cloud/test/cloud-auth-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-auth-store.test.ts
@@ -400,6 +400,212 @@ describe("CloudAuthStore app-session establish driver", () => {
   });
 });
 
+describe("CloudAuthStore session diet (GET-first)", () => {
+  it("mounts with a live cookie session on one status GET and zero establish POSTs", async () => {
+    const scheduler = newScheduler();
+    const focus$ = new Subject<void>();
+    const visible$ = new Subject<boolean>();
+    let getCalls = 0;
+    let establishCalls = 0;
+    const live = appSession({ expires_at: 100_000 });
+    const store = new CloudAuthStore({ readAuthState: oidcAuth });
+
+    const dispose = store.activate(
+      { authConfig: { oidc: null, localDev: null }, initialSession: null },
+      baseDeps({
+        scheduler,
+        windowFocus$: focus$,
+        documentVisible$: visible$,
+        readAppSessionStatus: async () => {
+          getCalls += 1;
+          return { ok: true, session: live };
+        },
+        establishAppSession: async () => {
+          establishCalls += 1;
+        },
+      }),
+    );
+    await drainMicrotasks();
+    advanceBy(scheduler, 0);
+    await drainMicrotasks();
+
+    // Cadence ticks, focus, and a visibility rise: the live session keeps
+    // covering the page, so nothing re-validates upstream.
+    advanceBy(scheduler, 60_000);
+    await drainMicrotasks();
+    focus$.next();
+    visible$.next(false);
+    visible$.next(true);
+    await drainMicrotasks();
+
+    assert.equal(getCalls, 1);
+    assert.equal(establishCalls, 0);
+    assert.equal(store.appSessionSnapshot.session, live);
+
+    dispose();
+  });
+
+  it("mounts with a fresh bootstrap session on zero session fetches of any kind", async () => {
+    const scheduler = newScheduler();
+    let getCalls = 0;
+    let establishCalls = 0;
+    const store = new CloudAuthStore({ readAuthState: oidcAuth });
+
+    const dispose = store.activate(
+      {
+        authConfig: { oidc: null, localDev: null },
+        initialSession: appSession({ expires_at: 100_000 }),
+      },
+      baseDeps({
+        scheduler,
+        readAppSessionStatus: async () => {
+          getCalls += 1;
+          return { ok: true, session: appSession({ expires_at: 100_000 }) };
+        },
+        establishAppSession: async () => {
+          establishCalls += 1;
+        },
+      }),
+    );
+    await drainMicrotasks();
+    advanceBy(scheduler, 0);
+    advanceBy(scheduler, 60_000);
+    await drainMicrotasks();
+
+    assert.equal(getCalls, 0);
+    assert.equal(establishCalls, 0);
+
+    dispose();
+  });
+
+  it("renews an expiring session through the status GET, not an establish POST", async () => {
+    const scheduler = newScheduler();
+    let getCalls = 0;
+    let establishCalls = 0;
+    // Inside the 30-minute renewal window but still fresh: present, expiring.
+    const expiring = appSession({ expires_at: 1_000 });
+    const renewed = appSession({ expires_at: 100_000 });
+    const store = new CloudAuthStore({ readAuthState: oidcAuth });
+
+    const dispose = store.activate(
+      { authConfig: { oidc: null, localDev: null }, initialSession: expiring },
+      baseDeps({
+        scheduler,
+        readAppSessionStatus: async () => {
+          getCalls += 1;
+          return { ok: true, session: renewed };
+        },
+        establishAppSession: async () => {
+          establishCalls += 1;
+        },
+      }),
+    );
+    await drainMicrotasks();
+
+    // The boot tick sees the expiring session: the GET is the renewal (the
+    // server slides the cookie on GET).
+    advanceBy(scheduler, 0);
+    await drainMicrotasks();
+    assert.equal(getCalls, 1);
+    assert.equal(establishCalls, 0);
+    assert.equal(store.appSessionSnapshot.session, renewed);
+
+    // Once renewed, later ticks cost nothing.
+    advanceBy(scheduler, 60_000);
+    await drainMicrotasks();
+    assert.equal(getCalls, 1);
+    assert.equal(establishCalls, 0);
+
+    dispose();
+  });
+
+  it("falls back to exactly one establish POST when the GET reports no session", async () => {
+    const scheduler = newScheduler();
+    let getCalls = 0;
+    let establishCalls = 0;
+    const established = appSession({ expires_at: 100_000 });
+    const store = new CloudAuthStore({ readAuthState: oidcAuth });
+
+    const dispose = store.activate(
+      { authConfig: { oidc: null, localDev: null }, initialSession: null },
+      baseDeps({
+        scheduler,
+        readAppSessionStatus: async () => {
+          getCalls += 1;
+          return { ok: true, session: getCalls === 1 ? null : established };
+        },
+        establishAppSession: async () => {
+          establishCalls += 1;
+        },
+      }),
+    );
+    // Initial GET reports no session; the settle edge fires the one fallback
+    // POST, whose completion refetches status and lands the session.
+    await drainMicrotasks();
+    assert.equal(establishCalls, 1);
+    assert.equal(getCalls, 2);
+    assert.equal(store.appSessionSnapshot.session, established);
+
+    advanceBy(scheduler, 0);
+    advanceBy(scheduler, 60_000);
+    await drainMicrotasks();
+    assert.equal(establishCalls, 1);
+    assert.equal(getCalls, 2);
+
+    dispose();
+  });
+
+  it("drops an establish completion that lands after dispose (stale epoch)", async () => {
+    let getCalls = 0;
+    let establishCalls = 0;
+    let resolveEstablish: (() => void) | undefined;
+    const store = new CloudAuthStore({ readAuthState: oidcAuth });
+
+    const dispose = store.activate(
+      { authConfig: { oidc: null, localDev: null }, initialSession: null },
+      baseDeps({
+        scheduler: newScheduler(),
+        readAppSessionStatus: async () => {
+          getCalls += 1;
+          return { ok: true, session: null };
+        },
+        establishAppSession: () => {
+          establishCalls += 1;
+          return new Promise<void>((resolve) => {
+            resolveEstablish = resolve;
+          });
+        },
+      }),
+    );
+    await drainMicrotasks();
+    assert.equal(establishCalls, 1);
+    const getCallsBeforeDispose = getCalls;
+
+    dispose();
+    resolveEstablish?.();
+    await drainMicrotasks();
+    // The stale completion must not adopt the token or refetch status.
+    assert.equal(getCalls, getCallsBeforeDispose);
+
+    // A fresh activation still treats the token as never-established, so the
+    // fallback POST fires again instead of being swallowed by adopted state.
+    const disposeSecond = store.activate(
+      { authConfig: { oidc: null, localDev: null }, initialSession: null },
+      baseDeps({
+        scheduler: newScheduler(),
+        readAppSessionStatus: async () => ({ ok: true, session: null }),
+        establishAppSession: async () => {
+          establishCalls += 1;
+        },
+      }),
+    );
+    await drainMicrotasks();
+    assert.equal(establishCalls, 2);
+
+    disposeSecond();
+  });
+});
+
 describe("CloudAuthStore renewal notice", () => {
   it("refreshAuthState clears a stale failure once storage no longer needs a refresh", async () => {
     const scheduler = newScheduler();

--- a/apps/notebook-cloud/test/cloud-session-auth-stability.test.ts
+++ b/apps/notebook-cloud/test/cloud-session-auth-stability.test.ts
@@ -17,6 +17,13 @@ function authState(overrides: Partial<CloudPrototypeAuthState> = {}): CloudProto
   };
 }
 
+/** Advance a flushed scheduler's virtual clock by `ms`, stopping at the target frame. */
+function advance(scheduler: VirtualTimeScheduler, ms: number): void {
+  scheduler.maxFrames = scheduler.frame + ms;
+  scheduler.schedule(() => {}, ms);
+  scheduler.flush();
+}
+
 /** Deps whose timers never fire (the scheduler is never flushed) and whose
  *  network operations are inert, so activate() only seeds synchronous state. */
 function inertDeps(session: CloudAppSession | null): CloudAuthStoreDeps {
@@ -88,6 +95,39 @@ describe("cloud session auth stability (store projections)", () => {
 
     assert.equal(keys.at(-1), "app-session");
     sub.unsubscribe();
+    dispose();
+  });
+
+  it("adopts a live cookie session across OIDC token churn without an establish POST", () => {
+    let current = authState({ token: "token-a" });
+    let establishCalls = 0;
+    const session: CloudAppSession = {
+      provider: "oidc",
+      expires_at: 100_000,
+      cache_key: "cache-a",
+    };
+    const store = new CloudAuthStore({ readAuthState: () => current });
+    const scheduler = new VirtualTimeScheduler(VirtualAction, Infinity);
+
+    const dispose = store.activate(
+      { authConfig: { oidc: null, localDev: null }, initialSession: session },
+      {
+        ...inertDeps(session),
+        scheduler,
+        establishAppSession: async () => {
+          establishCalls += 1;
+        },
+      },
+    );
+
+    // Boot tick adopts the live session; a token rotation alone must not
+    // re-validate upstream while the cookie still covers the page.
+    advance(scheduler, 0);
+    current = authState({ token: "token-b" });
+    store.refreshAuthState();
+    advance(scheduler, 60_000);
+
+    assert.equal(establishCalls, 0);
     dispose();
   });
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -766,15 +766,20 @@ test("cloud auth store re-establishes and refreshes cookie-backed state after OI
   );
 });
 
-test("cloud notebook list refresh re-establishes app sessions before listing notebooks", () => {
+test("cloud notebook list refresh stays on the GET-first session path", () => {
   const routeSourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
   const routeSourceText = readFileSync(routeSourcePath, "utf8");
 
-  assert.match(routeSourceText, /import \{ clearCloudAppSession, establishCloudAppSession \}/);
+  assert.match(routeSourceText, /import \{ clearCloudAppSession \}/);
   assert.match(
     routeSourceText,
-    /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*establishCloudAppSession\(authState\)[\s\S]*auth\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
-    "manual notebook-list refresh should re-run the trusted session exchange so pending invites can resolve",
+    /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*auth\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
+    "manual notebook-list refresh reads session status; pending invites resolve on the cookie-authenticated list fetch itself (syncStoredAppSessionProfile)",
+  );
+  assert.doesNotMatch(
+    routeSourceText,
+    /establishCloudAppSession/,
+    "the list view never re-validates upstream with an establish POST; the missing-session fallback lives in the auth store",
   );
 });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -699,6 +699,14 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(cookie, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.doesNotMatch(cookie, /session@example\.test/);
     assert.deepEqual(await response.json(), { ok: true, expires_in: 21_600 });
+
+    // Server-Timing explains where a slow exchange spends its time: upstream
+    // auth validation, profile sync, and cookie signing, each phased.
+    const serverTiming = response.headers.get("Server-Timing") ?? "";
+    assert.match(serverTiming, /(^|, )auth_validate;dur=\d+/);
+    assert.match(serverTiming, /(^|, )profile_sync;dur=\d+/);
+    assert.match(serverTiming, /(^|, )cookie_create;dur=\d+/);
+    assert.match(serverTiming, /(^|, )total;dur=\d+/);
   });
 
   it("reads app session cookie status without exposing identity credentials", async () => {
@@ -735,6 +743,14 @@ describe("Worker artifact routes", () => {
     assert.equal(body.session?.provider, "oidc");
     assert.equal(typeof body.session?.expires_at, "number");
     assert.equal(typeof body.session?.cache_key, "string");
+
+    // The GET never validates upstream: its Server-Timing phases are the
+    // cookie read and the sliding renewal, not auth_validate.
+    const serverTiming = response.headers.get("Server-Timing") ?? "";
+    assert.match(serverTiming, /(^|, )session_read;dur=\d+/);
+    assert.match(serverTiming, /(^|, )renew_cookie;dur=\d+/);
+    assert.match(serverTiming, /(^|, )total;dur=\d+/);
+    assert.doesNotMatch(serverTiming, /auth_validate/);
   });
 
   it("bootstraps an app session from a configured host session", async (t) => {
@@ -794,6 +810,11 @@ describe("Worker artifact routes", () => {
     assert.equal(typeof body.session?.expires_at, "number");
     assert.equal(typeof body.session?.cache_key, "string");
     assert.equal(env.DB.profiles.get("user:example:session%2Fcookie%20user")?.email_verified, 1);
+    assert.match(
+      response.headers.get("Server-Timing") ?? "",
+      /(^|, )host_bootstrap;dur=\d+/,
+      "host-session bootstrap must report its upstream identity phase",
+    );
   });
 
   for (const [label, claims] of [
@@ -1530,6 +1551,10 @@ describe("Worker artifact routes", () => {
     assert.match(cookie, /HttpOnly/);
     assert.match(cookie, /Secure/);
     assert.match(cookie, /SameSite=Lax/);
+
+    // The DELETE handler is a cookie clear with no awaited work: a near-zero
+    // total against a slow trace points upstream of the handler.
+    assert.match(response.headers.get("Server-Timing") ?? "", /(^|, )total;dur=\d+/);
   });
 
   it("serves the viewer runtimed WASM asset through the Worker assets binding", async () => {

--- a/apps/notebook-cloud/viewer/__tests__/oidc-callback-standalone.test.ts
+++ b/apps/notebook-cloud/viewer/__tests__/oidc-callback-standalone.test.ts
@@ -140,6 +140,32 @@ describe("standalone OIDC callback entry", () => {
     expect(navigation.replace).toHaveBeenCalledWith("/n/private-demo");
   });
 
+  it("POSTs /api/auth/session exactly once on a successful callback", async () => {
+    const requests: Array<{ method: string; url: string }> = [];
+
+    startOidcCallback({
+      authConfig,
+      completeOidcRedirect: async () => ({ returnUrl: "/n/private-demo", token: oidcToken() }),
+      establishAppSession: (token, deps) =>
+        establishCloudAppSessionFromOidcTokenWithRetry(token, deps),
+      fetchImpl: async (input, init) => {
+        requests.push({ method: init?.method ?? "GET", url: String(input) });
+        return new Response(null, { status: 200 });
+      },
+      location,
+      navigate: navigation,
+      root,
+      sleep: async () => {},
+      storage,
+      timeoutSignal: stableTimeoutSignal,
+    });
+
+    await waitFor(() => expect(navigation.replace).toHaveBeenCalledWith("/n/private-demo"));
+    // The callback is one of the two allowed establish POST sites (the other
+    // is the auth store's missing-session fallback); it never doubles up.
+    expect(requests).toEqual([{ method: "POST", url: "/api/auth/session" }]);
+  });
+
   it("still returns to the callback return URL when app-session retry fails twice", async () => {
     let fetchCalls = 0;
 

--- a/apps/notebook-cloud/viewer/cloud-auth-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-auth-store.ts
@@ -1,8 +1,8 @@
 /**
  * Cloud viewer auth store: the single owner of prototype auth state, the
  * app-session view state, and the OIDC renewal notice, plus the drivers that
- * keep them fresh (OIDC token refresh, app-session status fetch, app-session
- * establish/bridge).
+ * keep them fresh (OIDC token refresh, app-session status fetch, and the
+ * GET-first app-session renewal with its fallback establish POST).
  *
  * Three module-level `BehaviorSubject`s, seeded synchronously at construction.
  * `cloudInstantPaintPrincipalMatcher` reads `authSnapshot`/`appSessionSnapshot`
@@ -71,10 +71,10 @@ import {
 } from "./oidc-auth";
 import { cloudAppSessionsEqual, type CloudAppSessionViewState } from "./use-cloud-auth";
 
-/** Cadence of the OIDC refresh and app-session establish timers. */
+/** Cadence of the OIDC refresh and app-session renewal drivers. */
 const AUTH_REFRESH_INTERVAL_MS = 60_000;
 
-/** Establish is not retried for an unchanged token inside this window. */
+/** The fallback establish POST is not retried for an unchanged token inside this window. */
 const ESTABLISH_BACKOFF_SECONDS = 5 * 60;
 
 const RENEWAL_IDLE: CloudAuthRenewalState = { kind: "idle", message: null };
@@ -250,6 +250,13 @@ export class CloudAuthStore {
   private establishedToken: string | null = null;
   private lastEstablishAtSeconds = 0;
   private establishInFlight: Promise<void> | null = null;
+  /**
+   * Activation epoch: bumped by `activate()` and its disposer. Async
+   * completions capture it at issue and drop their writes when it no longer
+   * matches, so work from a torn-down activation cannot mutate the module
+   * singleton's state.
+   */
+  private activationEpoch = 0;
 
   constructor(options: CloudAuthStoreOptions = {}) {
     this.readAuthState = options.readAuthState ?? cloudPrototypeAuthFromWindow;
@@ -335,6 +342,7 @@ export class CloudAuthStore {
    * virtual time and injected fakes.
    */
   activate(config: CloudAuthStoreConfig, deps: CloudAuthStoreDeps = {}): () => void {
+    this.activationEpoch += 1;
     this.authConfig = config.authConfig;
     this.autoRefreshOidc = config.autoRefreshOidc !== false;
     this.appSessionRefreshFallback = config.appSessionRefreshFallback === true;
@@ -406,9 +414,10 @@ export class CloudAuthStore {
         .subscribe(),
     );
 
-    // App-session establish/bridge: `renewIfNeeded` guards single-flight, token
-    // change, backoff, and renewal skew internally, so a plain trigger stream
-    // is enough.
+    // App-session renewal: GET-first. `renewIfNeeded` adopts a live cookie
+    // session without any network call, renews an expiring one through the
+    // status GET (the server slides the cookie on GET), and only falls back
+    // to the establish POST when the fetched status reports no session.
     subscription.add(
       merge(
         timer(0, AUTH_REFRESH_INTERVAL_MS, scheduler),
@@ -422,7 +431,10 @@ export class CloudAuthStore {
       this._appSessionFetch$.next();
     }
 
-    return () => subscription.unsubscribe();
+    return () => {
+      this.activationEpoch += 1;
+      subscription.unsubscribe();
+    };
   }
 
   private seedAppSession(initialSession: CloudAppSession | null): void {
@@ -465,6 +477,7 @@ export class CloudAuthStore {
   }
 
   private async runRefreshOidc(): Promise<void> {
+    const epoch = this.activationEpoch;
     const oidc = this.authConfig?.oidc ?? null;
     // The configured flag is the "refresh even without an app session" intent
     // (the notebook route enables it only for edit-mode links). An existing app
@@ -493,11 +506,20 @@ export class CloudAuthStore {
         storage: this.oidcStorage,
         nowSeconds: this.nowSeconds(),
       });
+      if (epoch !== this.activationEpoch) {
+        return;
+      }
       this.refreshAuthState();
       this.setRenewal(RENEWAL_IDLE);
     } catch (error) {
+      if (epoch !== this.activationEpoch) {
+        return;
+      }
       if (this.appSessionRefreshFallback) {
         const status = await this.readAppSessionStatusOp().catch(() => null);
+        if (epoch !== this.activationEpoch) {
+          return;
+        }
         if (cloudAppSessionIsFresh(status?.session, this.nowSeconds())) {
           console.warn(
             "[notebook-cloud] OIDC session refresh failed; continuing with app session cookie",
@@ -514,6 +536,15 @@ export class CloudAuthStore {
     }
   }
 
+  /**
+   * GET-first session diet. A page holding a live cookie session makes zero
+   * establish POSTs: the token is adopted as covered, and later OIDC token
+   * rotation alone never re-validates upstream. A present-but-expiring
+   * session renews through the status GET, whose response slides the cookie
+   * server-side. The establish POST is the fallback for exactly one case:
+   * the fetched status reported no session while the client holds a valid
+   * OIDC token.
+   */
   private renewIfNeeded(): void {
     const authState = this._authState$.getValue();
     if (authState.mode !== "oidc" || !authState.token) {
@@ -525,11 +556,18 @@ export class CloudAuthStore {
       return;
     }
     const nowSeconds = this.nowSeconds();
-    const tokenChanged = this.establishedToken !== authState.token;
-    const sessionNeedsRenewal = cloudAppSessionNeedsRenewal(view.session, nowSeconds);
-    if (!tokenChanged && !sessionNeedsRenewal) {
+    if (!cloudAppSessionNeedsRenewal(view.session, nowSeconds)) {
+      this.establishedToken = authState.token;
       return;
     }
+    if (view.session) {
+      // Inside the renewal window with a session still present: the GET is
+      // the renewal. If the session actually lapsed, the fetched null routes
+      // the next trigger into the fallback POST below.
+      this.refreshAppSessionStatus();
+      return;
+    }
+    const tokenChanged = this.establishedToken !== authState.token;
     if (this.establishInFlight) {
       return;
     }
@@ -537,9 +575,13 @@ export class CloudAuthStore {
       return;
     }
 
+    const epoch = this.activationEpoch;
     this.lastEstablishAtSeconds = nowSeconds;
     this.establishInFlight = this.establishAppSessionOp(authState)
       .then(() => {
+        if (epoch !== this.activationEpoch) {
+          return;
+        }
         this.establishedToken = authState.token;
         this.refreshAppSessionStatus();
       })

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -35,7 +35,7 @@ import {
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { cloudResponseError } from "./cloud-response";
-import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
+import { clearCloudAppSession } from "./app-session";
 import {
   CloudNotebookDashboard,
   CloudNotebookDashboardSearchInput,
@@ -244,16 +244,11 @@ export function CloudNotebookListView({
   ]);
 
   const refreshList = () => {
+    // GET-first session diet: the status GET renews the cookie server-side
+    // and the auth store's fallback establish covers a truly missing session,
+    // so a manual refresh never re-validates upstream with a POST.
     if (authState.mode === "oidc" && authState.token) {
-      void establishCloudAppSession(authState)
-        .catch((error: unknown) => {
-          console.warn("[notebook-cloud] app session refresh before notebook list failed", error);
-        })
-        .finally(() => {
-          auth.refreshAppSessionStatus();
-          setRefreshIndex((value) => value + 1);
-        });
-      return;
+      auth.refreshAppSessionStatus();
     }
     setRefreshIndex((value) => value + 1);
   };


### PR DESCRIPTION
A production trace of one logout, login, and notebook open shows nine /api/auth/session calls costing ~7.2s, because page mounts POST and the POST handler validates upstream on every call (docs/audits/cloud-login-flow-2026-07-15.md). This puts the session flow on a diet with three invariants. A page mount with a live cookie session costs at most one status GET and zero establish POSTs: the auth store adopts the token when the fetched session is fresh, so OIDC token rotation alone never re-validates upstream, and a fresh bootstrap session delivered with the page costs no session fetch at all. The establish POST happens in exactly two places: the OIDC callback exchange, and the store's fallback when the status GET reports no session while the client holds a valid OIDC token. A present-but-expiring session renews through the status GET, which already slides the cookie server-side, instead of re-validating upstream.

The store's establish completion and the OIDC refresh driver's post-await writes now capture the activation epoch at issue and drop their writes when it no longer matches, so work from a torn-down activation cannot mutate the module singleton. The manual notebook-list refresh drops its establish POST and reads status through the store; pending invites still resolve because the cookie-authenticated list fetch runs syncStoredAppSessionProfile itself. The OIDC refresh cadence is unchanged.

routeAppSession responses now carry Server-Timing with stable metric names so session latency explains itself in any future trace: session_read, host_bootstrap, and renew_cookie on GET; auth_validate, profile_sync, and cookie_create on POST; total on every method. Cloudflare advances Date.now() only across I/O, so a near-zero total against a slow trace points at scheduling upstream of the handler, which is where the 2.8s DELETE for a three-line cookie-clear has to live. Wire shapes, cookie semantics, and OIDC token handling are unchanged.

