### PR TITLE
fix(cloud): flatten decorative gradients to solid tints

### DIFF
--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -105,6 +105,19 @@ section and `docs/adr/frontend-sync-bridge.md` Decision 8 before editing
   `test` script will not catch it. Full pattern: frontend-dev skill,
   "Module-Singleton Source Stores".
 
+## Visual language
+
+Cloud chrome is flat and Ink-forward. State tints are single solid
+`color-mix(...)` values; decorative gradients are prototype-era residue and
+must not be reintroduced, including when mirroring existing atoms into new
+surfaces (that is how they propagate). The one sanctioned gradient is the
+`.cloud-startup-line` skeleton shimmer, which is motion, not decoration.
+Separators are `border-top`/`border-right` hairlines with tinted washes, not
+raised cards or drop shadows. Standalone entries that skip the viewer
+stylesheet (the OIDC callback) carry mirrored tokens from
+`src/styles/notebook-base.css`; keep them in sync when the host chrome
+retunes.
+
 ## Verification
 
 Use the narrowest relevant command:

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -223,12 +223,7 @@ body {
   border: 0;
   border-radius: 0;
   padding: 0.5rem clamp(0.5rem, 2vw, 1rem) 0.5rem clamp(0.75rem, 4vw, 2rem);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, currentColor 9%, var(--background)) 0%,
-    color-mix(in srgb, currentColor 4%, var(--background)) 42%,
-    var(--background) 100%
-  );
+  background: color-mix(in srgb, currentColor 6%, var(--background));
 }
 
 @keyframes cloud-notice-enter {
@@ -2100,12 +2095,7 @@ body {
   --cloud-home-panel-wash: color-mix(in srgb, #10b981 5%, var(--background));
   border-top: 1px solid var(--cloud-home-panel-border);
   padding: 0.75rem 0.25rem;
-  background: linear-gradient(
-    180deg,
-    var(--cloud-home-panel-wash) 0%,
-    color-mix(in srgb, var(--background) 98%, transparent) 64%,
-    transparent 100%
-  );
+  background: var(--cloud-home-panel-wash);
 }
 
 .cloud-home-panel[data-mode="anonymous"],

--- a/apps/notebook-cloud/viewer/oidc-callback-standalone.ts
+++ b/apps/notebook-cloud/viewer/oidc-callback-standalone.ts
@@ -392,12 +392,7 @@ body {
 .cloud-oidc-panel {
   --cloud-oidc-panel-border: color-mix(in srgb, #10b981 68%, transparent);
   --cloud-oidc-panel-wash: color-mix(in srgb, #10b981 5%, var(--background));
-  background: linear-gradient(
-    180deg,
-    var(--cloud-oidc-panel-wash) 0%,
-    color-mix(in srgb, var(--background) 98%, transparent) 64%,
-    transparent 100%
-  );
+  background: var(--cloud-oidc-panel-wash);
   border-top: 1px solid var(--cloud-oidc-panel-border);
   display: grid;
   gap: 0.875rem;


### PR DESCRIPTION
Three decorative gradients flatten to solid `color-mix` tints: the cloud-home panel wash, the notebook-notices vertical fade, and the sign-in callback panel that inherited the wash by mirroring the home atoms. The `.cloud-startup-line` skeleton shimmer stays, since it is motion rather than decoration.

The systemic half: a new "Visual language" section in `apps/notebook-cloud/AGENTS.md` names the flat-tint rule and the propagation mechanism (agents mirror existing atoms into new surfaces, so prototype-era gradients kept reproducing). Also records the mirrored-token contract for standalone entries that skip the viewer stylesheet.
