### PR TITLE
docs(audits): mark cloud-login session diet landed

### DIFF
--- a/docs/audits/cloud-login-flow-2026-07-15.md
+++ b/docs/audits/cloud-login-flow-2026-07-15.md
@@ -37,7 +37,7 @@ The first-party signed-out page (the "Sign in with Anaconda" screen) predates th
 
 ## Sequencing
 
-1. Session diet (this audit's companion PRs): client GET-first bootstrap, single POST at OIDC callback, worker instrumentation for the slow POST/DELETE.
+1. Session diet. LANDED (#4056, validated live on preview): client GET-first bootstrap, single POST at OIDC callback, `Server-Timing` instrumentation on the worker. Session calls across the full logout/login/open flow dropped from nine to three; signed-in mounts and post-callback reloads make zero.
 2. Immutable cache headers on hashed assets; SPA route for notebook open (app-shell arc).
 3. Sync-socket concurrency + DO wake measurement (progressive-connect arc).
 4. Dedup fixes (discovery, blobs, theme frame) as they are found in code.


### PR DESCRIPTION
Marks the session-diet recommendation (sequencing item 1) as landed in #4056, validated live on preview: nine session calls became three across the full logout/login/open flow. Items 2-5 (immutable cache headers + SPA notebook route, sync-socket concurrency + DO-wake metric, dedup fixes, signed-out page redesign) stay tracked to their arcs.
