### PR TITLE
fix(runtimed): surface conda warm-env failures and raise the Windows timeout

### DIFF
--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -253,6 +253,7 @@ export default function App() {
     const envLabel = PYTHON_ENV_LABELS[pythonEnv];
     setSelectedPoolReady(false);
     setPoolWaitTimedOut(false);
+    setErrorMessage(null);
     setSteps((prev) =>
       prev.map((s) =>
         s.id === "tools"
@@ -372,6 +373,7 @@ export default function App() {
     setPythonEnv(selected);
     setSelectedPoolReady(false);
     setPoolWaitTimedOut(false);
+    setErrorMessage(null);
     setSteps((prev) =>
       prev.map((s) =>
         s.id === "tools"

--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -6,7 +6,13 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "@/components/environment";
-import { isOnboardingPoolReady, type OnboardingPoolState, type PythonEnv } from "./pool-readiness";
+import {
+  hasOnboardingPoolError,
+  isOnboardingPoolReady,
+  onboardingPoolErrorMessage,
+  type OnboardingPoolState,
+  type PythonEnv,
+} from "./pool-readiness";
 import type { DaemonStatus } from "./types";
 
 type Runtime = "python" | "deno";
@@ -268,10 +274,28 @@ export default function App() {
 
           if (isOnboardingPoolReady(pythonEnv, state)) {
             setSelectedPoolReady(true);
+            setErrorMessage(null);
             setSteps((prev) =>
               prev.map((s) =>
                 s.id === "tools"
                   ? { ...s, label: `${envLabel} runtime ready`, status: "completed" }
+                  : s,
+              ),
+            );
+            return;
+          }
+
+          // A recorded warm-env failure means the daemon hit a real problem
+          // (bad package, import error, timeout, missing runtime). Surface it
+          // instead of spinning on "warming" until the poll cap — the daemon
+          // keeps retrying with backoff, so the user can still continue.
+          if (hasOnboardingPoolError(pythonEnv, state)) {
+            setPoolWaitTimedOut(true);
+            setErrorMessage(onboardingPoolErrorMessage(envLabel, selected));
+            setSteps((prev) =>
+              prev.map((s) =>
+                s.id === "tools"
+                  ? { ...s, label: `${envLabel} runtime setup failed`, status: "failed" }
                   : s,
               ),
             );

--- a/apps/notebook/onboarding/pool-readiness.ts
+++ b/apps/notebook/onboarding/pool-readiness.ts
@@ -4,6 +4,16 @@ export type OnboardingPoolRuntimeState = {
   available?: number;
   warming?: number;
   pool_size?: number;
+  /** Human-readable error message from the daemon (absent if healthy). */
+  error?: string;
+  /** Package that failed to install, when the daemon could identify one. */
+  failed_package?: string;
+  /** Error classification: "timeout" | "invalid_package" | "import_error" | "setup_failed". */
+  error_kind?: string;
+  /** Consecutive warm-env failures (0 if healthy). */
+  consecutive_failures?: number;
+  /** Seconds until the daemon retries warming (0 if imminent or healthy). */
+  retry_in_secs?: number;
 };
 
 export type OnboardingPoolState = Partial<Record<PythonEnv, OnboardingPoolRuntimeState>>;
@@ -17,4 +27,35 @@ export function isOnboardingPoolReady(pythonEnv: PythonEnv, state: OnboardingPoo
   }
 
   return (selected.available ?? 0) > 0;
+}
+
+/**
+ * A pool has surfaced a real failure the user should see (rather than a
+ * transient "still warming"). True when the daemon recorded at least one
+ * warm-env failure and no environment is available yet.
+ */
+export function hasOnboardingPoolError(pythonEnv: PythonEnv, state: OnboardingPoolState): boolean {
+  const selected = state[pythonEnv];
+  if (!selected) return false;
+  if (isOnboardingPoolReady(pythonEnv, state)) return false;
+  return (selected.consecutive_failures ?? 0) > 0 && Boolean(selected.error);
+}
+
+/**
+ * Build a user-facing message from a failed pool's error fields.
+ */
+export function onboardingPoolErrorMessage(
+  envLabel: string,
+  selected: OnboardingPoolRuntimeState,
+): string {
+  if (selected.error_kind === "invalid_package" && selected.failed_package) {
+    return `${envLabel} setup failed: package "${selected.failed_package}" could not be installed.`;
+  }
+  if (selected.error_kind === "timeout") {
+    return `${envLabel} setup timed out. This can happen on a slow network — it will keep retrying in the background.`;
+  }
+  const detail = selected.error?.trim();
+  return detail
+    ? `${envLabel} setup failed: ${detail}`
+    : `${envLabel} setup failed. It will keep retrying in the background.`;
 }

--- a/apps/notebook/src/__tests__/onboarding-pool-readiness.test.ts
+++ b/apps/notebook/src/__tests__/onboarding-pool-readiness.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isOnboardingPoolReady } from "../../onboarding/pool-readiness";
+import {
+  hasOnboardingPoolError,
+  isOnboardingPoolReady,
+  onboardingPoolErrorMessage,
+} from "../../onboarding/pool-readiness";
 
 describe("onboarding pool readiness", () => {
   it("does not treat a warming selected pool as ready", () => {
@@ -32,5 +36,79 @@ describe("onboarding pool readiness", () => {
         uv: { available: 0, warming: 0, pool_size: 0 },
       }),
     ).toBe(true);
+  });
+});
+
+describe("onboarding pool error", () => {
+  it("flags a failed pool with a recorded error", () => {
+    expect(
+      hasOnboardingPoolError("conda", {
+        conda: {
+          available: 0,
+          warming: 0,
+          pool_size: 1,
+          consecutive_failures: 2,
+          error: "warm-env timed out after 900s",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag an error while still warming without a failure", () => {
+    expect(
+      hasOnboardingPoolError("conda", {
+        conda: { available: 0, warming: 1, pool_size: 1 },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag an error once an env is available", () => {
+    expect(
+      hasOnboardingPoolError("conda", {
+        conda: {
+          available: 1,
+          warming: 0,
+          pool_size: 1,
+          consecutive_failures: 3,
+          error: "stale error",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a failure with no recorded message", () => {
+    expect(
+      hasOnboardingPoolError("conda", {
+        conda: { available: 0, warming: 0, pool_size: 1, consecutive_failures: 1 },
+      }),
+    ).toBe(false);
+  });
+
+  it("names the failed package for invalid_package errors", () => {
+    expect(
+      onboardingPoolErrorMessage("Conda", {
+        error_kind: "invalid_package",
+        failed_package: "bogus-pkg",
+        error: "No solution found",
+      }),
+    ).toContain("bogus-pkg");
+  });
+
+  it("gives a network-friendly message for timeouts", () => {
+    const message = onboardingPoolErrorMessage("Conda", {
+      error_kind: "timeout",
+      error: "warm-env subprocess timed out after 900s",
+    });
+    expect(message).toContain("timed out");
+    expect(message).toContain("retrying");
+  });
+
+  it("falls back to the raw error detail", () => {
+    expect(
+      onboardingPoolErrorMessage("UV", {
+        error_kind: "setup_failed",
+        error: "disk full",
+      }),
+    ).toContain("disk full");
   });
 });

--- a/crates/kernel-env/AGENTS.md
+++ b/crates/kernel-env/AGENTS.md
@@ -110,6 +110,9 @@ The daemon maintains pre-created environments (base set + user's `default_packag
 - Warming loops replenish as environments are consumed
 - Pool entries named `runtimed-{uv,conda,pixi}-{uuid}`, content-free, claimable by any notebook
 
+Warm-env failures must surface in pool status with a real `error_kind` so
+onboarding does not spin forever waiting for `available > 0`.
+
 ### First-launch capture
 
 On first launch from pool:

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -6502,11 +6502,20 @@ impl Daemon {
             }
             Err(e) => {
                 error!("[runtimed] Conda warm-env subprocess failed: {}", e);
+                // A subprocess timeout is the #4017 signature (slow,
+                // download-dominated conda-forge install on Windows). Classify
+                // it as "timeout" so onboarding can show the retry-friendly
+                // message rather than a generic setup failure.
+                let error_kind = if e.contains("timed out") {
+                    "timeout"
+                } else {
+                    "setup_failed"
+                };
                 guard
                     .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: e,
-                        error_kind: "setup_failed".to_string(),
+                        error_kind: error_kind.to_string(),
                     }))
                     .await;
             }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -5623,6 +5623,48 @@ impl GcMarkSet {
 /// Disk is cheap; data loss isn't.
 pub(crate) const BLOB_GC_GRACE_SECS: u64 = 30 * 24 * 3600;
 
+/// Default overall timeout for a `runtimed warm-env` subprocess.
+///
+/// Covers the full solve + download + install + validate pipeline. On a slow
+/// machine or network, conda-forge downloads (win-64 pulls pywin32,
+/// vc14_runtime, etc.) can dominate this budget, so the value is intentionally
+/// generous and can be raised further via [`WARM_ENV_TIMEOUT_ENV`].
+pub(crate) const WARM_ENV_TIMEOUT_SECS: u64 = 900;
+
+/// Environment variable that overrides [`WARM_ENV_TIMEOUT_SECS`].
+///
+/// Field escape hatch for environments where the download-dominated conda
+/// install runs long (issue #4017 — slow/proxied home networks on Windows).
+pub(crate) const WARM_ENV_TIMEOUT_ENV: &str = "RUNTIMED_WARM_ENV_TIMEOUT_SECS";
+
+/// Effective warm-env subprocess timeout.
+///
+/// Reads [`WARM_ENV_TIMEOUT_ENV`] on each call. Invalid or zero values fall
+/// back to the compiled default with a warning.
+pub(crate) fn warm_env_timeout() -> std::time::Duration {
+    match std::env::var(WARM_ENV_TIMEOUT_ENV) {
+        Ok(val) => match val.parse::<u64>() {
+            Ok(secs) if secs > 0 => std::time::Duration::from_secs(secs),
+            _ => {
+                warn!(
+                    "[runtimed] warm-env: ignoring invalid {}={:?}, using default {}s",
+                    WARM_ENV_TIMEOUT_ENV, val, WARM_ENV_TIMEOUT_SECS
+                );
+                std::time::Duration::from_secs(WARM_ENV_TIMEOUT_SECS)
+            }
+        },
+        Err(_) => std::time::Duration::from_secs(WARM_ENV_TIMEOUT_SECS),
+    }
+}
+
+/// Take the accumulated warm-env stderr tail, trimmed, if any non-empty text
+/// was captured. Consumes the buffer so the message is only attached once.
+fn drain_stderr_tail(tail: &std::sync::Arc<std::sync::Mutex<String>>) -> Option<String> {
+    let captured = std::mem::take(&mut *tail.lock().ok()?);
+    let trimmed = captured.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 /// Environment variable that overrides [`BLOB_GC_GRACE_SECS`].
 ///
 /// Primarily for development and tests that want a short grace period to
@@ -6678,7 +6720,11 @@ impl Daemon {
     ///
     /// Config is sent as a single JSON object on the child's stdin.
     /// The child writes newline-delimited JSON events (progress + result) on
-    /// stdout. A 10-minute overall timeout kills the child if it hangs.
+    /// stdout. Its stderr (tracing logs, panics, native loader errors) is
+    /// captured and mirrored into the daemon log — the daemon is detached on
+    /// Windows, so inheriting stderr would drop those diagnostics on the floor
+    /// (issue #4017). A [`warm_env_timeout`]-bounded overall timeout kills the
+    /// child if it hangs.
     async fn spawn_warm_env(
         &self,
         env_type: EnvType,
@@ -6712,10 +6758,43 @@ impl Daemon {
             .arg("warm-env")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|e| format!("Failed to spawn warm-env: {e}"))?;
+
+        // Drain the child's stderr into the daemon log. Retain the tail so a
+        // failure result with no `error` field (e.g. the child was killed by a
+        // native loader error before it could emit one) can still surface a
+        // real message instead of a generic placeholder.
+        let stderr_tail = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let stderr_task = child.stderr.take().map(|stderr| {
+            let type_str = type_str.to_string();
+            let stderr_tail = stderr_tail.clone();
+            tokio::spawn(async move {
+                let mut lines = tokio::io::BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    warn!("[runtimed] warm-env {type_str} stderr: {line}");
+                    if let Ok(mut tail) = stderr_tail.lock() {
+                        tail.push_str(&line);
+                        tail.push('\n');
+                        // Keep only the last ~2 KiB so a chatty child cannot
+                        // grow this buffer without bound. Snap to a UTF-8 char
+                        // boundary so slicing multibyte stderr never panics.
+                        if tail.len() > 2048 {
+                            let mut start = tail.len() - 2048;
+                            while start < tail.len() && !tail.is_char_boundary(start) {
+                                start += 1;
+                            }
+                            *tail = tail[start..].to_string();
+                        }
+                    }
+                }
+            })
+        });
 
         // Write config to stdin and close it so the child can proceed.
         {
@@ -6738,7 +6817,7 @@ impl Daemon {
         let mut lines = tokio::io::BufReader::new(stdout).lines();
         let mut last_result: Option<crate::warm_env::WarmEnvResult> = None;
 
-        let timeout = std::time::Duration::from_secs(600);
+        let timeout = warm_env_timeout();
         let read_result = tokio::time::timeout(timeout, async {
             while let Ok(Some(line)) = lines.next_line().await {
                 match serde_json::from_str::<crate::warm_env::WarmEnvEvent>(&line) {
@@ -6760,12 +6839,26 @@ impl Daemon {
             // Kill before waiting — don't block on a wedged child.
             let _ = child.kill().await;
             let _ = child.wait().await;
-            return Err("warm-env subprocess timed out after 10 minutes".to_string());
+            if let Some(task) = stderr_task {
+                let _ = task.await;
+            }
+            let tail = drain_stderr_tail(&stderr_tail);
+            return Err(format!(
+                "warm-env subprocess timed out after {}s{}",
+                timeout.as_secs(),
+                tail.map(|t| format!("; last stderr: {t}"))
+                    .unwrap_or_default()
+            ));
         }
 
         let status = child.wait().await;
+        // The stderr drain finishes once the pipe closes on child exit; await
+        // it so the tail buffer is complete before we read it for diagnostics.
+        if let Some(task) = stderr_task {
+            let _ = task.await;
+        }
 
-        if let Some(result) = last_result {
+        if let Some(mut result) = last_result {
             // Treat non-zero exit as failure even if the child emitted a
             // success result (it may have crashed during teardown).
             if let Ok(s) = &status {
@@ -6775,13 +6868,28 @@ impl Daemon {
                     ));
                 }
             }
+            // A failure result that carries no usable message (child died
+            // before writing one) still deserves the captured stderr tail.
+            if !result.success
+                && result
+                    .error
+                    .as_ref()
+                    .is_none_or(|message| message.trim().is_empty())
+            {
+                result.error = drain_stderr_tail(&stderr_tail)
+                    .map(|tail| format!("warm-env {type_str} failed; stderr: {tail}"));
+            }
             return Ok(result);
         }
 
+        let tail = drain_stderr_tail(&stderr_tail);
+        let tail_suffix = tail.map(|t| format!("; stderr: {t}")).unwrap_or_default();
         match status {
-            Ok(s) if s.success() => Err("warm-env exited 0 but no result event on stdout".into()),
-            Ok(s) => Err(format!("warm-env exited with status {s}")),
-            Err(e) => Err(format!("Failed to wait on warm-env: {e}")),
+            Ok(s) if s.success() => Err(format!(
+                "warm-env exited 0 but no result event on stdout{tail_suffix}"
+            )),
+            Ok(s) => Err(format!("warm-env exited with status {s}{tail_suffix}")),
+            Err(e) => Err(format!("Failed to wait on warm-env: {e}{tail_suffix}")),
         }
     }
 
@@ -9545,6 +9653,53 @@ mod tests {
     async fn blob_gc_default_grace_is_thirty_days() {
         // Guard constant — changing it silently would undo spec 1.
         assert_eq!(BLOB_GC_GRACE_SECS, 30 * 24 * 3600);
+    }
+
+    #[tokio::test]
+    async fn warm_env_timeout_respects_env_override() {
+        std::env::set_var(WARM_ENV_TIMEOUT_ENV, "1234");
+        assert_eq!(warm_env_timeout(), std::time::Duration::from_secs(1234));
+
+        // Zero and garbage both fall back to the compiled default.
+        std::env::set_var(WARM_ENV_TIMEOUT_ENV, "0");
+        assert_eq!(
+            warm_env_timeout(),
+            std::time::Duration::from_secs(WARM_ENV_TIMEOUT_SECS)
+        );
+
+        std::env::set_var(WARM_ENV_TIMEOUT_ENV, "not-a-number");
+        assert_eq!(
+            warm_env_timeout(),
+            std::time::Duration::from_secs(WARM_ENV_TIMEOUT_SECS)
+        );
+
+        std::env::remove_var(WARM_ENV_TIMEOUT_ENV);
+        assert_eq!(
+            warm_env_timeout(),
+            std::time::Duration::from_secs(WARM_ENV_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn drain_stderr_tail_returns_none_when_empty_or_whitespace() {
+        let empty = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        assert_eq!(drain_stderr_tail(&empty), None);
+
+        let whitespace = std::sync::Arc::new(std::sync::Mutex::new("  \n\t ".to_string()));
+        assert_eq!(drain_stderr_tail(&whitespace), None);
+    }
+
+    #[test]
+    fn drain_stderr_tail_trims_and_consumes() {
+        let tail = std::sync::Arc::new(std::sync::Mutex::new(
+            "\nImportError: DLL load failed\n".to_string(),
+        ));
+        assert_eq!(
+            drain_stderr_tail(&tail).as_deref(),
+            Some("ImportError: DLL load failed")
+        );
+        // Consumed — a second drain yields nothing.
+        assert_eq!(drain_stderr_tail(&tail), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Fix conda warm-env: surface failures and raise the Windows timeout

Fixes #4017 — onboarding's "Checking Conda runtime" spins forever on Windows, with no clue why.

## Background: three processes

The daemon keeps a **pool of pre-built conda environments** (default size 1). Onboarding just polls until the pool has `available > 0`.

| Process | Role |
|---|---|
| **Onboarding UI** | React; polls pool status ~1/sec |
| **`runtimed` daemon** | Long-running background process; owns the pool |
| **`warm-env` child** | Short-lived subprocess the daemon spawns to build one env (download ~120 conda packages, then launch Python to validate) |

```mermaid
flowchart TD
    subgraph Desktop["Desktop app (Tauri + React)"]
        UI["Onboarding UI<br/>shows 'Checking Conda runtime'"]
    end
    subgraph Daemon["runtimed daemon"]
        Loop["warming loop<br/>keeps the pool full"]
        Spawn["spawn_warm_env()<br/>the PARENT side"]
        PoolDoc["Pool status<br/>available / error / error_kind ..."]
    end
    subgraph Child["warm-env CHILD process"]
        Work["solve + download + install<br/>conda packages, then launch python"]
    end

    UI -->|"polls pool status ~1/sec"| PoolDoc
    Loop -->|"pool empty → build one"| Spawn
    Spawn -->|"spawns subprocess"| Work
    Work -->|"stdout: JSON progress + result"| Spawn
    Work -.->|"stderr: the REAL error detail"| Spawn
    Spawn -->|"writes outcome"| PoolDoc
    PoolDoc -->|"available > 0 ⇒ unblock UI"| UI

    classDef bug fill:#ffe0e0,stroke:#d33,stroke-width:2px,color:#000
    class Work,Spawn bug
    linkStyle 4 stroke:#d33,stroke-width:2px
```
*Red = where the bug lives: the parent that spawns the child, and the child's stderr channel (dotted).*

## The bug

Two problems compounded into an eternal spinner with zero breadcrumbs:

- **Timeout too short.** The parent gave the child a hard **600s** budget. On Windows the conda download alone can exceed that (slow/proxied networks push it further). On timeout the child is killed, the pool never fills, and the UI polls `available = 0` forever.
- **Error invisible.** The child's stderr was **inherited** by the daemon. But the Windows daemon is detached (no console), so inherited stderr goes to `/dev/null` — the detailed failure reason was written and instantly discarded.

```mermaid
sequenceDiagram
    participant UI as Onboarding UI
    participant D as Daemon (parent)
    participant C as warm-env child

    D->>C: spawn — stderr = INHERIT ❌
    C->>C: download conda packages (slow on Windows)
    Note over C: download takes > 600s
    D->>D: 600s timeout fires ❌ too short
    D-->>C: kill the child
    Note over D: ❌ child stderr was inherited →<br/>went nowhere, daemon detached
    loop every ~1s, forever
        UI->>D: get pool status
        D-->>UI: available = 0
    end
    Note over UI: spins forever
```

## The fix

```mermaid
sequenceDiagram
    participant UI as Onboarding UI
    participant D as Daemon (parent)
    participant C as warm-env child
    participant Buf as Daemon log + 2KB tail buffer

    D->>C: spawn — stderr = PIPED ✅
    C-->>Buf: ✅ every stderr line captured live
    C->>C: download conda packages
    alt finishes within 900s (was 600s)
        C->>D: stdout result → success
        D->>UI: available = 1 ✅ spinner clears
    else exceeds 900s
        D->>D: 900s timeout fires, now configurable
        D-->>C: kill the child
        D->>Buf: read captured stderr tail
        D->>UI: ✅ error = timed out after 900s + captured stderr tail<br/>error_kind = timeout
        Note over UI: shows a real message,<br/>stops spinning, retries in background
    end
```

- **Capture stderr (headline fix).** Switched the child's stderr from *inherit* to *piped*. The parent now reads it line by line into the daemon log and keeps the last ~2KB, which backfills the error message when the child dies without a reason. The failure is now visible in both logs and pool status.
- **Raise + unlock the timeout.** 600s → **900s**, now overridable via `RUNTIMED_WARM_ENV_TIMEOUT_SECS` so a slow network can extend it without a rebuild. This lets a genuinely-slow-but-fine install finish.
- **Classify timeouts.** Timeouts were tagged as the generic `"setup_failed"`; now errors containing "timed out" get `error_kind: "timeout"`, so the frontend can show the correct "slow network, retrying" message.
- **Frontend reacts.** The UI previously treated "not ready" as "still warming." It now checks for a recorded failure and, if present, stops spinning and shows the message while the daemon keeps retrying with backoff.

## Verification

Verified **end-to-end on Windows through the real `runtimed` daemon** — not the old repro that called the child's conda logic directly and bypassed the parent (where all three fixes live).

- **Scenario 1 (forced short timeout):** pool status shows `error_kind: "timeout"` and the real rattler download logs captured in `error` — the stderr Windows used to drop. ✅
- **Scenario 2 (default 900s):** the same slow install completes; `available: 1`. ✅
- Rust unit tests (timeout override, stderr drain) + frontend tests green; `cargo xtask lint --fix` clean.
