### PR TITLE
fix(runtimed): restore full-coverage file checkpoints as staged baselines

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -234,9 +234,31 @@ impl RoomDurability {
             .as_ref()
             .filter(|tail| !tail.is_repairable_torn_suffix())
             .map(|tail| format!("recovery journal has preserved corrupt data: {tail:?}"));
+        let mut manifest = recovered.record.manifest;
+        // A checkpoint that exported every durable head proves the file on
+        // disk is a complete baseline for this journal, even when no import
+        // ever staged a source generation (a notebook created at a path is
+        // born without one; ordinary saves record checkpoints, not staged
+        // sources). Restore treats that manifest as durably staged so the
+        // room finalizes on the normal recovered path instead of failing
+        // materialization as source_degraded. A foreign disk write still
+        // fails finalization as a source conflict through the fingerprint
+        // check, and an unresolved checkpoint intent keeps its dedicated
+        // resolution path.
+        if degraded_reason.is_none()
+            && matches!(
+                manifest.source_phase,
+                super::recovery::RecoverySourcePhase::Pending
+                    | super::recovery::RecoverySourcePhase::Failed
+            )
+            && manifest.pending_file_checkpoint.is_none()
+            && manifest.file_checkpoint_covers_durable_heads()
+        {
+            manifest.source_phase = super::recovery::RecoverySourcePhase::DurablyStaged;
+        }
         Self::from_state(
             Some(journal),
-            recovered.record.manifest,
+            manifest,
             recovered.record.automerge_snapshot,
             true,
             degraded_reason,
@@ -1378,6 +1400,182 @@ mod tests {
             vec![change_hash]
         );
         assert_eq!(recovered.record.automerge_snapshot, snapshot);
+    }
+
+    /// A notebook created at a path never stages a source generation, so its
+    /// journal reads Pending with peer changes. When the file checkpoint
+    /// exported every durable head, the export is a complete baseline and
+    /// recovery must restore it as durably staged, not source_degraded.
+    #[test]
+    fn recovered_full_coverage_checkpoint_restores_as_staged_baseline() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(path.clone()),
+            source_fingerprint(b""),
+            0,
+            genesis,
+        );
+        let (snapshot, heads, _encoded_heads, change_hash) = snapshot_with_change(7);
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads.clone(),
+                DurableMutation::Peer {
+                    change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        let exported = source_fingerprint(b"exported ipynb bytes");
+        durability
+            .commit_file_checkpoint(path, exported, heads, 1)
+            .unwrap();
+        assert_eq!(
+            durability.manifest().source_phase,
+            RecoverySourcePhase::Pending
+        );
+
+        let recovered = match journal.load(exported).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        assert_eq!(
+            recovered.record.manifest.source_phase,
+            RecoverySourcePhase::Pending
+        );
+        let reloaded = RoomDurability::recovered(journal, recovered);
+        let manifest = reloaded.manifest();
+        assert_eq!(manifest.source_phase, RecoverySourcePhase::DurablyStaged);
+        assert!(manifest.file_checkpoint_covers_durable_heads());
+        // The restored baseline completes the normal recovered-source path.
+        reloaded.commit_source_ready(0).unwrap();
+        assert_eq!(reloaded.manifest().source_phase, RecoverySourcePhase::Ready);
+    }
+
+    /// A durable peer change committed after the last export means disk is a
+    /// stale prefix, not a complete baseline. Recovery must not claim it as
+    /// staged.
+    #[test]
+    fn recovered_checkpoint_with_unexported_tail_stays_pending() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "value", 1_i64).unwrap();
+        let first_snapshot = doc.save();
+        let first_heads = doc
+            .get_heads()
+            .iter()
+            .map(|head| head.0)
+            .collect::<Vec<_>>();
+        let first_hash = doc.get_changes(&[])[0].hash().0;
+        doc.put(ROOT, "value", 2_i64).unwrap();
+        let second_snapshot = doc.save();
+        let second_heads = doc
+            .get_heads()
+            .iter()
+            .map(|head| head.0)
+            .collect::<Vec<_>>();
+        let second_hash = doc
+            .get_changes(&[])
+            .iter()
+            .map(|change| change.hash().0)
+            .find(|hash| *hash != first_hash)
+            .unwrap();
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(path.clone()),
+            source_fingerprint(b""),
+            0,
+            genesis,
+        );
+        durability
+            .commit_snapshot(
+                &first_snapshot,
+                first_heads.clone(),
+                DurableMutation::Peer {
+                    change_hashes: vec![first_hash],
+                },
+            )
+            .unwrap();
+        let exported = source_fingerprint(b"exported ipynb bytes");
+        durability
+            .commit_file_checkpoint(path, exported, first_heads, 1)
+            .unwrap();
+        durability
+            .commit_snapshot(
+                &second_snapshot,
+                second_heads,
+                DurableMutation::Peer {
+                    change_hashes: vec![second_hash],
+                },
+            )
+            .unwrap();
+
+        let recovered = match journal.load(exported).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        let reloaded = RoomDurability::recovered(journal, recovered);
+        let manifest = reloaded.manifest();
+        assert!(!manifest.file_checkpoint_covers_durable_heads());
+        assert_eq!(manifest.source_phase, RecoverySourcePhase::Pending);
+    }
+
+    /// An unresolved checkpoint intent owns its recovery through
+    /// `resolve_recovered_file_checkpoint`; the baseline restore must not
+    /// preempt that resolution.
+    #[test]
+    fn recovered_pending_checkpoint_intent_is_not_claimed_as_baseline() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(path.clone()),
+            source_fingerprint(b""),
+            0,
+            genesis,
+        );
+        let (snapshot, heads, _encoded_heads, change_hash) = snapshot_with_change(7);
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads.clone(),
+                DurableMutation::Peer {
+                    change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        let exported = source_fingerprint(b"exported ipynb bytes");
+        durability
+            .prepare_file_checkpoint(path, exported, heads, 1, None)
+            .unwrap();
+
+        // The journal's latest record is the crash shape: an intent written
+        // before its commit marker.
+        let recovered = match journal.load(exported).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        assert!(recovered.record.manifest.pending_file_checkpoint.is_some());
+        let reloaded = RoomDurability::recovered(journal, recovered);
+        assert_eq!(
+            reloaded.manifest().source_phase,
+            RecoverySourcePhase::Pending
+        );
+        assert!(reloaded.manifest().pending_file_checkpoint.is_some());
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -1448,13 +1448,27 @@ mod tests {
             recovered.record.manifest.source_phase,
             RecoverySourcePhase::Pending
         );
-        let reloaded = RoomDurability::recovered(journal, recovered);
+
+        // No code path writes Failed today, but it is a serialized variant of
+        // the on-disk journal format, and restore already treats it exactly
+        // like Pending. The baseline promotion must cover it the same way so
+        // a journal written with Failed cannot restore as an unjoinable room.
+        let mut failed_record = recovered.clone();
+        failed_record.record.manifest.source_phase = RecoverySourcePhase::Failed;
+
+        let reloaded = RoomDurability::recovered(journal.clone(), recovered);
         let manifest = reloaded.manifest();
         assert_eq!(manifest.source_phase, RecoverySourcePhase::DurablyStaged);
         assert!(manifest.file_checkpoint_covers_durable_heads());
         // The restored baseline completes the normal recovered-source path.
         reloaded.commit_source_ready(0).unwrap();
         assert_eq!(reloaded.manifest().source_phase, RecoverySourcePhase::Ready);
+
+        let reloaded_from_failed = RoomDurability::recovered(journal, failed_record);
+        assert_eq!(
+            reloaded_from_failed.manifest().source_phase,
+            RecoverySourcePhase::DurablyStaged
+        );
     }
 
     /// A durable peer change committed after the last export means disk is a

--- a/crates/runtimed/src/notebook_sync_server/recovery.rs
+++ b/crates/runtimed/src/notebook_sync_server/recovery.rs
@@ -159,6 +159,23 @@ impl RecoveryManifest {
         }
         Ok(())
     }
+
+    /// True when the recorded file checkpoint exported every durable head:
+    /// the file on disk is a complete baseline for this journal, with no
+    /// durable change left unexported. Head order is not significant.
+    pub(crate) fn file_checkpoint_covers_durable_heads(&self) -> bool {
+        if self.canonical_path.is_none()
+            || self.file_save_sequence.is_none()
+            || self.durable_heads.is_empty()
+        {
+            return false;
+        }
+        let mut exported = self.exported_heads.clone();
+        let mut durable = self.durable_heads.clone();
+        exported.sort_unstable();
+        durable.sort_unstable();
+        exported == durable
+    }
 }
 
 /// One independently recoverable journal record.


### PR DESCRIPTION
Fixes the undead-room half of #4065.

A notebook created at a path never stages a source generation. Ordinary saves record file checkpoints with `source_generation: None`, so the journal manifest stays `source_phase: pending` with peer changes forever. On the next daemon start, restore classified that shape as `source_degraded` and failed initial materialization, and the retry gate could never pass because applying the recovered journal is itself what makes the doc non-pristine. The room became permanently unjoinable while the disk file was a byte-exact export of every durable head. Live incident: 2,201 rejected connections over 2.5 hours, an auto-launch agent storm, and daemon-wide fd exhaustion (full chain in #4065).

The fix is one normalization at journal load. `RoomDurability::recovered` now detects a manifest whose file checkpoint exported every durable head (no unresolved checkpoint intent, no corrupt tail) and restores it as `DurablyStaged`: the export is a complete baseline by construction. The room then finalizes on the existing recovered-source path, where `finalize_recovered_source` still verifies the disk fingerprint, so a foreign disk write surfaces as `source_conflict` with explicit reconciliation instead of an undead room.

## Behavioral coverage

| Journal shape at restore | Before | After |
|---|---|---|
| Checkpoint covers all durable heads, disk matches | undead room (`source_degraded`, unretryable) | restores staged, finalizes Ready |
| Checkpoint covers all durable heads, disk changed | undead room | `source_conflict`, explicit reconciliation |
| Peer change committed after last checkpoint | `source_degraded` | unchanged (disk is a stale prefix, not a baseline) |
| Unresolved checkpoint intent (crash mid-save) | intent resolution | unchanged (resolution path keeps ownership) |
| Corrupt journal tail | degraded | unchanged (no normalization on corrupt evidence) |

New tests cover the heal, the unexported tail, and the pending-intent case. The full-coverage predicate is order-insensitive on heads and lives on `RecoveryManifest` next to the phase it interprets.

Save-side staging (having the first full-coverage save claim a generation so these manifests never exist) is deliberately not in this change; it touches generation semantics shared with catalog publication and is tracked in #4065.

Full `cargo test -p runtimed`: 1222 passed; three failures reproduced as load flakes unrelated to this diff (each passes in isolation except `shell_env_overlay::capture_returns_at_least_path`, which times out its 3s shell-startup capture on a machine under heavy compile load).
