### PR TITLE
fix(runtimed): shutdown and reaping block only on durability-boundary failures

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1670,7 +1670,7 @@ impl Daemon {
     /// recovery evidence and may be reaped or cleanly shut down; reopening
     /// reconstructs the same Degraded lifecycle from disk plus journal.
     fn room_requires_durability_repair(room: &crate::notebook_sync_server::NotebookRoom) -> bool {
-        room.durability.status().is_degraded()
+        room.durability.status().requires_durability_repair()
     }
 
     fn mark_room_durability_degraded(
@@ -1678,7 +1678,10 @@ impl Daemon {
         reason: String,
         document_heads: Vec<String>,
     ) {
-        room.durability.mark_degraded(reason.clone());
+        room.durability.mark_degraded(
+            crate::notebook_sync_server::durability::DegradationKind::DurabilityBoundary,
+            reason.clone(),
+        );
         room.lifecycle
             .mark_degraded(reason.clone(), document_heads, true);
         let _ = room.state.with_doc(|state| {
@@ -1747,7 +1750,7 @@ impl Daemon {
                 let reason = room
                     .durability
                     .status()
-                    .degraded_reason
+                    .degraded_reason()
                     .or_else(|| room.lifecycle.availability().status().reason.clone())
                     .unwrap_or_else(|| {
                         "room is degraded and requires explicit durability repair".to_string()
@@ -7518,8 +7521,10 @@ mod tests {
 
         // Model an asynchronous journal failure discovered by the causal
         // head barrier, after candidate selection and snapshot commit.
-        room.durability
-            .mark_degraded("injected durable wait failure");
+        room.durability.mark_degraded(
+            crate::notebook_sync_server::durability::DegradationKind::DurabilityBoundary,
+            "injected durable wait failure",
+        );
         Daemon::await_reaper_durability(
             &room,
             &required_heads,
@@ -7700,6 +7705,124 @@ mod tests {
             2,
             "the degraded recovery room and later publication must both remain resident"
         );
+    }
+
+    /// A source conflict with a healthy recovery journal is durable recovery
+    /// evidence, not a storage failure. Clean shutdown must release the room
+    /// instead of pinning the daemon alive until the conflict is reconciled
+    /// (issue #4062).
+    #[tokio::test]
+    async fn clean_shutdown_releases_room_with_healthy_journal_source_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = lease_test_config(&temp_dir);
+        let docs_dir = config.notebook_docs_dir.clone();
+        let daemon = Daemon::new_for_test(config).unwrap();
+        let uuid = uuid::Uuid::new_v4();
+        let notebook_path = temp_dir.path().join("source-conflict.ipynb");
+        std::fs::write(
+            &notebook_path,
+            br#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#,
+        )
+        .unwrap();
+        let room = Arc::new(crate::notebook_sync_server::NotebookRoom::new_fresh(
+            uuid,
+            Some(notebook_path.clone()),
+            &docs_dir,
+            daemon.blob_store.clone(),
+            false,
+        ));
+
+        // Journal the exact live heads first so the shutdown barrier lands on
+        // the already-durable path with the conflict marker still set. This is
+        // the incident shape: an idle conflicted room with nothing left to
+        // commit.
+        let (snapshot, heads, encoded_heads) = {
+            let mut doc = room.doc.write().await;
+            let heads = doc.get_heads();
+            let encoded = heads.iter().map(ToString::to_string).collect::<Vec<_>>();
+            let raw = heads.iter().map(|head| head.0).collect::<Vec<_>>();
+            (doc.save(), raw, encoded)
+        };
+        room.durability
+            .commit_snapshot(
+                &snapshot,
+                heads,
+                crate::notebook_sync_server::durability::DurableMutation::Daemon,
+            )
+            .unwrap();
+
+        let reason = format!(
+            "source_conflict: {} changed on disk while journal heads were not exported; both versions were preserved",
+            notebook_path.display()
+        );
+        room.durability.mark_degraded(
+            crate::notebook_sync_server::durability::DegradationKind::SourceState,
+            reason.clone(),
+        );
+        room.lifecycle.mark_source_conflict(reason, encoded_heads);
+        assert!(room.durability.status().is_degraded());
+        assert!(!Daemon::room_requires_durability_repair(&room));
+
+        let outcome = daemon
+            .notebook_rooms
+            .insert_or_get(uuid, room.clone(), Some(&notebook_path))
+            .await
+            .unwrap();
+        let (_, reservation) = outcome.into_parts();
+        drop(reservation);
+
+        daemon
+            .shutdown_notebook_rooms()
+            .await
+            .expect("a healthy-journal source conflict must not block clean shutdown");
+        assert_eq!(
+            daemon.notebook_rooms.len().await,
+            0,
+            "the conflicted room must be released with the rest of the registry"
+        );
+    }
+
+    /// A durability-boundary failure is the case the repair gate exists for:
+    /// the room must stay resident and clean shutdown must report it.
+    #[tokio::test]
+    async fn clean_shutdown_retains_room_with_durability_boundary_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = lease_test_config(&temp_dir);
+        let docs_dir = config.notebook_docs_dir.clone();
+        let daemon = Daemon::new_for_test(config).unwrap();
+        let uuid = uuid::Uuid::new_v4();
+        let room = Arc::new(crate::notebook_sync_server::NotebookRoom::new_fresh(
+            uuid,
+            None,
+            &docs_dir,
+            daemon.blob_store.clone(),
+            true,
+        ));
+        room.durability.mark_degraded(
+            crate::notebook_sync_server::durability::DegradationKind::DurabilityBoundary,
+            "injected journal failure",
+        );
+        assert!(Daemon::room_requires_durability_repair(&room));
+
+        let outcome = daemon
+            .notebook_rooms
+            .insert_or_get(uuid, room.clone(), None)
+            .await
+            .unwrap();
+        let (_, reservation) = outcome.into_parts();
+        drop(reservation);
+
+        let error = daemon
+            .shutdown_notebook_rooms()
+            .await
+            .expect_err("a failed durability boundary must block clean shutdown");
+        assert!(
+            error.to_string().contains("clean shutdown retained 1 room"),
+            "unexpected shutdown error: {error:#}"
+        );
+        assert_eq!(daemon.notebook_rooms.len().await, 1);
+        assert!(daemon.notebook_rooms.peek_uuid(uuid).await.is_some());
+        assert!(room.durability.status().requires_durability_repair());
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -5068,7 +5068,7 @@ impl Daemon {
     }
 
     /// Test helper: put a resident room into the state a file-watcher
-    /// `SourceConflict` leaves behind — durability degraded as
+    /// `SourceConflict` leaves behind, durability degraded as
     /// `SourceState` (the journal itself is healthy) and lifecycle
     /// degraded with the `source_conflict` code. `pub` so integration
     /// tests (separate crate) can drive reaper sweeps against a

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -5067,6 +5067,27 @@ impl Daemon {
         self.notebook_rooms.len().await
     }
 
+    /// Test helper: put a resident room into the state a file-watcher
+    /// `SourceConflict` leaves behind — durability degraded as
+    /// `SourceState` (the journal itself is healthy) and lifecycle
+    /// degraded with the `source_conflict` code. `pub` so integration
+    /// tests (separate crate) can drive reaper sweeps against a
+    /// conflicted room; the marking internals are `pub(crate)`.
+    #[doc(hidden)]
+    pub async fn test_mark_room_source_conflict(&self, uuid: uuid::Uuid, reason: &str) -> bool {
+        let Some(room) = self.notebook_rooms.peek_uuid(uuid).await else {
+            return false;
+        };
+        let document_heads = room.durability.status().durable_heads;
+        room.durability.mark_degraded(
+            crate::notebook_sync_server::durability::DegradationKind::SourceState,
+            reason.to_string(),
+        );
+        room.lifecycle
+            .mark_source_conflict(reason.to_string(), document_heads);
+        true
+    }
+
     /// One sweep at production cap. Convenience wrapper around
     /// `ghost_room_reaper_sweep_with_cap` for tests that only want to
     /// drive the TTL layer.
@@ -7823,6 +7844,120 @@ mod tests {
         assert_eq!(daemon.notebook_rooms.len().await, 1);
         assert!(daemon.notebook_rooms.peek_uuid(uuid).await.is_some());
         assert!(room.durability.status().requires_durability_repair());
+    }
+
+    /// The other half of the #4062 contract: releasing a healthy-journal
+    /// source-conflict room on clean shutdown is only safe because disk plus
+    /// journal reconstruct the same Degraded lifecycle on reopen. The
+    /// conflict must surface again, not silently clear.
+    #[tokio::test]
+    async fn reopen_after_clean_shutdown_rehydrates_source_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = lease_test_config(&temp_dir);
+        let notebook_path = temp_dir.path().join("reopen-conflict.ipynb");
+        std::fs::write(&notebook_path, b"{}").unwrap();
+        let canonical_path = std::fs::canonicalize(&notebook_path).unwrap();
+        let notebook_id = uuid::Uuid::new_v4();
+
+        let daemon = Daemon::new_for_test(config.clone()).unwrap();
+        daemon.notebook_registry.record(
+            &canonical_path,
+            notebook_id,
+            &chrono::Utc::now().to_rfc3339(),
+        );
+        let manifest =
+            write_ready_recovery_with_peer_edit(&config, &canonical_path, notebook_id).await;
+        assert_ne!(
+            manifest.durable_heads, manifest.exported_heads,
+            "the journal must hold peer heads that were never exported to disk"
+        );
+
+        // External edit while journal heads were not exported: disk no
+        // longer matches the journal's staged source fingerprint.
+        std::fs::write(
+            &canonical_path,
+            br#"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[{"id":"disk-cell","cell_type":"code","metadata":{},"execution_count":null,"outputs":[],"source":["external_edit = 3\n"]}]}"#,
+        )
+        .unwrap();
+
+        // First open surfaces the conflict as a lifecycle degradation over a
+        // healthy journal.
+        {
+            let (room, _guard) = crate::notebook_sync_server::get_or_create_room_result(
+                &daemon.notebook_rooms,
+                notebook_id,
+                crate::notebook_sync_server::RoomCreationOptions {
+                    path: Some(canonical_path.clone()),
+                    initial_load_execution_store_dir: Some(&daemon.config.execution_store_dir),
+                    docs_dir: &daemon.config.notebook_docs_dir,
+                    blob_store: daemon.blob_store.clone(),
+                    ephemeral: false,
+                    trusted_packages: daemon.trusted_packages.clone(),
+                },
+            )
+            .await
+            .unwrap();
+            assert!(matches!(
+                room.lifecycle.availability(),
+                crate::notebook_sync_server::RoomAvailability::Degraded(_)
+            ));
+            assert!(!Daemon::room_requires_durability_repair(&room));
+        }
+
+        daemon
+            .shutdown_notebook_rooms()
+            .await
+            .expect("a healthy-journal source conflict must not block clean shutdown");
+        assert_eq!(daemon.notebook_rooms.len().await, 0);
+        drop(daemon);
+
+        // Re-create the daemon over the same cache dir and reopen: the
+        // conflict must be reconstructed from disk plus journal.
+        let restarted = Daemon::new_for_test(config).unwrap();
+        let resolved = restarted
+            .resolve_file_notebook_id(&canonical_path)
+            .await
+            .expect("journal identity discovery should survive the restart");
+        assert_eq!(resolved, notebook_id);
+        let (room, _guard) = crate::notebook_sync_server::get_or_create_room_result(
+            &restarted.notebook_rooms,
+            resolved,
+            crate::notebook_sync_server::RoomCreationOptions {
+                path: Some(canonical_path.clone()),
+                initial_load_execution_store_dir: Some(&restarted.config.execution_store_dir),
+                docs_dir: &restarted.config.notebook_docs_dir,
+                blob_store: restarted.blob_store.clone(),
+                ephemeral: false,
+                trusted_packages: restarted.trusted_packages.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let crate::notebook_sync_server::RoomAvailability::Degraded(status) =
+            room.lifecycle.availability()
+        else {
+            panic!("reopen must reconstruct the Degraded lifecycle, not clear the conflict");
+        };
+        let reason = status
+            .reason
+            .expect("rehydrated degradation must carry its reason");
+        assert!(
+            reason.contains("source_conflict"),
+            "unexpected rehydrated reason: {reason}"
+        );
+        let error = room
+            .lifecycle
+            .source_state()
+            .status()
+            .error
+            .clone()
+            .expect("rehydrated source axis must carry the structured error");
+        assert_eq!(error.code, "source_conflict");
+        assert!(
+            !room.durability.status().requires_durability_repair(),
+            "a rehydrated source conflict must stay reapable and shutdown-releasable"
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -22,6 +22,38 @@ use super::recovery::{
     RecoveryManifest, RecoverySourcePhase, RecoveryUnavailableReason, SourceFingerprint,
 };
 
+/// Structural classification of a room degradation. The kind is lifecycle
+/// policy, not display text: shutdown and reaping consult it through
+/// `RoomDurabilityStatus::requires_durability_repair`, so every mark site
+/// must declare which failure class it is reporting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DegradationKind {
+    /// The durability boundary itself failed: the journal cannot accept
+    /// records or has preserved corrupt data. The room must stay resident
+    /// for explicit repair because disk plus journal no longer reconstruct
+    /// its acknowledged state.
+    DurabilityBoundary,
+    /// A source-level conflict or failure while the recovery journal stays
+    /// healthy. Disk plus journal reconstruct the same degraded lifecycle
+    /// on reopen, so the room may be reaped or cleanly shut down.
+    SourceState,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RoomDegradation {
+    pub(crate) kind: DegradationKind,
+    pub(crate) reason: String,
+}
+
+impl RoomDegradation {
+    fn boundary(reason: impl Into<String>) -> Self {
+        Self {
+            kind: DegradationKind::DurabilityBoundary,
+            reason: reason.into(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RoomDurabilityStatus {
     pub(crate) has_durable_record: bool,
@@ -32,12 +64,31 @@ pub(crate) struct RoomDurabilityStatus {
     pub(crate) source_phase: RecoverySourcePhase,
     pub(crate) source_fingerprint: SourceFingerprint,
     pub(crate) has_peer_changes: bool,
-    pub(crate) degraded_reason: Option<String>,
+    pub(crate) degraded: Option<RoomDegradation>,
 }
 
 impl RoomDurabilityStatus {
     pub(crate) fn is_degraded(&self) -> bool {
-        self.degraded_reason.is_some()
+        self.degraded.is_some()
+    }
+
+    pub(crate) fn degraded_reason(&self) -> Option<String> {
+        self.degraded
+            .as_ref()
+            .map(|degradation| degradation.reason.clone())
+    }
+
+    /// Only a failed durability boundary requires the room to stay resident
+    /// for repair. A `SourceState` degradation is durable recovery evidence,
+    /// not a storage failure.
+    pub(crate) fn requires_durability_repair(&self) -> bool {
+        matches!(
+            &self.degraded,
+            Some(RoomDegradation {
+                kind: DegradationKind::DurabilityBoundary,
+                ..
+            })
+        )
     }
 }
 
@@ -177,7 +228,8 @@ pub(crate) fn commit_daemon_notebook_mutation(
             let document_heads = doc.get_heads_hex();
             let reason =
                 format!("{operation} journal commit failed before acknowledgement: {error}");
-            room.durability.mark_degraded(reason.clone());
+            room.durability
+                .mark_degraded(DegradationKind::DurabilityBoundary, reason.clone());
             room.lifecycle
                 .mark_degraded(reason.clone(), document_heads, document_readable);
             let _ = room.state.with_doc(|state| {
@@ -195,7 +247,7 @@ struct DurabilityState {
     manifest: RecoveryManifest,
     durable_snapshot: Arc<[u8]>,
     has_durable_record: bool,
-    degraded_reason: Option<String>,
+    degraded: Option<RoomDegradation>,
 }
 
 /// Single serialization point for all durable NotebookDoc history in a room.
@@ -229,11 +281,15 @@ impl RoomDurability {
 
     /// Restore the exact latest complete record selected by recovery scanning.
     pub(crate) fn recovered(journal: RecoveryJournal, recovered: RecoveredJournalRecord) -> Self {
-        let degraded_reason = recovered
+        let degraded = recovered
             .ignored_tail
             .as_ref()
             .filter(|tail| !tail.is_repairable_torn_suffix())
-            .map(|tail| format!("recovery journal has preserved corrupt data: {tail:?}"));
+            .map(|tail| {
+                RoomDegradation::boundary(format!(
+                    "recovery journal has preserved corrupt data: {tail:?}"
+                ))
+            });
         let mut manifest = recovered.record.manifest;
         // A checkpoint that exported every durable head proves the file on
         // disk is a complete baseline for this journal, even when no import
@@ -245,7 +301,7 @@ impl RoomDurability {
         // fails finalization as a source conflict through the fingerprint
         // check, and an unresolved checkpoint intent keeps its dedicated
         // resolution path.
-        if degraded_reason.is_none()
+        if degraded.is_none()
             && matches!(
                 manifest.source_phase,
                 super::recovery::RecoverySourcePhase::Pending
@@ -261,7 +317,7 @@ impl RoomDurability {
             manifest,
             recovered.record.automerge_snapshot,
             true,
-            degraded_reason,
+            degraded,
         )
     }
 
@@ -286,13 +342,13 @@ impl RoomDurability {
         manifest: RecoveryManifest,
         durable_snapshot: Vec<u8>,
         has_durable_record: bool,
-        degraded_reason: Option<String>,
+        degraded: Option<RoomDegradation>,
     ) -> Self {
         let state = DurabilityState {
             manifest,
             durable_snapshot: durable_snapshot.into(),
             has_durable_record,
-            degraded_reason,
+            degraded,
         };
         let status = status_from_state(&state);
         let (status_tx, _) = watch::channel(status);
@@ -392,7 +448,7 @@ impl RoomDurability {
 
         if let Err(error) = journal.append(&promoted_manifest, &state.durable_snapshot) {
             let reason = error.to_string();
-            state.degraded_reason = Some(reason.clone());
+            state.degraded = Some(RoomDegradation::boundary(reason.clone()));
             self.status_tx.send_replace(status_from_state(&state));
             return Err(RoomDurabilityError::Journal(error));
         }
@@ -485,7 +541,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &committed_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -494,7 +550,7 @@ impl RoomDurability {
         state.manifest = manifest;
         state.durable_snapshot = committed_snapshot.into();
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(DurableCommitOutcome::Committed(status))
@@ -574,7 +630,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &durable_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -583,7 +639,7 @@ impl RoomDurability {
         state.manifest = manifest;
         state.durable_snapshot = durable_snapshot.into();
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(DurableCommitOutcome::Committed(status))
@@ -628,7 +684,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -636,7 +692,7 @@ impl RoomDurability {
 
         state.manifest = manifest;
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(DurableCommitOutcome::Committed(status))
@@ -693,7 +749,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -734,7 +790,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -787,14 +843,14 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
         }
         state.manifest = manifest;
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(DurableCommitOutcome::Committed(status))
@@ -894,7 +950,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -975,7 +1031,7 @@ impl RoomDurability {
         state.manifest = manifest;
         state.durable_snapshot = Arc::from(snapshot);
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(ReconciledSourceCommit {
@@ -1043,7 +1099,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason);
+                state.degraded = Some(RoomDegradation::boundary(reason));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -1052,7 +1108,7 @@ impl RoomDurability {
         state.manifest = manifest;
         state.durable_snapshot = snapshot.into();
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(DurableCommitOutcome::Committed(status))
@@ -1126,7 +1182,7 @@ impl RoomDurability {
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &snapshot) {
                 let reason = error.to_string();
-                state.degraded_reason = Some(reason.clone());
+                state.degraded = Some(RoomDegradation::boundary(reason.clone()));
                 self.status_tx.send_replace(status_from_state(&state));
                 return Err(RoomDurabilityError::Journal(error));
             }
@@ -1134,15 +1190,22 @@ impl RoomDurability {
         state.manifest = manifest;
         state.durable_snapshot = snapshot.into();
         state.has_durable_record = true;
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         Ok(DurableCommitOutcome::Committed(status))
     }
 
-    pub(crate) fn mark_degraded(&self, reason: impl Into<String>) -> RoomDurabilityStatus {
+    pub(crate) fn mark_degraded(
+        &self,
+        kind: DegradationKind,
+        reason: impl Into<String>,
+    ) -> RoomDurabilityStatus {
         let mut state = self.lock_state();
-        state.degraded_reason = Some(reason.into());
+        state.degraded = Some(RoomDegradation {
+            kind,
+            reason: reason.into(),
+        });
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         status
@@ -1150,15 +1213,17 @@ impl RoomDurability {
 
     pub(crate) fn clear_degraded(&self) -> RoomDurabilityStatus {
         let mut state = self.lock_state();
-        state.degraded_reason = None;
+        state.degraded = None;
         let status = status_from_state(&state);
         self.status_tx.send_replace(status.clone());
         status
     }
 
     /// Wait until the latest durable snapshot contains every required change.
-    /// A degraded journal returns immediately instead of masquerading as a
-    /// timeout, and the wait always has a caller-supplied bound.
+    /// A failed durability boundary returns immediately instead of
+    /// masquerading as a timeout, and the wait always has a caller-supplied
+    /// bound. A `SourceState` degradation does not short-circuit: the journal
+    /// is healthy, so it can still satisfy the head barrier.
     pub(crate) async fn await_durable(
         &self,
         required_heads: &[String],
@@ -1169,7 +1234,11 @@ impl RoomDurability {
         let wait = async {
             loop {
                 let status = receiver.borrow().clone();
-                if let Some(reason) = &status.degraded_reason {
+                if let Some(RoomDegradation {
+                    kind: DegradationKind::DurabilityBoundary,
+                    reason,
+                }) = &status.degraded
+                {
                     return Err(RoomDurabilityError::Degraded(reason.clone()));
                 }
                 let snapshot = self.durable_snapshot();
@@ -1178,7 +1247,11 @@ impl RoomDurability {
                 }
                 if receiver.changed().await.is_err() {
                     let current = self.status();
-                    if let Some(reason) = current.degraded_reason {
+                    if let Some(RoomDegradation {
+                        kind: DegradationKind::DurabilityBoundary,
+                        reason,
+                    }) = current.degraded
+                    {
                         return Err(RoomDurabilityError::Degraded(reason));
                     }
                     return Err(RoomDurabilityError::TimedOut);
@@ -1211,7 +1284,7 @@ fn status_from_state(state: &DurabilityState) -> RoomDurabilityStatus {
         source_phase: state.manifest.source_phase,
         source_fingerprint: state.manifest.source_fingerprint,
         has_peer_changes: !state.manifest.peer_change_hashes.is_empty(),
-        degraded_reason: state.degraded_reason.clone(),
+        degraded: state.degraded.clone(),
     }
 }
 
@@ -1596,13 +1669,33 @@ mod tests {
     async fn degraded_barrier_fails_without_waiting_for_timeout() {
         let (snapshot, heads, encoded_heads, _) = snapshot_with_change(1);
         let durability = RoomDurability::volatile(Uuid::nil(), snapshot, heads);
-        durability.mark_degraded("disk full");
+        durability.mark_degraded(DegradationKind::DurabilityBoundary, "disk full");
 
         let error = durability
             .await_durable(&encoded_heads, Duration::from_secs(10))
             .await
             .unwrap_err();
         assert!(matches!(error, RoomDurabilityError::Degraded(reason) if reason == "disk full"));
+    }
+
+    /// A source-level degradation leaves the journal healthy, so a durable
+    /// snapshot that already contains the required heads still satisfies the
+    /// barrier instead of failing as a storage error.
+    #[tokio::test]
+    async fn source_state_degradation_does_not_fail_a_satisfied_barrier() {
+        let (snapshot, heads, encoded_heads, _) = snapshot_with_change(1);
+        let durability = RoomDurability::volatile(Uuid::nil(), snapshot, heads);
+        durability.mark_degraded(
+            DegradationKind::SourceState,
+            "source_conflict: disk changed while journal heads were not exported",
+        );
+
+        let status = durability
+            .await_durable(&encoded_heads, Duration::from_secs(10))
+            .await
+            .expect("a healthy journal must satisfy the barrier despite a source conflict");
+        assert!(status.is_degraded());
+        assert!(!status.requires_durability_repair());
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1748,16 +1748,22 @@ pub(crate) fn commit_file_watcher_changes(
                     &error,
                     super::durability::RoomDurabilityError::SourceConflict { .. }
                 );
-                let reason = if source_conflict {
-                    format!(
-                        "source_conflict: external source changed while journal heads were not exported; both versions were preserved: {error}"
+                let (kind, reason) = if source_conflict {
+                    (
+                        super::durability::DegradationKind::SourceState,
+                        format!(
+                            "source_conflict: external source changed while journal heads were not exported; both versions were preserved: {error}"
+                        ),
                     )
                 } else {
-                    format!(
-                        "file watcher journal commit failed before external changes became visible: {error}"
+                    (
+                        super::durability::DegradationKind::DurabilityBoundary,
+                        format!(
+                            "file watcher journal commit failed before external changes became visible: {error}"
+                        ),
                     )
                 };
-                room.durability.mark_degraded(reason.clone());
+                room.durability.mark_degraded(kind, reason.clone());
                 if source_conflict {
                     room.lifecycle
                         .mark_source_conflict(reason.clone(), document_heads);
@@ -1817,7 +1823,11 @@ async fn complete_external_source_revision(
             "external source generation {} was staged but could not become Ready: {error}",
             status.source_generation
         );
-        degrade_external_source_revision(room, reason);
+        degrade_external_source_revision(
+            room,
+            super::durability::DegradationKind::SourceState,
+            reason,
+        );
         return false;
     }
     let projection = match super::projection::build_live_notebook_projection_for_generation(
@@ -1832,7 +1842,11 @@ async fn complete_external_source_revision(
                 "external source generation {} could not build its bounded projection: {error:#}",
                 status.source_generation
             );
-            degrade_external_source_revision(room, reason);
+            degrade_external_source_revision(
+                room,
+                super::durability::DegradationKind::SourceState,
+                reason,
+            );
             return false;
         }
     };
@@ -1844,7 +1858,11 @@ async fn complete_external_source_revision(
             "external source generation {} was staged but could not become Ready: {error}",
             status.source_generation
         );
-        degrade_external_source_revision(room, reason);
+        degrade_external_source_revision(
+            room,
+            super::durability::DegradationKind::DurabilityBoundary,
+            reason,
+        );
         return false;
     }
     room.lifecycle.complete_external_source_revision(
@@ -1857,9 +1875,13 @@ async fn complete_external_source_revision(
     true
 }
 
-fn degrade_external_source_revision(room: &NotebookRoom, reason: String) {
+fn degrade_external_source_revision(
+    room: &NotebookRoom,
+    kind: super::durability::DegradationKind,
+    reason: String,
+) {
     let document_heads = room.durability.status().durable_heads;
-    room.durability.mark_degraded(reason.clone());
+    room.durability.mark_degraded(kind, reason.clone());
     room.lifecycle
         .mark_degraded(reason.clone(), document_heads, true);
     let _ = room.state.with_doc(|state| {

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1748,9 +1748,19 @@ pub(crate) fn commit_file_watcher_changes(
                     &error,
                     super::durability::RoomDurabilityError::SourceConflict { .. }
                 );
+                // A source conflict is only SourceState when the rollback
+                // restored the live document: disk plus journal then
+                // reconstruct the same degraded lifecycle on reopen. If the
+                // rollback snapshot failed to load, the live doc still holds
+                // half-applied external changes, so the room must stay
+                // resident for repair.
                 let (kind, reason) = if source_conflict {
                     (
-                        super::durability::DegradationKind::SourceState,
+                        if document_readable {
+                            super::durability::DegradationKind::SourceState
+                        } else {
+                            super::durability::DegradationKind::DurabilityBoundary
+                        },
                         format!(
                             "source_conflict: external source changed while journal heads were not exported; both versions were preserved: {error}"
                         ),

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -2265,6 +2265,7 @@ pub(crate) async fn apply_ipynb_changes_inner(
             if let Err(error) = sidecars {
                 degrade_external_source_revision(
                     room,
+                    super::durability::DegradationKind::SourceState,
                     format!("external source runtime sidecars failed: {error}"),
                 );
                 return AppliedIpynbChanges::default();
@@ -2580,6 +2581,7 @@ pub(crate) async fn apply_ipynb_changes_inner(
         if let Err(error) = sidecars {
             degrade_external_source_revision(
                 room,
+                super::durability::DegradationKind::SourceState,
                 format!("external source runtime sidecars failed: {error}"),
             );
             return AppliedIpynbChanges::default();

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -111,7 +111,10 @@ pub(super) async fn apply_notebook_doc_frame(
                     let document_heads = doc.get_heads_hex();
                     let reason =
                         format!("journal commit failed before peer acknowledgement: {error}");
-                    room.durability.mark_degraded(reason.clone());
+                    room.durability.mark_degraded(
+                        super::durability::DegradationKind::DurabilityBoundary,
+                        reason.clone(),
+                    );
                     room.lifecycle
                         .mark_degraded(reason.clone(), document_heads, document_readable);
                     let _ = room.state.with_doc(|state| {

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -58,7 +58,10 @@ async fn apply_runtime_agent_notebook_doc_frame(
                     let reason = format!(
                         "journal commit failed before runtime-agent acknowledgement: {error}"
                     );
-                    room.durability.mark_degraded(reason.clone());
+                    room.durability.mark_degraded(
+                        super::durability::DegradationKind::DurabilityBoundary,
+                        reason.clone(),
+                    );
                     room.lifecycle
                         .mark_degraded(reason.clone(), document_heads, document_readable);
                     let _ = room.state.with_doc(|state| {

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -160,7 +160,10 @@ fn degrade_file_checkpoint(
     exported_heads: &[[u8; 32]],
     reason: String,
 ) -> String {
-    durability.mark_degraded(reason.clone());
+    durability.mark_degraded(
+        super::durability::DegradationKind::DurabilityBoundary,
+        reason.clone(),
+    );
     lifecycle.mark_degraded(reason.clone(), checkpoint_heads_hex(exported_heads), true);
     let _ = runtime_state.with_doc(|state| {
         state.set_file_source_issue(Some(&runtime_doc::FileSourceIssue::Degraded {
@@ -730,7 +733,10 @@ pub(crate) async fn save_notebook_to_disk_with_claim_and_intent(
             let reason = format!(
                 "file checkpoint committed, but its recovered projection could not be retained: {error:#}"
             );
-            room.durability.mark_degraded(reason.clone());
+            room.durability.mark_degraded(
+                super::durability::DegradationKind::SourceState,
+                reason.clone(),
+            );
             room.lifecycle.mark_degraded(
                 reason.clone(),
                 checkpoint_heads_hex(&checkpoint.exported_heads),
@@ -1236,7 +1242,10 @@ pub(crate) async fn finalize_untitled_promotion(
     if let Err(error) = room.durability.promote_to_journal(recovery_journal) {
         let reason =
             format!("saved file checkpoint could not establish its recovery journal: {error}");
-        room.durability.mark_degraded(reason.clone());
+        room.durability.mark_degraded(
+            super::durability::DegradationKind::DurabilityBoundary,
+            reason.clone(),
+        );
         let document_heads = room.durability.status().durable_heads;
         room.lifecycle
             .mark_degraded(reason.clone(), document_heads, true);
@@ -1260,7 +1269,10 @@ pub(crate) async fn finalize_untitled_promotion(
             let reason = format!(
                 "saved file checkpoint could not retain its generation-owned projection: {error:#}"
             );
-            room.durability.mark_degraded(reason.clone());
+            room.durability.mark_degraded(
+                super::durability::DegradationKind::SourceState,
+                reason.clone(),
+            );
             room.lifecycle
                 .mark_degraded(reason.clone(), durability.durable_heads.clone(), true);
             let _ = room.state.with_doc(|state| {
@@ -2257,7 +2269,12 @@ pub(crate) async fn mark_external_source_conflict_if_needed(
         "source_conflict: {} changed on disk while journal heads were not exported; both versions were preserved",
         notebook_path.display()
     );
-    room.durability.mark_degraded(reason.clone());
+    // Both versions are preserved and the journal stays healthy, so this
+    // degradation must not pin the room resident through shutdown or reaping.
+    room.durability.mark_degraded(
+        super::durability::DegradationKind::SourceState,
+        reason.clone(),
+    );
     let document_heads = {
         let mut doc = room.doc.write().await;
         doc.get_heads_hex()
@@ -2351,7 +2368,10 @@ pub(crate) async fn process_watcher_event(room: &NotebookRoom, notebook_path: &P
         Ok(claim) => claim,
         Err(_) => {
             let reason = "external source checkpoint sequence exhausted".to_string();
-            room.durability.mark_degraded(reason.clone());
+            room.durability.mark_degraded(
+                super::durability::DegradationKind::DurabilityBoundary,
+                reason.clone(),
+            );
             let heads = room.durability.status().durable_heads;
             room.lifecycle.mark_degraded(reason.clone(), heads, true);
             return;

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1432,14 +1432,17 @@ impl NotebookRoom {
                         let reason = format!(
                             "source_degraded: could not resolve interrupted file checkpoint: {error}"
                         );
-                        durability.mark_degraded(reason.clone());
+                        durability.mark_degraded(
+                            super::durability::DegradationKind::DurabilityBoundary,
+                            reason.clone(),
+                        );
                         startup_durability_degraded = Some(reason);
                     }
                 }
             }
         }
         if startup_durability_degraded.is_none() {
-            startup_durability_degraded = durability.status().degraded_reason;
+            startup_durability_degraded = durability.status().degraded_reason();
         }
         let lifecycle = RoomLifecycle::new(genesis_snapshot, document_heads);
         if durability.status().has_durable_record {

--- a/crates/runtimed/src/requests/reconcile_notebook_source.rs
+++ b/crates/runtimed/src/requests/reconcile_notebook_source.rs
@@ -371,7 +371,10 @@ async fn archive_and_reload_source(
             "[notebook-sync] Reconciled NotebookDoc committed for {}, but runtime sidecars could not be refreshed: {}",
             room.id, reason
         );
-        room.durability.mark_degraded(reason.clone());
+        room.durability.mark_degraded(
+            crate::notebook_sync_server::durability::DegradationKind::SourceState,
+            reason.clone(),
+        );
         let _ = room.state.with_doc(|state| {
             state.set_file_checkpoint(&exported_heads, save_sequence)?;
             state.set_file_source_issue(Some(&runtime_doc::FileSourceIssue::Degraded {
@@ -431,7 +434,10 @@ async fn finish_reconciliation(
         Err(error) => {
             let reason =
                 format!("reconciled source data committed, but its Ready marker failed: {error}");
-            room.durability.mark_degraded(reason.clone());
+            room.durability.mark_degraded(
+                crate::notebook_sync_server::durability::DegradationKind::DurabilityBoundary,
+                reason.clone(),
+            );
             let _ = room.state.with_doc(|state| {
                 state.set_file_source_issue(Some(&runtime_doc::FileSourceIssue::Degraded {
                     reason: reason.clone(),
@@ -474,7 +480,10 @@ async fn finish_reconciliation(
                 let reason = format!(
                 "reconciled source data committed, but its projection could not be retained: {error:#}"
             );
-                room.durability.mark_degraded(reason.clone());
+                room.durability.mark_degraded(
+                    crate::notebook_sync_server::durability::DegradationKind::SourceState,
+                    reason.clone(),
+                );
                 let _ = room.state.with_doc(|state| {
                     state.set_file_source_issue(Some(&runtime_doc::FileSourceIssue::Degraded {
                         reason: reason.clone(),

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2046,8 +2046,8 @@ async fn test_ghost_reaper_skips_reconnected_room() {
 /// A `SourceState` degradation (healthy journal, conflicted source) does
 /// not pin a room resident: `requires_durability_repair()` lets the
 /// reaper's candidate filter and `remove_if` predicate pass. The reaper
-/// then runs steps clean shutdown does not — the persist-debouncer flush
-/// and the autosave-debouncer final save — against a Degraded room. The
+/// then runs steps clean shutdown does not, the persist-debouncer flush
+/// and the autosave-debouncer final save, against a Degraded room. The
 /// degraded-save guard in `save_notebook_to_disk` must keep that final
 /// save from overwriting the user's external edits on the conflicted
 /// file: the room is reaped and the on-disk bytes stay byte-identical.
@@ -2113,7 +2113,7 @@ async fn test_ghost_reaper_sweeps_source_conflicted_room_without_touching_disk()
 
     // Leave the live doc ahead of disk. A direct doc mutation schedules no
     // autosave, so the only save that could reach disk after this point is
-    // the reaper's own final autosave — the exact write the degraded-save
+    // the reaper's own final autosave, the exact write the degraded-save
     // guard must block.
     {
         let mut doc = room.doc.write().await;

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2043,6 +2043,114 @@ async fn test_ghost_reaper_skips_reconnected_room() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
+/// A `SourceState` degradation (healthy journal, conflicted source) does
+/// not pin a room resident: `requires_durability_repair()` lets the
+/// reaper's candidate filter and `remove_if` predicate pass. The reaper
+/// then runs steps clean shutdown does not — the persist-debouncer flush
+/// and the autosave-debouncer final save — against a Degraded room. The
+/// degraded-save guard in `save_notebook_to_disk` must keep that final
+/// save from overwriting the user's external edits on the conflicted
+/// file: the room is reaped and the on-disk bytes stay byte-identical.
+#[tokio::test]
+async fn test_ghost_reaper_sweeps_source_conflicted_room_without_touching_disk() {
+    use std::sync::atomic::Ordering;
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    config.room_eviction_delay_ms = Some(0);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new_for_test(config).unwrap();
+    let daemon_for_inspect = daemon.clone();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let nb_path = temp_dir.path().join("conflicted.ipynb");
+    write_test_ipynb(&nb_path, &[("c1", "code", "x = 1", vec![])]);
+
+    let notebook_id;
+    {
+        let result = connect::connect_open(socket_path.clone(), nb_path.clone(), "test")
+            .await
+            .unwrap();
+        notebook_id = result.info.notebook_id.clone();
+        let client = result.handle;
+        assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
+    }
+
+    let uuid = uuid::Uuid::parse_str(&notebook_id).unwrap();
+
+    // Wait for kernel teardown to stamp the timestamp so the room is a
+    // reaper candidate. Eviction flushes settle before this stamp lands.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(room) = daemon_for_inspect.test_get_room(uuid).await {
+            if room
+                .connections
+                .last_kernel_torn_down_at
+                .load(Ordering::Relaxed)
+                != 0
+                && room.connections.active_peers.load(Ordering::Relaxed) == 0
+            {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("kernel teardown did not stamp last_kernel_torn_down_at within 5s");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    let room = daemon_for_inspect.test_get_room(uuid).await.unwrap();
+
+    // Quiesce the file watcher so the external overwrite below stays a
+    // plain on-disk fact instead of racing the injected conflict marker.
+    room.file_binding.shutdown_notebook_watcher().await;
+
+    // Leave the live doc ahead of disk. A direct doc mutation schedules no
+    // autosave, so the only save that could reach disk after this point is
+    // the reaper's own final autosave — the exact write the degraded-save
+    // guard must block.
+    {
+        let mut doc = room.doc.write().await;
+        doc.update_source("c1", "unsaved_live_edit = 1").unwrap();
+    }
+
+    assert!(
+        daemon_for_inspect
+            .test_mark_room_source_conflict(
+                uuid,
+                "source_conflict: external source changed while journal heads were not exported; both versions were preserved",
+            )
+            .await
+    );
+
+    // The user's external edit is the current disk truth.
+    let external_bytes =
+        br#"{"cells":[],"metadata":{"edited":"externally"},"nbformat":4,"nbformat_minor":5}"#;
+    std::fs::write(&nb_path, external_bytes).unwrap();
+
+    let before = std::fs::read(&nb_path).unwrap();
+    daemon_for_inspect.ghost_room_reaper_sweep(0).await;
+    assert_eq!(
+        daemon_for_inspect.test_room_count().await,
+        0,
+        "a SourceState-degraded room must be reapable"
+    );
+    let after = std::fs::read(&nb_path).unwrap();
+    assert_eq!(
+        before, after,
+        "reaping a conflicted room must not rewrite the on-disk notebook"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
 /// PR 1 codex P1: the connection-generation bump on peer connect must
 /// preempt an in-flight teardown that snapshotted the previous value.
 /// Stage a teardown task with a delay, reconnect a peer before the


### PR DESCRIPTION
Closes #4062.

`room_requires_durability_repair` blocked clean shutdown on `status().is_degraded()`, which is true for a source conflict just as much as a journal-level failure. In production this meant `runt-nightly daemon restart` could not shut down while a room sat in `source_conflict` with a perfectly healthy recovery journal and both versions preserved on disk: the blocked shutdown cascaded into a service-manager stop, orphan detection, a signal kill, and stale-lock cleanup on every restart until someone reconciled the conflict by hand.

`RoomDegradation` now carries a structured `DegradationKind`, either `DurabilityBoundary` or `SourceState`, and every `mark_degraded` call site declares which one it is. `room_requires_durability_repair` and the `await_durable` short-circuit both consult the kind instead of the boolean, so a healthy-journal source conflict no longer pins the daemon alive, and clean shutdown and the ghost-room reaper can release it. Reopening the room reconstructs the same Degraded lifecycle from disk plus journal, so nothing about the user-visible degraded state changes, only whether the daemon insists on staying up to babysit it.

## Design decision

A watcher-detected source conflict is `SourceState` only when the rollback snapshot actually restored the live document. If that restore fails, the doc holds half-applied external changes and the room has to stay resident for repair, so that path classifies as `DurabilityBoundary` even though it originates from the same source-conflict detection code. The kind reflects what has to stay in memory to avoid data loss, not where the degradation was detected.

`await_durable` only short-circuits on boundary degradation. A room degraded with a healthy journal can still satisfy the head barrier through the normal already-durable path, which is what lets an idle conflicted room clear the shutdown barrier without special-casing it in the barrier logic itself.

User-facing degraded-reason strings are unchanged. This is purely about which degradations pin the daemon resident.

## Behavioral coverage

| Degradation cause | Kind | Shutdown / reap behavior |
|---|---|---|
| Journal append failure | DurabilityBoundary | Blocks shutdown, room retained for repair |
| Corrupt-record recovery | DurabilityBoundary | Blocks shutdown, room retained for repair |
| Source conflict, rollback snapshot restored | SourceState | Shuts down cleanly, reaped by ghost-room sweep, on-disk bytes untouched |
| Source conflict, rollback snapshot failed to restore | DurabilityBoundary | Stays resident (doc holds half-applied external changes) |
| Sidecar deferred-execution write failure (load.rs) | SourceState | Shuts down cleanly, journal still healthy |

New tests cover the reaper sweeping a source-conflicted room without rewriting the on-disk `.ipynb` (the degraded-save guard blocks the final autosave), and reopening a released conflict room reconstructing the Degraded lifecycle with the original `source_conflict` reason from disk plus journal.

`cargo test -p runtimed`, `tokio_mutex_lint`, and `cargo xtask lint` are all clean.
