### PR TITLE
fix(notebook): reconnect backoff governor and terminal failed-load latch

### DIFF
--- a/apps/notebook/src/AGENTS.md
+++ b/apps/notebook/src/AGENTS.md
@@ -28,7 +28,7 @@ Host-platform side effects (Tauri IPC, plugin calls, window chrome) flow through
 | Namespace | Purpose |
 |-----------|---------|
 | `host.transport` | `NotebookTransport` shared by SyncEngine / NotebookClient |
-| `host.daemon` | `isConnected`, `reconnect`, `getInfo`, `getReadyInfo` |
+| `host.daemon` | `isConnected`, `reconnect`, `getInfo`, `getReadyInfo`, optional `autoReconnect` (backoff + terminal failed-load latch) |
 | `host.daemonEvents` | `onReady` / `onProgress` / `onDisconnected` / `onUnavailable` |
 | `host.relay` | `notifySyncReady()` outbound signal |
 | `host.blobs` | `port()` — daemon blob-server HTTP port |

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1086,10 +1086,12 @@ function AppContent() {
     onActivateCommentThread: handleActivateCommentThread,
   });
 
-  // Connection/identity slot source: daemon lifecycle, stable for the
-  // app's lifetime (the dot must transition on daemon restarts).
+  // Connection/identity slot source: daemon lifecycle plus the reconnect
+  // governor, stable for the app's lifetime (the dot must transition on
+  // daemon restarts, and must not claim "reconnecting" while the governor
+  // is latched terminal and nothing is redialing).
   const desktopConnectionStatus = useMemo(
-    () => createDesktopConnectionStatusSource(host.daemonEvents),
+    () => createDesktopConnectionStatusSource(host.daemonEvents, host.daemon.autoReconnect),
     [host],
   );
   useEffect(() => () => desktopConnectionStatus.dispose(), [desktopConnectionStatus]);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1815,9 +1815,21 @@ function AppContent() {
       }
     });
 
-    // Listen for daemon disconnection (mid-session)
+    // Listen for daemon disconnection (mid-session). When the reconnect
+    // driver is latched (terminal initial-load failure), this close is the
+    // daemon rejecting the session. Present the terminal reason instead of
+    // a reconnect spinner. Retry clears the latch via host.daemon.reconnect.
     const unlistenDisconnect = host.daemonEvents.onDisconnected(() => {
       cancelReadyTimeout();
+      const reconnectState = host.daemon.autoReconnect?.getState();
+      if (reconnectState?.kind === "latched") {
+        setDaemonStatus({
+          status: "failed",
+          error: `Couldn't load this notebook: ${reconnectState.reason}`,
+          guidance: "Automatic reconnection is paused. Retry reconnects once.",
+        });
+        return;
+      }
       setDaemonStatus({
         status: "failed",
         error: "Runtime disconnected. Attempting to reconnect...",

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -696,7 +696,9 @@ describe("connection/identity slot wiring", () => {
     expect(appSource).toMatch(
       /trailingControls=\{[\s\S]{0,600}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{desktopConnectionStatus\}[\s\S]{0,200}?connectionLabel="Daemon connection"/,
     );
-    expect(appSource).toMatch(/createDesktopConnectionStatusSource\(host\.daemonEvents\)/);
+    expect(appSource).toMatch(
+      /createDesktopConnectionStatusSource\(host\.daemonEvents, host\.daemon\.autoReconnect\)/,
+    );
     expect(appSource).not.toMatch(/connectionStatus\$=\{host\.transport\.connectionStatus\$\}/);
   });
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -384,6 +384,16 @@ export function useNotebook() {
       setLoadError,
       bootstrapTimeoutMs: BOOTSTRAP_INTERACTIVE_TIMEOUT_MS,
       onBootstrapTimeout: () => {
+        // Automatic recovery stays inside the governor: retryNow() dials
+        // immediately and, on failure, the backoff schedule resumes.
+        // host.daemon.reconnect is exclusive to the user's explicit Retry —
+        // its reset() would cancel the governor's pending retry and replace
+        // it with one dial that schedules nothing on failure.
+        const autoReconnect = host.daemon.autoReconnect;
+        if (autoReconnect) {
+          autoReconnect.retryNow();
+          return;
+        }
         void host.daemon.reconnect({ force: true }).catch((error: unknown) => {
           logger.warn(
             "[automerge-notebook] forced reconnect after bootstrap timeout failed:",

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -392,6 +392,17 @@ export function useNotebook() {
           setLoadError(error instanceof Error ? error.message : String(error));
         });
       },
+      // A failed initial load is terminal for this room: the daemon closes
+      // the session right after sending the status, and every redial gets
+      // the same rejection. Latch the host's automatic reconnect loop off so
+      // it cannot hammer the daemon; the DaemonStatusBanner Retry goes
+      // through host.daemon.reconnect, which drops the latch.
+      onInitialLoadFailed: (reason) => {
+        host.daemon.autoReconnect?.latchFailure(reason);
+      },
+      onInitialLoadRecovered: () => {
+        host.daemon.autoReconnect?.clearLatch();
+      },
     });
 
     // ── Bootstrap / daemon lifecycle ─────────────────────────────

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -386,7 +386,7 @@ export function useNotebook() {
       onBootstrapTimeout: () => {
         // Automatic recovery stays inside the governor: retryNow() dials
         // immediately and, on failure, the backoff schedule resumes.
-        // host.daemon.reconnect is exclusive to the user's explicit Retry —
+        // host.daemon.reconnect is exclusive to the user's explicit Retry ,
         // its reset() would cancel the governor's pending retry and replace
         // it with one dial that schedules nothing on failure.
         const autoReconnect = host.daemon.autoReconnect;

--- a/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
@@ -1,5 +1,6 @@
+import { BehaviorSubject } from "rxjs";
 import { describe, expect, it } from "vite-plus/test";
-import type { ConnectionStatus } from "runtimed";
+import type { ConnectionStatus, ReconnectGovernorState } from "runtimed";
 import { createDesktopConnectionStatusSource } from "../desktop-connection-status";
 
 function createFakeDaemonEvents() {
@@ -73,6 +74,62 @@ describe("createDesktopConnectionStatusSource", () => {
     const statuses: ConnectionStatus[] = [];
     source.subscribe((status) => statuses.push(status));
     expect(statuses).toEqual(["online"]);
+  });
+
+  it("maps disconnect to offline when the reconnect governor is latched", () => {
+    const fake = createFakeDaemonEvents();
+    const state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents, {
+      getState: () => state$.getValue(),
+      state$,
+    });
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+
+    fake.fire("ready");
+    // Terminal initial-load failure latches the governor, then the daemon
+    // closes the session. Nothing is redialing, so "reconnecting" would lie.
+    state$.next({ kind: "latched", reason: "initial load failed" });
+    fake.fire("disconnected");
+
+    expect(statuses).toEqual(["connecting", "online", "offline"]);
+    expect(source.getCurrent()).toBe("offline");
+    source.dispose();
+  });
+
+  it("demotes reconnecting to offline when the latch lands after the disconnect", () => {
+    const fake = createFakeDaemonEvents();
+    const state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents, {
+      getState: () => state$.getValue(),
+      state$,
+    });
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+
+    fake.fire("ready");
+    fake.fire("disconnected");
+    expect(source.getCurrent()).toBe("reconnecting");
+
+    state$.next({ kind: "latched", reason: "initial load failed" });
+    expect(statuses).toEqual(["connecting", "online", "reconnecting", "offline"]);
+
+    // Manual Retry succeeds: daemon:ready brings the dot back to online.
+    state$.next({ kind: "idle" });
+    fake.fire("ready");
+    expect(source.getCurrent()).toBe("online");
+    source.dispose();
+  });
+
+  it("dispose detaches the governor state subscription", () => {
+    const fake = createFakeDaemonEvents();
+    const state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents, {
+      getState: () => state$.getValue(),
+      state$,
+    });
+    source.dispose();
+    expect(state$.observed).toBe(false);
   });
 
   it("unsubscribe and dispose detach cleanly", () => {

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -223,6 +223,30 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("latches the reconnect driver when initial load fails and re-arms on recovery", () => {
+    const onInitialLoadFailed = vi.fn();
+    const onInitialLoadRecovered = vi.fn();
+    const { bridge, subjects } = startBridge({
+      onInitialLoadFailed,
+      onInitialLoadRecovered,
+    });
+
+    subjects.sessionStatus$.next(failedStatus("source_degraded: no baseline"));
+
+    expect(onInitialLoadFailed).toHaveBeenCalledWith(
+      "source_degraded: no baseline",
+    );
+    expect(onInitialLoadRecovered).not.toHaveBeenCalled();
+
+    // A later live session reporting any non-failed phase clears the latch.
+    subjects.sessionStatus$.next(readyStatus());
+
+    expect(onInitialLoadFailed).toHaveBeenCalledTimes(1);
+    expect(onInitialLoadRecovered).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
   it("materializes and seeds app stores when initial sync becomes interactive", async () => {
     const {
       bridge,

--- a/apps/notebook/src/lib/desktop-connection-status.ts
+++ b/apps/notebook/src/lib/desktop-connection-status.ts
@@ -1,4 +1,4 @@
-import type { HostDaemonEvents } from "@nteract/notebook-host";
+import type { HostAutoReconnect, HostDaemonEvents } from "@nteract/notebook-host";
 import type { ConnectionStatus } from "runtimed";
 import type { NotebookConnectionStatusSource } from "@/components/notebook";
 
@@ -10,7 +10,7 @@ export interface DesktopConnectionStatusSource extends NotebookConnectionStatusS
 
 /**
  * Desktop connection-status source for the connection/identity slot,
- * derived from daemon lifecycle events.
+ * derived from daemon lifecycle events and the host's reconnect governor.
  *
  * The Tauri IPC transport's own `connectionStatus$` is honest about IPC
  * but constant in practice — the app never disconnects it, so a dot fed
@@ -24,12 +24,16 @@ export interface DesktopConnectionStatusSource extends NotebookConnectionStatusS
  *
  * - `onReady` → "online" (the host facade backfills from its cache, so a
  *   source created after the daemon is already up still reaches "online")
- * - `onDisconnected` → "reconnecting" (the host immediately starts its own
- *   reconnect — "reconnecting" is the truthful state, not "offline")
+ * - `onDisconnected` → "reconnecting" while the governor is armed (the
+ *   host redials on its own), but "offline" when the governor is latched
+ *   terminal — nothing is redialing, so a reconnecting dot would lie
+ * - a governor transition into "latched" demotes a live "reconnecting"
+ *   dot to "offline" (covers a latch that lands after the disconnect)
  * - `onUnavailable` → "offline"
  */
 export function createDesktopConnectionStatusSource(
   daemonEvents: Pick<HostDaemonEvents, "onReady" | "onDisconnected" | "onUnavailable">,
+  autoReconnect?: Pick<HostAutoReconnect, "getState" | "state$">,
 ): DesktopConnectionStatusSource {
   let current: ConnectionStatus = "connecting";
   const listeners = new Set<(status: ConnectionStatus) => void>();
@@ -43,9 +47,17 @@ export function createDesktopConnectionStatusSource(
 
   const unlisteners = [
     daemonEvents.onReady(() => next("online")),
-    daemonEvents.onDisconnected(() => next("reconnecting")),
+    daemonEvents.onDisconnected(() =>
+      next(autoReconnect?.getState().kind === "latched" ? "offline" : "reconnecting"),
+    ),
     daemonEvents.onUnavailable(() => next("offline")),
   ];
+
+  const latchSubscription = autoReconnect?.state$.subscribe((state) => {
+    if (state.kind === "latched" && current === "reconnecting") {
+      next("offline");
+    }
+  });
 
   return {
     getCurrent: () => current,
@@ -58,6 +70,7 @@ export function createDesktopConnectionStatusSource(
       for (const unlisten of unlisteners) {
         unlisten();
       }
+      latchSubscription?.unsubscribe();
       listeners.clear();
     },
   };

--- a/apps/notebook/src/lib/desktop-connection-status.ts
+++ b/apps/notebook/src/lib/desktop-connection-status.ts
@@ -26,7 +26,7 @@ export interface DesktopConnectionStatusSource extends NotebookConnectionStatusS
  *   source created after the daemon is already up still reaches "online")
  * - `onDisconnected` → "reconnecting" while the governor is armed (the
  *   host redials on its own), but "offline" when the governor is latched
- *   terminal — nothing is redialing, so a reconnecting dot would lie
+ *   terminal, nothing is redialing, so a reconnecting dot would lie
  * - a governor transition into "latched" demotes a live "reconnecting"
  *   dot to "offline" (covers a latch that lands after the disconnect)
  * - `onUnavailable` → "offline"

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -56,6 +56,15 @@ export interface NotebookSyncStoreBridgeOptions {
   setLoadError: (loadError: string | null) => void;
   bootstrapTimeoutMs?: number;
   onBootstrapTimeout?: () => void;
+  /**
+   * The daemon reported `initial_load: failed` for this room. The daemon
+   * closes the connection right after this status, so the caller should
+   * latch automatic reconnection off; redialing cannot succeed until the
+   * failure is resolved. Manual Retry (or a recovered load) re-arms it.
+   */
+  onInitialLoadFailed?: (reason: string) => void;
+  /** Any non-failed initial load phase on a live session; clears a latch. */
+  onInitialLoadRecovered?: () => void;
 }
 
 export interface NotebookSyncStoreBridge {
@@ -208,8 +217,12 @@ export function startNotebookSyncStoreBridge(
         options.setInitialLoadReadyForMutations(false);
         options.setLoadError(status.initial_load.reason);
         options.setIsLoading(false);
+        options.onInitialLoadFailed?.(status.initial_load.reason);
         return;
       }
+      // A live session reporting any non-failed phase proves the load is not
+      // terminally broken; idempotent latch-clear on the reconnect driver.
+      options.onInitialLoadRecovered?.();
 
       const initialLoadStreaming = isInitialLoadStreaming(status.initial_load);
       if (bootstrapTimeout !== null || interactiveReady || initialLoadStreaming) {

--- a/packages/notebook-host/src/index.ts
+++ b/packages/notebook-host/src/index.ts
@@ -4,6 +4,7 @@ export type {
   DaemonReadyPayload,
   DaemonUnavailablePayload,
   GitInfo,
+  HostAutoReconnect,
   HostBlobRef,
   HostBlobResolver,
   HostBlobs,

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -156,8 +156,11 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
       }
     },
     async reconnect(options) {
-      // Explicit reconnect (Retry button, bootstrap-timeout recovery):
-      // drop any terminal latch and restart the backoff schedule, then dial.
+      // Explicit user Retry only: drop any terminal latch and restart the
+      // backoff schedule, then dial once. Automatic recovery paths must use
+      // `autoReconnect.retryNow()` instead — this reset cancels the
+      // governor's pending retry and replaces it with a single dial whose
+      // failure schedules nothing.
       reconnectGovernor.reset();
       await reconnectDaemon(options?.force === true);
     },

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -24,7 +24,12 @@ import {
 } from "@tauri-apps/plugin-log";
 import { open as pluginOpenShell } from "@tauri-apps/plugin-shell";
 import { check as pluginCheckUpdate } from "@tauri-apps/plugin-updater";
-import { createHttpBlobResolver, type NotebookResponse, type NotebookTransport } from "runtimed";
+import {
+  ReconnectGovernor,
+  createHttpBlobResolver,
+  type NotebookResponse,
+  type NotebookTransport,
+} from "runtimed";
 import { createCommandRegistry } from "../commands";
 import { wireTauriMenuBridge } from "./menu-bridge";
 import { TauriTransport } from "./transport";
@@ -123,6 +128,25 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     return escalated;
   };
 
+  // The governor owns every automatic reconnect: `daemon:disconnected`
+  // triggers it exactly once per event through the host-level listeners
+  // below, so per-subscriber `onDisconnected` callbacks stay
+  // notification-only and backoff/latch policy lives in one place.
+  const reconnectGovernor = new ReconnectGovernor({
+    reconnect: () => reconnectDaemon(true),
+  });
+  _lastReconnectGovernorDispose?.();
+  const unlistenGovernorEvents = [
+    listenWebview<void>("daemon:disconnected", () => reconnectGovernor.connectionLost()),
+    listenWebview<DaemonReadyPayload>("daemon:ready", () =>
+      reconnectGovernor.connectionEstablished(),
+    ),
+  ];
+  _lastReconnectGovernorDispose = () => {
+    for (const unlisten of unlistenGovernorEvents) unlisten();
+    reconnectGovernor.dispose();
+  };
+
   const daemon: HostDaemon = {
     async isConnected() {
       try {
@@ -132,6 +156,9 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
       }
     },
     async reconnect(options) {
+      // Explicit reconnect (Retry button, bootstrap-timeout recovery):
+      // drop any terminal latch and restart the backoff schedule, then dial.
+      reconnectGovernor.reset();
       await reconnectDaemon(options?.force === true);
     },
     async getInfo() {
@@ -140,6 +167,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     async getReadyInfo() {
       return invoke<DaemonReadyPayload | null>("get_daemon_ready_info");
     },
+    autoReconnect: reconnectGovernor,
   };
 
   let blobResolver: HostBlobResolver | null = null;
@@ -216,11 +244,9 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
       };
     },
     onProgress: (cb) => listenWebview<DaemonProgressPayload>("daemon:progress", cb),
-    onDisconnected: (cb) =>
-      listenWebview<void>("daemon:disconnected", () => {
-        cb();
-        reconnectDaemon(true).catch(() => {});
-      }),
+    // Notification-only: the reconnect governor's host-level listener owns
+    // the automatic redial, so N subscribers never means N reconnect loops.
+    onDisconnected: (cb) => listenWebview<void>("daemon:disconnected", () => cb()),
     onUnavailable: (cb) => listenWebview<DaemonUnavailablePayload>("daemon:unavailable", cb),
   };
 
@@ -508,10 +534,20 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
  */
 let _lastMenuBridgeDispose: (() => void) | undefined;
 
+/**
+ * Internal: disposer for the previous host's reconnect governor and its
+ * host-level daemon lifecycle listeners. Same lifecycle story as the menu
+ * bridge above: one live governor per window, reclaimed when a new host is
+ * constructed (hot reload, tests).
+ */
+let _lastReconnectGovernorDispose: (() => void) | undefined;
+
 /** @internal Test helper — forget the most recent menu bridge disposer. */
 export function _resetMenuBridgeForTests(): void {
   _lastMenuBridgeDispose?.();
   _lastMenuBridgeDispose = undefined;
+  _lastReconnectGovernorDispose?.();
+  _lastReconnectGovernorDispose = undefined;
 }
 
 export { TauriTransport } from "./transport";

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -158,7 +158,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     async reconnect(options) {
       // Explicit user Retry only: drop any terminal latch and restart the
       // backoff schedule, then dial once. Automatic recovery paths must use
-      // `autoReconnect.retryNow()` instead — this reset cancels the
+      // `autoReconnect.retryNow()` instead, this reset cancels the
       // governor's pending retry and replaces it with a single dial whose
       // failure schedules nothing.
       reconnectGovernor.reset();

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -29,12 +29,7 @@
  *   point — not pre-optional now, to keep the contract honest.
  */
 
-import type {
-  BlobRef,
-  BlobResolver,
-  NotebookTransport,
-  ReconnectGovernorState,
-} from "runtimed";
+import type { BlobRef, BlobResolver, NotebookTransport, ReconnectGovernorState } from "runtimed";
 import type { Observable } from "rxjs";
 import type { CommandRegistry } from "./commands";
 
@@ -135,6 +130,12 @@ export interface HostAutoReconnect {
   latchFailure(reason: string): void;
   /** Drop the latch after a live session reports a non-failed load. */
   clearLatch(): void;
+  /**
+   * Pull the next automatic attempt forward to now (bootstrap timeout).
+   * Backoff survives a failed dial: the loop schedules the next attempt.
+   * No-op while latched; terminal failures go through the manual Retry.
+   */
+  retryNow(): void;
   getState(): ReconnectGovernorState;
   readonly state$: Observable<ReconnectGovernorState>;
 }

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -29,7 +29,13 @@
  *   point — not pre-optional now, to keep the contract honest.
  */
 
-import type { BlobRef, BlobResolver, NotebookTransport } from "runtimed";
+import type {
+  BlobRef,
+  BlobResolver,
+  NotebookTransport,
+  ReconnectGovernorState,
+} from "runtimed";
+import type { Observable } from "rxjs";
 import type { CommandRegistry } from "./commands";
 
 // ── Shared types ─────────────────────────────────────────────────────────
@@ -115,6 +121,24 @@ export type Unlisten = () => void;
 
 // ── Namespaces ───────────────────────────────────────────────────────────
 
+/**
+ * Control surface over the host's automatic reconnect loop.
+ *
+ * Present only on hosts that own such a loop (Tauri). The app latches the
+ * loop off when the daemon reports a terminal initial-load failure; the
+ * daemon closes the session right after that status, so reconnecting cannot
+ * succeed until the failure is resolved. `HostDaemon.reconnect` (the manual
+ * Retry path) drops the latch and restarts backoff before dialing.
+ */
+export interface HostAutoReconnect {
+  /** Stop automatic reconnection; `reason` renders in the terminal UI. */
+  latchFailure(reason: string): void;
+  /** Drop the latch after a live session reports a non-failed load. */
+  clearLatch(): void;
+  getState(): ReconnectGovernorState;
+  readonly state$: Observable<ReconnectGovernorState>;
+}
+
 /** Daemon connection state + diagnostics. */
 export interface HostDaemon {
   /** Fast synchronous-ish check; returns false when the daemon socket is down. */
@@ -130,6 +154,11 @@ export interface HostDaemon {
    * events aren't sticky, so the event-based path can miss the first fire.
    */
   getReadyInfo(): Promise<DaemonReadyPayload | null>;
+  /**
+   * Automatic-reconnect policy control, when this host runs such a loop.
+   * Consumers must tolerate absence (browser dev host reconnects on demand).
+   */
+  readonly autoReconnect?: HostAutoReconnect;
 }
 
 export type HostBlobRef = BlobRef;

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -359,9 +359,12 @@ describe("createTauriHost()", () => {
     const unlisten = host.daemonEvents.onReady((p) => received.push(p));
     // Flush the listen() promise so the callback is registered.
     await Promise.resolve();
-    const entry = capturedListens.find((x) => x.event === "daemon:ready");
-    expect(entry).toBeTruthy();
-    entry?.cb({ payload: { runtime: "python" } });
+    // Two listeners share this event: the host-level reconnect-governor
+    // listener installed at construction (payload-ignoring) and the one this
+    // test installed. A real Tauri event fires every registered callback.
+    const entries = capturedListens.filter((x) => x.event === "daemon:ready");
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) entry.cb({ payload: { runtime: "python" } });
     expect(received).toContainEqual({ runtime: "python" });
     unlisten();
     await Promise.resolve();
@@ -376,8 +379,10 @@ describe("createTauriHost()", () => {
     await Promise.resolve();
     expect(capturedInvokes.map((x) => x.cmd)).not.toContain("get_daemon_ready_info");
 
-    const entry = capturedListens.find((x) => x.event === "daemon:ready");
-    entry?.cb({ payload: { runtime: "python" } });
+    // Fire every daemon:ready listener (the reconnect governor holds one
+    // too); only the subscriber this test installed records the payload.
+    const entries = capturedListens.filter((x) => x.event === "daemon:ready");
+    for (const entry of entries) entry.cb({ payload: { runtime: "python" } });
     expect(received).toEqual([{ runtime: "python" }]);
   });
 

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -552,6 +552,29 @@ describe("createTauriHost()", () => {
     ]);
   });
 
+  it("autoReconnect.retryNow dials through the governor and no-ops while latched", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    await Promise.resolve();
+
+    host.daemon.autoReconnect?.retryNow();
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toEqual([
+      {
+        cmd: "reconnect_to_daemon",
+        args: { force: true },
+      },
+    ]);
+
+    // Link comes up (governor returns to idle), then the room load fails
+    // terminally: retryNow must not bypass the latch — that path is
+    // reserved for the manual Retry's reset.
+    for (const entry of capturedListens.filter((x) => x.event === "daemon:ready")) {
+      entry.cb({ payload: { runtime: "python" } });
+    }
+    host.daemon.autoReconnect?.latchFailure("initial load failed");
+    host.daemon.autoReconnect?.retryNow();
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toHaveLength(1);
+  });
+
   it("exposes a command registry", () => {
     const host = createTauriHost({ transport: stubTransport });
     expect(host.commands).toBeTruthy();

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -565,7 +565,7 @@ describe("createTauriHost()", () => {
     ]);
 
     // Link comes up (governor returns to idle), then the room load fails
-    // terminally: retryNow must not bypass the latch — that path is
+    // terminally: retryNow must not bypass the latch, that path is
     // reserved for the manual Retry's reset.
     for (const entry of capturedListens.filter((x) => x.event === "daemon:ready")) {
       entry.cb({ payload: { runtime: "python" } });

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -502,10 +502,12 @@ describe("createTauriHost()", () => {
     host.daemonEvents.onDisconnected(second);
     await Promise.resolve();
 
+    // Three listeners: the host-level reconnect-governor listener installed
+    // at construction plus the two notification-only subscribers. One
+    // simulated Tauri event fires every registered callback once.
     const entries = capturedListens.filter((x) => x.event === "daemon:disconnected");
-    expect(entries).toHaveLength(2);
-    entries[0]?.cb({ payload: undefined });
-    entries[1]?.cb({ payload: undefined });
+    expect(entries).toHaveLength(3);
+    for (const entry of entries) entry.cb({ payload: undefined });
 
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
@@ -518,6 +520,31 @@ describe("createTauriHost()", () => {
 
     resolveReconnect();
     await reconnectPromiseOverride;
+  });
+
+  it("latched auto-reconnect suppresses the disconnect redial until a manual reconnect", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    await Promise.resolve();
+
+    host.daemon.autoReconnect?.latchFailure("initial load failed");
+    expect(host.daemon.autoReconnect?.getState()).toEqual({
+      kind: "latched",
+      reason: "initial load failed",
+    });
+
+    const entries = capturedListens.filter((x) => x.event === "daemon:disconnected");
+    for (const entry of entries) entry.cb({ payload: undefined });
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toEqual([]);
+
+    // Manual Retry drops the latch and dials once.
+    await host.daemon.reconnect({ force: true });
+    expect(host.daemon.autoReconnect?.getState()).toEqual({ kind: "idle" });
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toEqual([
+      {
+        cmd: "reconnect_to_daemon",
+        args: { force: true },
+      },
+    ]);
   });
 
   it("exposes a command registry", () => {

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -60,6 +60,14 @@ export {
   type PollDefinition,
 } from "./poll";
 
+// Client reconnect policy: exponential backoff with jitter plus a terminal
+// failed-load latch (see reconnect-governor.ts)
+export {
+  ReconnectGovernor,
+  type ReconnectGovernorOptions,
+  type ReconnectGovernorState,
+} from "./reconnect-governor";
+
 // Local-first persistence: the NotebookDoc seed record plus the render-only
 // RuntimeStateDoc paint cache (see notebookDocChanged$ and the key-segment
 // docs in notebook-doc-persistence.ts)

--- a/packages/runtimed/src/reconnect-governor.ts
+++ b/packages/runtimed/src/reconnect-governor.ts
@@ -1,0 +1,226 @@
+/**
+ * ReconnectGovernor: client-side policy for automatic daemon reconnection.
+ *
+ * Any transport that auto-reconnects routes its retry decisions through this
+ * class, which owns two invariants:
+ *
+ * 1. **Backoff.** The first retry after a stable connection is immediate;
+ *    consecutive losses grow the delay exponentially with jitter, capped at
+ *    `maxDelayMs`. A daemon that rejects every connection is dialed at most
+ *    once per ~30s instead of several times per second. The attempt counter
+ *    resets only after a connection stays up for `stabilityWindowMs`, so a
+ *    connect-then-drop flap cannot re-arm the fast path.
+ * 2. **Terminal latch.** `latchFailure(reason)` (initial load reported
+ *    `Failed` for the room) stops automatic reconnection entirely. Only
+ *    `reset()` (a manual Retry) or `clearLatch()` (a live session reports a
+ *    non-failed load) re-arms the loop.
+ *
+ * Timers run on the injected `SchedulerLike` so tests drive them with virtual
+ * time. Every cancel/reset bumps an internal epoch; async completions from a
+ * previous epoch are ignored, so a stale reconnect settling late can never
+ * clobber a latch or a reset.
+ */
+
+import {
+  BehaviorSubject,
+  asyncScheduler,
+  type Observable,
+  type SchedulerLike,
+  type Subscription,
+} from "rxjs";
+
+export type ReconnectGovernorState =
+  | { kind: "idle" }
+  | { kind: "waiting"; attempt: number; delayMs: number }
+  | { kind: "reconnecting"; attempt: number }
+  | { kind: "latched"; reason: string };
+
+export interface ReconnectGovernorOptions {
+  /**
+   * One reconnect attempt. Resolution means the dial succeeded (session
+   * health is reported separately via `connectionEstablished`); rejection
+   * schedules the next attempt.
+   */
+  reconnect: () => Promise<void>;
+  /** Delay before the second consecutive attempt. Default 500ms. */
+  baseDelayMs?: number;
+  /** Delay ceiling. Default 30_000ms. */
+  maxDelayMs?: number;
+  /** Uniform jitter as a fraction of the raw delay. Default 0.25 (±25%). */
+  jitterRatio?: number;
+  /**
+   * How long a connection must stay established before the attempt counter
+   * resets to the immediate-retry fast path. Default 10_000ms.
+   */
+  stabilityWindowMs?: number;
+  /** Jitter source in [0, 1). Injectable for deterministic tests. */
+  random?: () => number;
+  /** Clock for retry and stability timers. Injectable for virtual time. */
+  scheduler?: SchedulerLike;
+}
+
+export class ReconnectGovernor {
+  private readonly reconnect: () => Promise<void>;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly jitterRatio: number;
+  private readonly stabilityWindowMs: number;
+  private readonly random: () => number;
+  private readonly scheduler: SchedulerLike;
+
+  private readonly _state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
+  readonly state$: Observable<ReconnectGovernorState> = this._state$.asObservable();
+
+  private attempt = 0;
+  private epoch = 0;
+  private retryTimer: Subscription | null = null;
+  private stabilityTimer: Subscription | null = null;
+  private disposed = false;
+
+  constructor(options: ReconnectGovernorOptions) {
+    this.reconnect = options.reconnect;
+    this.baseDelayMs = options.baseDelayMs ?? 500;
+    this.maxDelayMs = options.maxDelayMs ?? 30_000;
+    this.jitterRatio = options.jitterRatio ?? 0.25;
+    this.stabilityWindowMs = options.stabilityWindowMs ?? 10_000;
+    this.random = options.random ?? Math.random;
+    this.scheduler = options.scheduler ?? asyncScheduler;
+  }
+
+  getState(): ReconnectGovernorState {
+    return this._state$.getValue();
+  }
+
+  /**
+   * The daemon link dropped. Schedules the next automatic attempt unless a
+   * retry is already pending or the governor is latched.
+   */
+  connectionLost(): void {
+    if (this.disposed) return;
+    const state = this.getState();
+    if (state.kind === "latched" || state.kind === "waiting") return;
+    this.cancelStabilityTimer();
+    this.scheduleAttempt(this.attempt + 1);
+  }
+
+  /**
+   * The daemon link is up (daemon:ready). Cancels any pending retry. The
+   * attempt counter resets only after the link survives the stability
+   * window, so connect-then-drop flapping keeps growing the backoff.
+   */
+  connectionEstablished(): void {
+    if (this.disposed) return;
+    this.armStabilityTimer();
+    const kind = this.getState().kind;
+    if (kind === "latched" || kind === "idle") return;
+    this.cancelRetryTimer();
+    this.epoch++;
+    this._state$.next({ kind: "idle" });
+  }
+
+  /**
+   * Latch a terminal failure: automatic reconnection stops until `reset()`
+   * or `clearLatch()`. The reason is surfaced by the terminal UI.
+   */
+  latchFailure(reason: string): void {
+    if (this.disposed) return;
+    this.cancelRetryTimer();
+    this.cancelStabilityTimer();
+    this.epoch++;
+    this._state$.next({ kind: "latched", reason });
+  }
+
+  /**
+   * A live session reported a non-failed initial load; drop the latch
+   * without touching backoff. No-op unless latched.
+   */
+  clearLatch(): void {
+    if (this.disposed) return;
+    if (this.getState().kind !== "latched") return;
+    this.attempt = 0;
+    this.epoch++;
+    this._state$.next({ kind: "idle" });
+  }
+
+  /**
+   * Manual-retry intent: drop the latch, restart backoff from scratch, and
+   * cancel any pending automatic attempt. The caller performs its own dial.
+   */
+  reset(): void {
+    if (this.disposed) return;
+    this.cancelRetryTimer();
+    this.cancelStabilityTimer();
+    this.attempt = 0;
+    this.epoch++;
+    this._state$.next({ kind: "idle" });
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.cancelRetryTimer();
+    this.cancelStabilityTimer();
+    this.epoch++;
+    this._state$.complete();
+  }
+
+  private scheduleAttempt(attempt: number): void {
+    this.cancelRetryTimer();
+    this.attempt = attempt;
+    const delayMs = this.delayForAttempt(attempt);
+    const epoch = ++this.epoch;
+    if (delayMs === 0) {
+      // Immediate first retry keeps the healthy-disconnect UX snappy and
+      // runs inline so callers observe "reconnecting" synchronously.
+      this.runAttempt(attempt, epoch);
+      return;
+    }
+    this._state$.next({ kind: "waiting", attempt, delayMs });
+    this.retryTimer = this.scheduler.schedule(() => {
+      this.retryTimer = null;
+      if (this.disposed || epoch !== this.epoch) return;
+      this.runAttempt(attempt, epoch);
+    }, delayMs);
+  }
+
+  private runAttempt(attempt: number, epoch: number): void {
+    this._state$.next({ kind: "reconnecting", attempt });
+    this.reconnect().then(
+      () => {
+        // Dialed. Session health arrives out-of-band: either
+        // connectionEstablished (idle) or another connectionLost (next
+        // attempt). Nothing to do here.
+      },
+      () => {
+        if (this.disposed || epoch !== this.epoch) return;
+        this.scheduleAttempt(this.attempt + 1);
+      },
+    );
+  }
+
+  private delayForAttempt(attempt: number): number {
+    if (attempt <= 1) return 0;
+    const raw = Math.min(this.baseDelayMs * 2 ** (attempt - 2), this.maxDelayMs);
+    const jittered = raw * (1 + this.jitterRatio * (2 * this.random() - 1));
+    return Math.min(Math.max(Math.round(jittered), 0), this.maxDelayMs);
+  }
+
+  private armStabilityTimer(): void {
+    this.cancelStabilityTimer();
+    this.stabilityTimer = this.scheduler.schedule(() => {
+      this.stabilityTimer = null;
+      if (this.disposed) return;
+      this.attempt = 0;
+    }, this.stabilityWindowMs);
+  }
+
+  private cancelRetryTimer(): void {
+    this.retryTimer?.unsubscribe();
+    this.retryTimer = null;
+  }
+
+  private cancelStabilityTimer(): void {
+    this.stabilityTimer?.unsubscribe();
+    this.stabilityTimer = null;
+  }
+}

--- a/packages/runtimed/src/reconnect-governor.ts
+++ b/packages/runtimed/src/reconnect-governor.ts
@@ -143,6 +143,27 @@ export class ReconnectGovernor {
   }
 
   /**
+   * Pull the next automatic attempt forward to now. For callers whose own
+   * signal (bootstrap timeout) says the link is dead even though no
+   * `connectionLost` fired, or one fired and the retry is still waiting.
+   * Unlike `reset()`, the backoff schedule survives: a failed dial
+   * schedules the next attempt instead of leaving nothing pending. No-op
+   * while latched (terminal failures need `reset()`) or while an attempt
+   * is already in flight.
+   */
+  retryNow(): void {
+    if (this.disposed) return;
+    const kind = this.getState().kind;
+    if (kind === "latched" || kind === "reconnecting") return;
+    this.cancelRetryTimer();
+    this.cancelStabilityTimer();
+    const attempt = Math.max(this.attempt, 1);
+    this.attempt = attempt;
+    const epoch = ++this.epoch;
+    this.runAttempt(attempt, epoch);
+  }
+
+  /**
    * Manual-retry intent: drop the latch, restart backoff from scratch, and
    * cancel any pending automatic attempt. The caller performs its own dial.
    */

--- a/packages/runtimed/src/reconnect-governor.ts
+++ b/packages/runtimed/src/reconnect-governor.ts
@@ -226,6 +226,11 @@ export class ReconnectGovernor {
     return Math.min(Math.max(Math.round(jittered), 0), this.maxDelayMs);
   }
 
+  // A drop right after the window fires gets one immediate redial: the
+  // window IS the definition of having earned the fast path back. The
+  // pathological flap cycle (up for exactly the window, then drop) dials
+  // once per stabilityWindowMs, the accepted floor, versus several per
+  // second unguarded.
   private armStabilityTimer(): void {
     this.cancelStabilityTimer();
     this.stabilityTimer = this.scheduler.schedule(() => {

--- a/packages/runtimed/tests/reconnect-governor.test.ts
+++ b/packages/runtimed/tests/reconnect-governor.test.ts
@@ -181,6 +181,32 @@ describe("ReconnectGovernor backoff", () => {
     h.governor.dispose();
   });
 
+  it("a loss in the same frame the stability window fires takes the fast path", async () => {
+    const h = createHarness({ stabilityWindowMs: 10_000 });
+
+    // Reach attempt 2 so a non-reset loss would schedule a delayed retry.
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    advanceBy(h.scheduler, 500);
+    h.dials.at(-1)?.resolve();
+    await drainMicrotasks();
+    h.governor.connectionEstablished();
+
+    // The timer fires at exactly the window boundary; the loss lands in the
+    // same virtual frame. The window elapsed, so the fast path is earned:
+    // attempt 1, immediate dial, and backoff still grows from there on the
+    // next consecutive loss.
+    advanceBy(h.scheduler, 10_000);
+    const before = h.dialFrames.length;
+    h.governor.connectionLost();
+    expect(h.dialFrames).toHaveLength(before + 1);
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 1 });
+    await dialResolvesThenDrops(h);
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    h.governor.dispose();
+  });
+
   it("connectionEstablished cancels a pending retry", async () => {
     const h = createHarness();
 

--- a/packages/runtimed/tests/reconnect-governor.test.ts
+++ b/packages/runtimed/tests/reconnect-governor.test.ts
@@ -1,0 +1,327 @@
+/**
+ * ReconnectGovernor contract tests.
+ *
+ * Timers run on an injected `VirtualTimeScheduler`; reconnect promises settle
+ * on the real microtask queue, drained explicitly with `drainMicrotasks`. The
+ * two load-bearing behaviors are the backoff schedule (a rejecting daemon can
+ * never be dialed at multiple connects per second) and the terminal latch
+ * (a Failed initial load stops automatic reconnection until Retry).
+ */
+
+import { ReconnectGovernor } from "runtimed";
+import { VirtualAction, VirtualTimeScheduler } from "rxjs";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+/** Advance the virtual clock by `ms`, stopping at the target frame. */
+function advanceBy(scheduler: VirtualTimeScheduler, ms: number): void {
+  const target = scheduler.frame + ms;
+  scheduler.maxFrames = target;
+  scheduler.schedule(() => {}, ms);
+  scheduler.flush();
+}
+
+/** Let queued microtasks (promise `.then` chains) run to completion. */
+async function drainMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+function newScheduler(): VirtualTimeScheduler {
+  return new VirtualTimeScheduler(VirtualAction, Infinity);
+}
+
+interface Harness {
+  scheduler: VirtualTimeScheduler;
+  governor: ReconnectGovernor;
+  /** Virtual-time frames at which `reconnect` was called. */
+  dialFrames: number[];
+  /** Settle controls for each reconnect call, in call order. */
+  dials: Array<{ resolve: () => void; reject: (err: unknown) => void }>;
+}
+
+function createHarness(
+  options: Partial<ConstructorParameters<typeof ReconnectGovernor>[0]> = {},
+): Harness {
+  const scheduler = newScheduler();
+  const dialFrames: number[] = [];
+  const dials: Harness["dials"] = [];
+  const governor = new ReconnectGovernor({
+    reconnect: () =>
+      new Promise<void>((resolve, reject) => {
+        dialFrames.push(scheduler.frame);
+        dials.push({ resolve: () => resolve(), reject });
+      }),
+    // random 0.5 makes the jitter factor exactly 1.0, so delays are deterministic.
+    random: () => 0.5,
+    scheduler,
+    ...options,
+  });
+  return { scheduler, governor, dialFrames, dials };
+}
+
+/** Drive one full "dial resolves, daemon closes the session again" cycle. */
+async function dialResolvesThenDrops(h: Harness): Promise<void> {
+  h.dials.at(-1)?.resolve();
+  await drainMicrotasks();
+  h.governor.connectionLost();
+}
+
+describe("ReconnectGovernor backoff", () => {
+  it("retries immediately on the first loss, then grows the delay exponentially to the cap", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    expect(h.dialFrames).toEqual([0]);
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 1 });
+
+    // attempt 2..N: delays 500, 1000, 2000, ..., capped at 30_000.
+    const expectedDelays = [500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+    for (const [i, delay] of expectedDelays.entries()) {
+      await dialResolvesThenDrops(h);
+      expect(h.governor.getState()).toEqual({
+        kind: "waiting",
+        attempt: i + 2,
+        delayMs: delay,
+      });
+      const before = h.dialFrames.length;
+      advanceBy(h.scheduler, delay - 1);
+      expect(h.dialFrames).toHaveLength(before);
+      advanceBy(h.scheduler, 1);
+      expect(h.dialFrames).toHaveLength(before + 1);
+    }
+
+    h.governor.dispose();
+  });
+
+  it("keeps jittered delays within the ±25% band and under the cap", () => {
+    const low = createHarness({ random: () => 0 });
+    low.governor.connectionLost();
+    low.dials[0]?.resolve();
+    // Second attempt with random()=0: 500 * 0.75 = 375.
+    low.governor.connectionLost();
+    expect(low.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 375 });
+    low.governor.dispose();
+
+    const high = createHarness({
+      random: () => 0.999999,
+      baseDelayMs: 2_000,
+      maxDelayMs: 1_000,
+    });
+    high.governor.connectionLost();
+    high.dials[0]?.resolve();
+    // Raw delay already at the cap; upward jitter clamps back to the cap.
+    high.governor.connectionLost();
+    expect(high.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 1_000 });
+    high.governor.dispose();
+  });
+
+  it("schedules the next attempt on its own when the dial itself rejects", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    expect(h.dialFrames).toEqual([0]);
+    h.dials[0]?.reject(new Error("daemon not listening"));
+    await drainMicrotasks();
+
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+    advanceBy(h.scheduler, 500);
+    expect(h.dialFrames).toHaveLength(2);
+
+    h.governor.dispose();
+  });
+
+  it("ignores duplicate connectionLost while a retry is already pending", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    h.governor.connectionLost();
+    h.governor.connectionLost();
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    advanceBy(h.scheduler, 500);
+    expect(h.dialFrames).toHaveLength(2);
+
+    h.governor.dispose();
+  });
+
+  it("resets to the immediate fast path only after the link stays up for the stability window", async () => {
+    const h = createHarness({ stabilityWindowMs: 10_000 });
+
+    // Two consecutive losses reach attempt 2.
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    advanceBy(h.scheduler, 500);
+    expect(h.dialFrames).toHaveLength(2);
+
+    // Ready arrives but the link drops before the stability window elapses:
+    // backoff keeps growing (attempt 3), no immediate redial flap.
+    h.dials.at(-1)?.resolve();
+    await drainMicrotasks();
+    h.governor.connectionEstablished();
+    advanceBy(h.scheduler, 9_999);
+    h.governor.connectionLost();
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 3, delayMs: 1_000 });
+    advanceBy(h.scheduler, 1_000);
+    expect(h.dialFrames).toHaveLength(3);
+
+    // This time the link survives the window; the next loss is immediate.
+    h.dials.at(-1)?.resolve();
+    await drainMicrotasks();
+    h.governor.connectionEstablished();
+    advanceBy(h.scheduler, 10_000);
+    const before = h.dialFrames.length;
+    h.governor.connectionLost();
+    expect(h.dialFrames).toHaveLength(before + 1);
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 1 });
+
+    h.governor.dispose();
+  });
+
+  it("connectionEstablished cancels a pending retry", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    h.governor.connectionEstablished();
+    expect(h.governor.getState()).toEqual({ kind: "idle" });
+    advanceBy(h.scheduler, 60_000);
+    expect(h.dialFrames).toHaveLength(1);
+
+    h.governor.dispose();
+  });
+});
+
+describe("ReconnectGovernor terminal latch", () => {
+  it("latchFailure cancels the pending retry and stops the loop", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    h.governor.latchFailure("source_degraded: recovery contains peer changes");
+    expect(h.governor.getState()).toEqual({
+      kind: "latched",
+      reason: "source_degraded: recovery contains peer changes",
+    });
+
+    advanceBy(h.scheduler, 120_000);
+    h.governor.connectionLost();
+    advanceBy(h.scheduler, 120_000);
+    expect(h.dialFrames).toHaveLength(1);
+
+    h.governor.dispose();
+  });
+
+  it("reset clears the latch and re-arms immediate retry", () => {
+    const h = createHarness();
+
+    h.governor.latchFailure("load failed");
+    h.governor.reset();
+    expect(h.governor.getState()).toEqual({ kind: "idle" });
+
+    h.governor.connectionLost();
+    expect(h.dialFrames).toHaveLength(1);
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 1 });
+
+    h.governor.dispose();
+  });
+
+  it("clearLatch drops only a latched state", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    const waiting = h.governor.getState();
+    h.governor.clearLatch();
+    expect(h.governor.getState()).toEqual(waiting);
+    advanceBy(h.scheduler, 500);
+    expect(h.dialFrames).toHaveLength(2);
+
+    h.governor.latchFailure("load failed");
+    h.governor.clearLatch();
+    expect(h.governor.getState()).toEqual({ kind: "idle" });
+
+    h.governor.dispose();
+  });
+
+  it("connectionEstablished does not clear a latch", () => {
+    const h = createHarness();
+
+    h.governor.latchFailure("load failed");
+    h.governor.connectionEstablished();
+    expect(h.governor.getState()).toEqual({ kind: "latched", reason: "load failed" });
+
+    h.governor.dispose();
+  });
+
+  it("emits state transitions on the readonly observable", async () => {
+    const h = createHarness();
+    const seen: string[] = [];
+    const sub = h.governor.state$.subscribe((state) => seen.push(state.kind));
+
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    h.governor.latchFailure("load failed");
+    h.governor.reset();
+
+    expect(seen).toEqual(["idle", "reconnecting", "waiting", "latched", "idle"]);
+    sub.unsubscribe();
+    h.governor.dispose();
+  });
+});
+
+describe("ReconnectGovernor stale-completion invalidation", () => {
+  it("ignores a dial rejection that settles after reset", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    expect(h.dialFrames).toHaveLength(1);
+
+    h.governor.reset();
+    h.dials[0]?.reject(new Error("late failure"));
+    await drainMicrotasks();
+
+    expect(h.governor.getState()).toEqual({ kind: "idle" });
+    advanceBy(h.scheduler, 120_000);
+    expect(h.dialFrames).toHaveLength(1);
+
+    h.governor.dispose();
+  });
+
+  it("ignores a dial rejection that settles after latchFailure", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    h.governor.latchFailure("load failed");
+    h.dials[0]?.reject(new Error("late failure"));
+    await drainMicrotasks();
+
+    expect(h.governor.getState()).toEqual({ kind: "latched", reason: "load failed" });
+    advanceBy(h.scheduler, 120_000);
+    expect(h.dialFrames).toHaveLength(1);
+
+    h.governor.dispose();
+  });
+
+  it("does nothing after dispose", () => {
+    const h = createHarness();
+    const spy = vi.fn();
+    const sub = h.governor.state$.subscribe({ complete: spy });
+
+    h.governor.dispose();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    h.governor.connectionLost();
+    h.governor.latchFailure("load failed");
+    advanceBy(h.scheduler, 120_000);
+    expect(h.dialFrames).toHaveLength(0);
+    sub.unsubscribe();
+  });
+});

--- a/packages/runtimed/tests/reconnect-governor.test.ts
+++ b/packages/runtimed/tests/reconnect-governor.test.ts
@@ -197,6 +197,65 @@ describe("ReconnectGovernor backoff", () => {
   });
 });
 
+describe("ReconnectGovernor retryNow", () => {
+  it("pulls a waiting backoff attempt forward and resumes the schedule on failure", async () => {
+    const h = createHarness();
+
+    // Bootstrap-timeout scenario: the daemon died mid-load, the governor is
+    // waiting out a backoff delay when the caller demands an immediate dial.
+    h.governor.connectionLost();
+    await dialResolvesThenDrops(h);
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    const beforeFrame = h.scheduler.frame;
+    h.governor.retryNow();
+    expect(h.dialFrames).toEqual([0, beforeFrame]);
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 2 });
+
+    // The immediate dial fails: the backoff schedule resumes, not silence.
+    h.dials.at(-1)?.reject(new Error("daemon still down"));
+    await drainMicrotasks();
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 3, delayMs: 1_000 });
+    advanceBy(h.scheduler, 1_000);
+    expect(h.dialFrames).toHaveLength(3);
+
+    h.governor.dispose();
+  });
+
+  it("dials from idle and enters the backoff loop on failure", async () => {
+    const h = createHarness();
+
+    h.governor.retryNow();
+    expect(h.dialFrames).toEqual([0]);
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 1 });
+
+    h.dials[0]?.reject(new Error("daemon not listening"));
+    await drainMicrotasks();
+    expect(h.governor.getState()).toEqual({ kind: "waiting", attempt: 2, delayMs: 500 });
+
+    h.governor.dispose();
+  });
+
+  it("is a no-op while latched and while an attempt is in flight", async () => {
+    const h = createHarness();
+
+    h.governor.connectionLost();
+    expect(h.governor.getState()).toEqual({ kind: "reconnecting", attempt: 1 });
+    h.governor.retryNow();
+    expect(h.dialFrames).toHaveLength(1);
+
+    h.dials[0]?.resolve();
+    await drainMicrotasks();
+    h.governor.latchFailure("load failed");
+    h.governor.retryNow();
+    advanceBy(h.scheduler, 120_000);
+    expect(h.dialFrames).toHaveLength(1);
+    expect(h.governor.getState()).toEqual({ kind: "latched", reason: "load failed" });
+
+    h.governor.dispose();
+  });
+});
+
 describe("ReconnectGovernor terminal latch", () => {
   it("latchFailure cancels the pending retry and stops the loop", async () => {
     const h = createHarness();


### PR DESCRIPTION
Client half of #4065. A room whose initial materialization fails sends `initial_load Failed` and closes the session. The desktop client read that close as a transient disconnect and redialed immediately, several times per second, indefinitely. In the incident that's 2,201 rejected connections over 2.5 hours, contributing to daemon fd exhaustion.

Adds `ReconnectGovernor` (`packages/runtimed/src/reconnect-governor.ts`) as the single authority over automatic reconnects. It owns two invariants: exponential backoff with +/-25% jitter capped at 30s, where the attempt counter only resets after the link stays up for a stability window (so connect-then-drop flapping can't re-arm the fast path); and a terminal latch, armed when the room reports a failed initial load, that blocks all automatic redial until the user hits Retry or a live session reports a non-failed phase. An epoch counter invalidates stale async completions across reset/latch transitions, so a delayed callback from a superseded attempt can never clobber a fresher latch or reset.

The status dot now consults the governor before mapping `daemon:disconnected`. Latched-terminal reports "offline" instead of a permanent "reconnecting" lie sitting next to the terminal-failure banner.

Bootstrap-timeout auto-recovery now goes through `governor.retryNow()` instead of `host.daemon.reconnect`. `retryNow()` pulls the next attempt forward and keeps the backoff schedule alive if the dial fails, so a daemon dying mid-load can't strand the client with nothing pending. `reset()` stays exclusive to the user Retry button: it cancels any pending retry and dials once with nothing scheduled on failure.

The Tauri host's `daemon:disconnected` handler used to embed `reconnectDaemon(true)` per subscriber. The governor's single host-level listener now owns the redial, so `onDisconnected` callbacks are notification-only and N subscribers never means N reconnect loops.

## Behavioral coverage

| Event | Before | After |
|---|---|---|
| Room sends `initial_load Failed` | Immediate redial, unbounded rate | Governor latches; no automatic redial |
| Repeated connect-then-drop flapping | Reconnect storm, several/sec | Exponential backoff, capped 30s, jittered |
| Link stable past the stability window | N/A | Attempt counter resets, next loss starts from immediate retry |
| Status dot while latched | Reports "reconnecting" forever | Reports "offline" |
| User clicks Retry | Same as any redial | Drops latch, resets backoff, dials once |
| Bootstrap-timeout auto-recovery | Called `host.daemon.reconnect` directly | Routes through `governor.retryNow()`, resumes backoff on failure |
| Stale async completion after reset/latch | Could overwrite newer state | Epoch check drops it |

Virtual-time tests (rxjs `VirtualTimeScheduler`) cover the backoff schedule, the latch, and the bootstrap-timeout path. Full gate: root vitest suite (2,764 tests), `apps/notebook` build (`tsc -b`), lint clean.

Related: #4065 (server-side restore heal and save-side baseline fix land separately), #4053, #4062.
