### PR TITLE
fix(runtimed): single-flight kernel auto-launch per room

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2875,20 +2875,105 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
 /// Auto-launch kernel for a trusted notebook when first peer connects.
 /// This is similar to handle_notebook_request(LaunchKernel) but without a request/response.
 ///
-/// Resolves the metadata snapshot from the Automerge doc (if the first client has
-/// already synced) or falls back to reading the .ipynb from disk.
+/// Loops over [`auto_launch_kernel_attempt`]: one iteration per admitted
+/// single-flight token. An iteration hands back a fresh token only when its
+/// benign no-peers abort raced a reconnect. That connect was refused
+/// admission (`InFlight`) while this task still held the gate and has no
+/// retry trigger of its own, so this task retries on its behalf.
 pub(crate) async fn auto_launch_kernel(
     room: &std::sync::Arc<NotebookRoom>,
     notebook_id: &str,
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
-    // Single-flight admission token from `NotebookRoom::try_begin_auto_launch`.
-    // This function owns the attempt end to end: dropping the token on any
-    // exit path that did not launch a kernel (and was not a benign abort)
-    // arms the failure cooldown, so early returns need no per-site handling.
     attempt: super::room::AutoLaunchAttempt,
 ) {
+    let mut attempt = attempt;
+    loop {
+        attempt = match auto_launch_kernel_attempt(
+            room,
+            notebook_id,
+            default_runtime.clone(),
+            default_python_env.clone(),
+            daemon.clone(),
+            attempt,
+        )
+        .await
+        {
+            Some(next) => next,
+            None => return,
+        };
+        info!(
+            "[notebook-sync] Auto-launch abort raced a reconnect for {}; retrying",
+            notebook_id
+        );
+        // The abort reset lifecycle to NotStarted; restore Resolving to
+        // mirror what the connect path writes after admission, so the
+        // reconnected peer never sits on stale NotStarted.
+        if let Err(e) = room
+            .state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        {
+            warn!("[runtime-state] {}", e);
+        }
+    }
+}
+
+/// Benign no-peers abort for an in-flight auto-launch attempt.
+///
+/// Releases the single-flight token, then re-checks active peers only after
+/// the release. The order is load-bearing: a connect that lands during the
+/// abort window is refused admission (`InFlight`) and has no retry trigger of
+/// its own, so a peers check taken before the release could see 0, release
+/// the gate, and strand the reconnected peer at `NotStarted` with nobody left
+/// to launch. Checking after the release closes that window: either this
+/// call sees the peer and re-admits on its behalf, or the connect itself got
+/// admitted after the release and owns the next attempt.
+///
+/// Returns a fresh token when the caller should retry the launch; `None`
+/// when the abort stands or another caller won re-admission.
+pub(crate) async fn release_attempt_and_readmit_if_peer_waiting(
+    room: &std::sync::Arc<NotebookRoom>,
+    attempt: super::room::AutoLaunchAttempt,
+) -> Option<super::room::AutoLaunchAttempt> {
+    reset_starting_state(room, None).await;
+    attempt.release_without_cooldown();
+    if room
+        .connections
+        .active_peers
+        .load(std::sync::atomic::Ordering::Relaxed)
+        == 0
+    {
+        return None;
+    }
+    match room.try_begin_auto_launch() {
+        super::room::AutoLaunchAdmission::Admitted(next) => Some(next),
+        // InFlight: the racing connect was admitted after the release and
+        // owns the retry. CoolingDown: a concurrent failed attempt armed
+        // the gate between release and re-check; its Error lifecycle is
+        // the signal the connected peer observes.
+        _ => None,
+    }
+}
+
+/// One admitted auto-launch attempt, owned end to end.
+///
+/// Resolves the metadata snapshot from the Automerge doc (if the first client
+/// has already synced) or falls back to reading the .ipynb from disk.
+///
+/// Token disposition: dropping `attempt` on any exit path that did not launch
+/// a kernel (and was not a benign abort) arms the failure cooldown, so error
+/// returns need no per-site handling. Returns `Some(token)` only when a
+/// benign no-peers abort re-admitted a reconnect that raced it; the caller
+/// must retry with that token.
+async fn auto_launch_kernel_attempt(
+    room: &std::sync::Arc<NotebookRoom>,
+    notebook_id: &str,
+    default_runtime: crate::runtime::Runtime,
+    default_python_env: crate::settings_doc::PythonEnvType,
+    daemon: std::sync::Arc<crate::daemon::Daemon>,
+    attempt: super::room::AutoLaunchAttempt,
+) -> Option<super::room::AutoLaunchAttempt> {
     // Check if room still has peers (protect against race condition where client disconnects
     // before we finish launching)
     if room
@@ -2898,9 +2983,7 @@ pub(crate) async fn auto_launch_kernel(
         == 0
     {
         debug!("[notebook-sync] Auto-launch aborted: no peers remaining");
-        reset_starting_state(room, None).await;
-        attempt.release_without_cooldown();
-        return;
+        return release_attempt_and_readmit_if_peer_waiting(room, attempt).await;
     }
 
     // For saved notebooks, notebook_path_opt is the file path (kernel cwd = parent dir).
@@ -2978,7 +3061,7 @@ pub(crate) async fn auto_launch_kernel(
         if has_runtime_agent {
             debug!("[notebook-sync] Auto-launch skipped: runtime agent already exists");
             attempt.release_without_cooldown();
-            return;
+            return None;
         }
     }
 
@@ -2990,9 +3073,7 @@ pub(crate) async fn auto_launch_kernel(
         == 0
     {
         debug!("[notebook-sync] Auto-launch aborted: no peers (after status check)");
-        reset_starting_state(room, None).await;
-        attempt.release_without_cooldown();
-        return;
+        return release_attempt_and_readmit_if_peer_waiting(room, attempt).await;
     }
 
     // Clear any stale comm state from a previous kernel (in case it crashed)
@@ -3070,7 +3151,7 @@ pub(crate) async fn auto_launch_kernel(
                     &details,
                 )
                 .await;
-                return;
+                return None;
             }
         }
     };
@@ -3131,7 +3212,7 @@ pub(crate) async fn auto_launch_kernel(
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
-                return;
+                return None;
             }
         }
     }
@@ -3205,7 +3286,7 @@ pub(crate) async fn auto_launch_kernel(
                         Err(()) => {
                             reset_and_publish_prewarmed_acquire_error(room, env_source.as_str())
                                 .await;
-                            return;
+                            return None;
                         }
                     }
                 };
@@ -3265,7 +3346,7 @@ pub(crate) async fn auto_launch_kernel(
                                     env_source.as_str(),
                                 )
                                 .await;
-                                return;
+                                return None;
                             }
                         }
                     };
@@ -3297,7 +3378,7 @@ pub(crate) async fn auto_launch_kernel(
                     Ok(None) => None,
                     Err(()) => {
                         reset_and_publish_prewarmed_acquire_error(room, prewarmed.as_str()).await;
-                        return;
+                        return None;
                     }
                 };
                 ("python", prewarmed, pooled_env)
@@ -3337,7 +3418,7 @@ pub(crate) async fn auto_launch_kernel(
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
-                return;
+                return None;
             }
         }
     }
@@ -3398,7 +3479,7 @@ pub(crate) async fn auto_launch_kernel(
                         Some(KernelErrorReason::EnvironmentPrepareFailed),
                         &details,
                     );
-                    return;
+                    return None;
                 }
             }
         } else {
@@ -3490,7 +3571,7 @@ pub(crate) async fn auto_launch_kernel(
                                     Some(KernelErrorReason::EnvironmentPrepareFailed),
                                     &details,
                                 );
-                                return;
+                                return None;
                             }
                         }
                     }
@@ -3532,7 +3613,7 @@ pub(crate) async fn auto_launch_kernel(
                             Some(KernelErrorReason::EnvironmentPrepareFailed),
                             &details,
                         );
-                        return;
+                        return None;
                     }
                 }
             }
@@ -3618,7 +3699,7 @@ pub(crate) async fn auto_launch_kernel(
                                     Some(KernelErrorReason::EnvironmentPrepareFailed),
                                     &details,
                                 );
-                                return;
+                                return None;
                             }
                         }
                     }
@@ -3652,7 +3733,7 @@ pub(crate) async fn auto_launch_kernel(
                 details,
             )
             .await;
-            return;
+            return None;
         };
 
         let detected_yml = crate::project_file::DetectedProjectFile {
@@ -3677,7 +3758,7 @@ pub(crate) async fn auto_launch_kernel(
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
-                return;
+                return None;
             }
         }
 
@@ -3693,7 +3774,7 @@ pub(crate) async fn auto_launch_kernel(
                     &details,
                 )
                 .await;
-                return;
+                return None;
             }
         };
 
@@ -3819,7 +3900,7 @@ pub(crate) async fn auto_launch_kernel(
                             &details,
                         )
                         .await;
-                        return;
+                        return None;
                     }
                 } else {
                     true
@@ -3856,7 +3937,7 @@ pub(crate) async fn auto_launch_kernel(
                     &details,
                 )
                 .await;
-                return;
+                return None;
             }
             // The banner stays lit until a terminal phase is written. Emit Ready so
             // it clears whether the sync completed or we fell through to the existing env.
@@ -3891,7 +3972,7 @@ pub(crate) async fn auto_launch_kernel(
                     &details,
                 )
                 .await;
-                return;
+                return None;
             }
 
             match kernel_env::conda::prepare_environment_in(
@@ -3941,7 +4022,7 @@ pub(crate) async fn auto_launch_kernel(
                         &details,
                     )
                     .await;
-                    return;
+                    return None;
                 }
             }
         }
@@ -3998,7 +4079,7 @@ pub(crate) async fn auto_launch_kernel(
                     &details,
                 )
                 .await;
-                return;
+                return None;
             }
         }
     } else if matches!(env_source, EnvSource::PixiToml) {
@@ -4028,7 +4109,7 @@ pub(crate) async fn auto_launch_kernel(
                     &details,
                 )
                 .await;
-                return;
+                return None;
             }
         }
     }
@@ -4090,7 +4171,7 @@ pub(crate) async fn auto_launch_kernel(
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
-                return;
+                return None;
             }
         }
     }
@@ -4230,12 +4311,12 @@ pub(crate) async fn auto_launch_kernel(
                             "[notebook-sync] Runtime agent connect cancelled (superseded or died)"
                         );
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
-                        return;
+                        return None;
                     }
                     TimedOneShot::TimedOut => {
                         warn!("[notebook-sync] Agent failed to connect within 30s");
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
-                        return;
+                        return None;
                     }
                 }
 
@@ -4272,43 +4353,15 @@ pub(crate) async fn auto_launch_kernel(
                         env_source: es,
                     }) => {
                         // env path already registered for GC protection above (before spawn)
-
-                        // Store launched config for env sync drift detection
-                        {
-                            let mut lc = room.runtime_agent_launched_config.write().await;
-                            *lc = Some(launched_config.clone());
-                        }
-
-                        let es_label = es.as_str().to_string();
-                        publish_kernel_state_presence(
+                        finish_auto_launch_success(
                             room,
-                            presence::KernelStatus::Idle,
-                            &es_label,
+                            kernel_type,
+                            es.as_str(),
+                            &runtime_agent_id,
+                            launched_config.clone(),
+                            attempt,
                         )
                         .await;
-
-                        // Write Running(Idle) + kernel info to RuntimeStateDoc
-                        // so frontends see "idle" via CRDT sync.
-                        if let Err(e) = room.state.with_doc(|sd| {
-                            sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
-                            sd.set_kernel_info(kernel_type, kernel_type, &es_label)?;
-                            sd.set_runtime_agent_id(&runtime_agent_id)?;
-                            // Fresh kernel is in sync with its launched config
-                            sd.set_env_sync(true, &[], &[], false, false)?;
-                            Ok(())
-                        }) {
-                            warn!("[runtime-state] {}", e);
-                        }
-
-                        info!(
-                            "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
-                            kernel_type, es_label
-                        );
-
-                        // Reopen the single-flight gate with no cooldown; the
-                        // running kernel is what keeps later connects from
-                        // auto-launching again.
-                        attempt.succeed();
                     }
                     Ok(
                         notebook_protocol::protocol::RuntimeAgentResponse::Error { error }
@@ -4363,6 +4416,59 @@ pub(crate) async fn auto_launch_kernel(
             }
         }
     }
+
+    // Terminal: either the kernel launched (token consumed by
+    // `finish_auto_launch_success`) or a launch/agent error path above
+    // published its lifecycle and the token drops here as a failure,
+    // arming the cooldown.
+    None
+}
+
+/// Terminal bookkeeping for a kernel that launched: record the launched
+/// config for env-sync drift detection, publish Idle presence, write
+/// Running(Idle) + kernel info to RuntimeStateDoc, and mark the
+/// single-flight attempt successful.
+///
+/// The token disposition lives here so the success exit of the launch flow
+/// cannot drop the token as a failure, which would arm the failure cooldown
+/// after every successful launch and block the next legitimate auto-launch
+/// for the cooldown window. The gate reopens with no cooldown; the running
+/// kernel is what keeps later connects from auto-launching again.
+pub(crate) async fn finish_auto_launch_success(
+    room: &NotebookRoom,
+    kernel_type: &str,
+    env_source_label: &str,
+    runtime_agent_id: &str,
+    launched_config: LaunchedEnvConfig,
+    attempt: super::room::AutoLaunchAttempt,
+) {
+    // Store launched config for env sync drift detection
+    {
+        let mut lc = room.runtime_agent_launched_config.write().await;
+        *lc = Some(launched_config);
+    }
+
+    publish_kernel_state_presence(room, presence::KernelStatus::Idle, env_source_label).await;
+
+    // Write Running(Idle) + kernel info to RuntimeStateDoc
+    // so frontends see "idle" via CRDT sync.
+    if let Err(e) = room.state.with_doc(|sd| {
+        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        sd.set_kernel_info(kernel_type, kernel_type, env_source_label)?;
+        sd.set_runtime_agent_id(runtime_agent_id)?;
+        // Fresh kernel is in sync with its launched config
+        sd.set_env_sync(true, &[], &[], false, false)?;
+        Ok(())
+    }) {
+        warn!("[runtime-state] {}", e);
+    }
+
+    info!(
+        "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
+        kernel_type, env_source_label
+    );
+
+    attempt.succeed();
 }
 
 /// Publish the daemon's `KernelState` presence so late-joining peers

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2883,6 +2883,11 @@ pub(crate) async fn auto_launch_kernel(
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
+    // Single-flight admission token from `NotebookRoom::try_begin_auto_launch`.
+    // This function owns the attempt end to end: dropping the token on any
+    // exit path that did not launch a kernel (and was not a benign abort)
+    // arms the failure cooldown, so early returns need no per-site handling.
+    attempt: super::room::AutoLaunchAttempt,
 ) {
     // Check if room still has peers (protect against race condition where client disconnects
     // before we finish launching)
@@ -2894,6 +2899,7 @@ pub(crate) async fn auto_launch_kernel(
     {
         debug!("[notebook-sync] Auto-launch aborted: no peers remaining");
         reset_starting_state(room, None).await;
+        attempt.release_without_cooldown();
         return;
     }
 
@@ -2971,6 +2977,7 @@ pub(crate) async fn auto_launch_kernel(
         let has_runtime_agent = room.runtime_agent_handle.lock().await.is_some();
         if has_runtime_agent {
             debug!("[notebook-sync] Auto-launch skipped: runtime agent already exists");
+            attempt.release_without_cooldown();
             return;
         }
     }
@@ -2984,6 +2991,7 @@ pub(crate) async fn auto_launch_kernel(
     {
         debug!("[notebook-sync] Auto-launch aborted: no peers (after status check)");
         reset_starting_state(room, None).await;
+        attempt.release_without_cooldown();
         return;
     }
 
@@ -4296,6 +4304,11 @@ pub(crate) async fn auto_launch_kernel(
                             "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
                             kernel_type, es_label
                         );
+
+                        // Reopen the single-flight gate with no cooldown; the
+                        // running kernel is what keeps later connects from
+                        // auto-launching again.
+                        attempt.succeed();
                     }
                     Ok(
                         notebook_protocol::protocol::RuntimeAgentResponse::Error { error }

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -237,53 +237,78 @@ where
                 || created_new_at_path);
 
         if should_auto_launch {
-            info!(
-                "[notebook-sync] Auto-launching kernel for notebook {} (trust: {:?}, new: {})",
-                notebook_id, trust_status, is_new_notebook
-            );
-            // Write Resolving immediately so clients never see stale NotStarted
-            if let Err(e) = room
-                .state
-                .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
-            {
-                warn!("[runtime-state] {}", e);
+            // Single-flight admission: at most one auto-launch attempt per
+            // room. A connect that loses admission observes the in-flight
+            // attempt (or the previous failure) through RuntimeStateDoc, so
+            // a client reconnect loop cannot spawn agents at connect
+            // frequency. The gate check happens before the Resolving write
+            // so a skipped connect cannot mask a failed attempt's Error
+            // lifecycle.
+            match room.try_begin_auto_launch() {
+                super::room::AutoLaunchAdmission::Admitted(attempt) => {
+                    info!(
+                        "[notebook-sync] Auto-launching kernel for notebook {} (trust: {:?}, new: {})",
+                        notebook_id, trust_status, is_new_notebook
+                    );
+                    // Write Resolving immediately so clients never see stale NotStarted
+                    if let Err(e) = room
+                        .state
+                        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+                    {
+                        warn!("[runtime-state] {}", e);
+                    }
+                    // Spawn auto-launch in background so we don't block sync
+                    let room_clone = room.clone();
+                    let panic_room = room.clone();
+                    let notebook_id_clone = notebook_id.to_string();
+                    let daemon_clone = ctx.daemon.clone();
+                    let default_runtime = ctx.default_runtime.clone();
+                    let default_python_env = ctx.default_python_env.clone();
+                    spawn_supervised(
+                        "auto-launch-kernel",
+                        async move {
+                            auto_launch_kernel(
+                                &room_clone,
+                                &notebook_id_clone,
+                                default_runtime,
+                                default_python_env,
+                                daemon_clone,
+                                attempt,
+                            )
+                            .await;
+                        },
+                        move |_| {
+                            let r = panic_room;
+                            // with_doc is sync (std::sync::Mutex), so no need for tokio::spawn
+                            // to acquire the lock. But spawn_supervised's panic handler runs
+                            // outside async context, so we still need spawn for the closure.
+                            tokio::spawn(async move {
+                                // Auto-launch panic — no specific typed reason. Clear
+                                // any stale error_reason so the frontend prompt isn't
+                                // stuck on an earlier missing_ipykernel, etc.
+                                if let Err(e) = r.state.with_doc(|sd| {
+                                    sd.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)
+                                }) {
+                                    tracing::warn!("[runtime-state] {}", e);
+                                }
+                            });
+                        },
+                    );
+                }
+                super::room::AutoLaunchAdmission::InFlight => {
+                    debug!(
+                        "[notebook-sync] Auto-launch skipped for {}: attempt already in flight",
+                        notebook_id
+                    );
+                }
+                super::room::AutoLaunchAdmission::CoolingDown { remaining } => {
+                    debug!(
+                        "[notebook-sync] Auto-launch skipped for {}: cooling down after failed attempt ({}ms remaining)",
+                        notebook_id,
+                        remaining.as_millis()
+                    );
+                }
             }
-            // Spawn auto-launch in background so we don't block sync
-            let room_clone = room.clone();
-            let panic_room = room.clone();
-            let notebook_id_clone = notebook_id.to_string();
-            let daemon_clone = ctx.daemon.clone();
-            let default_runtime = ctx.default_runtime.clone();
-            let default_python_env = ctx.default_python_env.clone();
-            spawn_supervised(
-                "auto-launch-kernel",
-                async move {
-                    auto_launch_kernel(
-                        &room_clone,
-                        &notebook_id_clone,
-                        default_runtime,
-                        default_python_env,
-                        daemon_clone,
-                    )
-                    .await;
-                },
-                move |_| {
-                    let r = panic_room;
-                    // with_doc is sync (std::sync::Mutex), so no need for tokio::spawn
-                    // to acquire the lock. But spawn_supervised's panic handler runs
-                    // outside async context, so we still need spawn for the closure.
-                    tokio::spawn(async move {
-                        // Auto-launch panic — no specific typed reason. Clear
-                        // any stale error_reason so the frontend prompt isn't
-                        // stuck on an earlier missing_ipykernel, etc.
-                        if let Err(e) = r.state.with_doc(|sd| {
-                            sd.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)
-                        }) {
-                            tracing::warn!("[runtime-state] {}", e);
-                        }
-                    });
-                },
-            );
         } else if !has_kernel && matches!(trust_status, runt_trust::TrustStatus::Untrusted) {
             // Kernel blocked on trust approval — write this to RuntimeStateDoc
             // so the frontend shows "Awaiting Trust Approval" instead of "Initializing"

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -283,7 +283,7 @@ where
                             // to acquire the lock. But spawn_supervised's panic handler runs
                             // outside async context, so we still need spawn for the closure.
                             tokio::spawn(async move {
-                                // Auto-launch panic — no specific typed reason. Clear
+                                // Auto-launch panic, no specific typed reason. Clear
                                 // any stale error_reason so the frontend prompt isn't
                                 // stuck on an earlier missing_ipykernel, etc.
                                 if let Err(e) = r.state.with_doc(|sd| {

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -965,6 +965,96 @@ impl Drop for SourceReconciliationClaim {
     }
 }
 
+/// Minimum spacing between auto-launch attempts after a failed one. A tight
+/// client reconnect loop must not respawn runtime agents at connect
+/// frequency; each failure holds the gate closed for this long.
+pub(crate) const AUTO_LAUNCH_FAILURE_COOLDOWN: std::time::Duration =
+    std::time::Duration::from_secs(5);
+
+/// Per-room single-flight gate for kernel auto-launch.
+///
+/// At most one auto-launch attempt runs per room at a time; connects that
+/// arrive while an attempt is in flight observe that attempt through
+/// RuntimeStateDoc instead of spawning another agent. A failed attempt closes
+/// the gate for [`AUTO_LAUNCH_FAILURE_COOLDOWN`] so a reconnect loop cannot
+/// turn connect frequency into agent spawn frequency.
+///
+/// Sync-only state behind `std::sync::Mutex`; never hold the lock across an
+/// `.await`.
+#[derive(Default)]
+pub(crate) struct AutoLaunchGate {
+    state: std::sync::Mutex<AutoLaunchGateState>,
+}
+
+#[derive(Default)]
+struct AutoLaunchGateState {
+    in_flight: bool,
+    cooldown_until: Option<tokio::time::Instant>,
+}
+
+impl AutoLaunchGate {
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, AutoLaunchGateState> {
+        // Recover from poisoning: the guarded state is two plain fields and
+        // every critical section is trivially panic-free, so a poisoned lock
+        // carries no torn invariant. Recovering also keeps the token's Drop
+        // from double-panicking during unwind.
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// Outcome of asking the gate for permission to auto-launch.
+pub(crate) enum AutoLaunchAdmission {
+    /// Caller owns the attempt; the gate stays closed until the token drops.
+    Admitted(AutoLaunchAttempt),
+    /// Another attempt is in flight; observe it via RuntimeStateDoc.
+    InFlight,
+    /// A recent attempt failed; the gate reopens after `remaining`.
+    CoolingDown { remaining: std::time::Duration },
+}
+
+enum AutoLaunchOutcome {
+    /// Default: any drop without an explicit outcome (early return, panic
+    /// unwind, launch error) counts as a failure and arms the cooldown.
+    Failed,
+    /// Kernel launched; reopen the gate immediately.
+    Succeeded,
+    /// Benign abort (no peers left, kernel already present); reopen the gate
+    /// immediately so the next connect can launch without waiting.
+    Released,
+}
+
+/// Owned token for one auto-launch attempt. Dropping it reopens the gate;
+/// the drop path is where the failure cooldown is armed, so every early
+/// return and panic in the launch flow is covered without per-site calls.
+pub(crate) struct AutoLaunchAttempt {
+    room: Arc<NotebookRoom>,
+    outcome: AutoLaunchOutcome,
+}
+
+impl AutoLaunchAttempt {
+    /// Mark the attempt successful: reopen the gate with no cooldown.
+    pub(crate) fn succeed(mut self) {
+        self.outcome = AutoLaunchOutcome::Succeeded;
+    }
+
+    /// Mark the attempt a benign no-op: reopen the gate with no cooldown.
+    pub(crate) fn release_without_cooldown(mut self) {
+        self.outcome = AutoLaunchOutcome::Released;
+    }
+}
+
+impl Drop for AutoLaunchAttempt {
+    fn drop(&mut self) {
+        let mut st = self.room.auto_launch_gate.lock_state();
+        st.in_flight = false;
+        if matches!(self.outcome, AutoLaunchOutcome::Failed) {
+            st.cooldown_until = Some(tokio::time::Instant::now() + AUTO_LAUNCH_FAILURE_COOLDOWN);
+        }
+    }
+}
+
 pub struct NotebookRoom {
     /// Permanent, immutable UUID for this room, independent of the display
     /// path or string lookup keys used by callers. Rooms are still looked up
@@ -1050,6 +1140,9 @@ pub struct NotebookRoom {
     /// sync handler to validate connections and prevent stale cleanup from
     /// clobbering state.
     pub current_runtime_agent_id: Arc<RwLock<Option<String>>>,
+    /// Single-flight gate for kernel auto-launch. All auto-launch admission
+    /// goes through [`NotebookRoom::try_begin_auto_launch`].
+    pub(crate) auto_launch_gate: AutoLaunchGate,
 }
 
 impl NotebookRoom {
@@ -1580,6 +1673,36 @@ impl NotebookRoom {
             runtime_agent_generation: Arc::new(AtomicU64::new(0)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
+            auto_launch_gate: AutoLaunchGate::default(),
+        })
+    }
+
+    /// Ask the auto-launch gate for permission to start an attempt.
+    ///
+    /// Returns `Admitted` with an owned token when no attempt is in flight
+    /// and no failure cooldown is active. The token must accompany the
+    /// attempt end to end: dropping it without calling
+    /// [`AutoLaunchAttempt::succeed`] or
+    /// [`AutoLaunchAttempt::release_without_cooldown`] counts as a failure
+    /// and arms [`AUTO_LAUNCH_FAILURE_COOLDOWN`].
+    pub(crate) fn try_begin_auto_launch(self: &Arc<Self>) -> AutoLaunchAdmission {
+        let now = tokio::time::Instant::now();
+        let mut st = self.auto_launch_gate.lock_state();
+        if st.in_flight {
+            return AutoLaunchAdmission::InFlight;
+        }
+        if let Some(until) = st.cooldown_until {
+            if now < until {
+                return AutoLaunchAdmission::CoolingDown {
+                    remaining: until - now,
+                };
+            }
+        }
+        st.in_flight = true;
+        st.cooldown_until = None;
+        AutoLaunchAdmission::Admitted(AutoLaunchAttempt {
+            room: Arc::clone(self),
+            outcome: AutoLaunchOutcome::Failed,
         })
     }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -13126,3 +13126,156 @@ async fn auto_launch_gate_admission_clears_stale_cooldown() {
         "success must not inherit the earlier failure's cooldown"
     );
 }
+
+/// A launch attempt with zero peers aborts benignly through the real
+/// `auto_launch_kernel` entry point: lifecycle lands back on NotStarted and
+/// the gate reopens with no cooldown, so the next connect launches
+/// immediately. Deleting the benign release at the no-peers exit turns this
+/// abort into a failure cooldown and fails the admission assertion below.
+#[tokio::test]
+async fn auto_launch_no_peers_abort_resets_lifecycle_and_reopens_gate() {
+    let (tmp, room) = gate_test_room();
+    let daemon = crate::daemon::Daemon::new_for_test(test_daemon_config(&tmp)).unwrap();
+
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a,
+        _ => panic!("first request must be admitted"),
+    };
+    // Mirror the connect path: Resolving is written right after admission.
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        .unwrap();
+    assert_eq!(
+        room.connections
+            .active_peers
+            .load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "test premise: the admitted peer has already disconnected"
+    );
+
+    auto_launch_kernel(
+        &room,
+        &room.id.to_string(),
+        crate::runtime::Runtime::Python,
+        crate::settings_doc::PythonEnvType::Uv,
+        daemon,
+        attempt,
+    )
+    .await;
+
+    let lifecycle = room
+        .state
+        .read(|sd| sd.read_state().kernel.lifecycle)
+        .unwrap();
+    assert_eq!(
+        lifecycle,
+        RuntimeLifecycle::NotStarted,
+        "benign no-peers abort must reset the Resolving lifecycle"
+    );
+    // A subsequent connect re-triggers: admission must succeed immediately,
+    // with no failure cooldown from the benign abort.
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.release_without_cooldown(),
+        AutoLaunchAdmission::InFlight => panic!("benign abort must release the gate"),
+        AutoLaunchAdmission::CoolingDown { .. } => {
+            panic!("benign abort must not arm the failure cooldown")
+        }
+    }
+}
+
+/// The no-peers abort re-admits a reconnect that raced the abort window
+/// (#4065 reconnect-loop workload): the reconnect bumped `active_peers` but
+/// was refused admission (`InFlight`) while the aborting task still held the
+/// gate, so the aborting task must hand itself a fresh token and retry on
+/// the reconnected peer's behalf. The peers re-check runs only after the
+/// token release; checked before, this connect would be stranded at
+/// NotStarted with no retry trigger.
+#[tokio::test]
+async fn auto_launch_no_peers_abort_readmits_reconnect_that_raced_the_abort() {
+    let (_tmp, room) = gate_test_room();
+
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a,
+        _ => panic!("first request must be admitted"),
+    };
+    // The reconnect landed during the abort window: peer count is back to 1
+    // but its connect saw InFlight and was swallowed.
+    room.connections
+        .active_peers
+        .store(1, std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        matches!(room.try_begin_auto_launch(), AutoLaunchAdmission::InFlight),
+        "the racing connect is refused while the abort is in progress"
+    );
+
+    let next = release_attempt_and_readmit_if_peer_waiting(&room, attempt)
+        .await
+        .expect("a waiting peer must be re-admitted for retry");
+
+    // The re-admitted token holds the gate for the retry.
+    assert!(
+        matches!(room.try_begin_auto_launch(), AutoLaunchAdmission::InFlight),
+        "the retry token must hold the gate"
+    );
+    next.release_without_cooldown();
+}
+
+/// When no peer raced the abort, the no-peers release stands: no retry
+/// token, gate open for whichever connect arrives next.
+#[tokio::test]
+async fn auto_launch_no_peers_abort_stands_when_no_peer_waiting() {
+    let (_tmp, room) = gate_test_room();
+
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a,
+        _ => panic!("first request must be admitted"),
+    };
+
+    let next = release_attempt_and_readmit_if_peer_waiting(&room, attempt).await;
+    assert!(next.is_none(), "no waiting peer means no retry token");
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.release_without_cooldown(),
+        _ => panic!("gate must be open after the abort stands"),
+    }
+}
+
+/// Success disposition at the launch exit site: `finish_auto_launch_success`
+/// must write Running(Idle) and reopen the gate with no cooldown. Deleting
+/// `attempt.succeed()` inside it drops the token as a failure, arms the 5s
+/// cooldown after every successful launch, and fails the admission assertion.
+#[tokio::test]
+async fn auto_launch_success_disposition_reopens_gate_immediately() {
+    let (_tmp, room) = gate_test_room();
+
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a,
+        _ => panic!("first request must be admitted"),
+    };
+
+    finish_auto_launch_success(
+        &room,
+        "python",
+        "uv",
+        "runtime-agent:test",
+        LaunchedEnvConfig::default(),
+        attempt,
+    )
+    .await;
+
+    let lifecycle = room
+        .state
+        .read(|sd| sd.read_state().kernel.lifecycle)
+        .unwrap();
+    assert_eq!(
+        lifecycle,
+        RuntimeLifecycle::Running(KernelActivity::Idle),
+        "success bookkeeping must publish Running(Idle)"
+    );
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.release_without_cooldown(),
+        AutoLaunchAdmission::InFlight => panic!("success must release the gate"),
+        AutoLaunchAdmission::CoolingDown { .. } => {
+            panic!("success must not arm the failure cooldown")
+        }
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -2539,6 +2539,7 @@ fn test_room_with_path_and_store(
         runtime_agent_generation: Arc::new(AtomicU64::new(0)),
         next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         current_runtime_agent_id: Arc::new(RwLock::new(None)),
+        auto_launch_gate: AutoLaunchGate::default(),
     };
 
     (room, notebook_path)
@@ -12995,4 +12996,133 @@ async fn save_continuation_race_superseded_sequence_fails_manifest_triple_check_
         "after replayed stale s1 continuation",
     )
     .await;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-launch single-flight gate (issue #4065: reconnect-loop spawn storm)
+// ---------------------------------------------------------------------------
+
+fn gate_test_room() -> (tempfile::TempDir, Arc<NotebookRoom>) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+    (tmp, room)
+}
+
+/// Two concurrent auto-launch requests: the second must join the first
+/// attempt, not start its own. This is the single-flight property that keeps
+/// a client reconnect loop from spawning one runtime agent per connect.
+#[tokio::test(start_paused = true)]
+async fn auto_launch_gate_second_request_joins_in_flight_attempt() {
+    let (_tmp, room) = gate_test_room();
+
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a,
+        _ => panic!("first request must be admitted"),
+    };
+    assert!(
+        matches!(room.try_begin_auto_launch(), AutoLaunchAdmission::InFlight),
+        "second request must observe the in-flight attempt"
+    );
+
+    attempt.succeed();
+}
+
+/// A failed attempt closes the gate for the cooldown window, then a retry is
+/// admitted. Connect-frequency retries inside the window are rejected.
+#[tokio::test(start_paused = true)]
+async fn auto_launch_gate_failure_arms_cooldown_then_readmits() {
+    let (_tmp, room) = gate_test_room();
+
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a,
+        _ => panic!("first request must be admitted"),
+    };
+    // Dropping without an explicit outcome is the failure path (covers early
+    // returns and panics in auto_launch_kernel).
+    drop(attempt);
+
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::CoolingDown { remaining } => {
+            assert!(remaining <= AUTO_LAUNCH_FAILURE_COOLDOWN);
+            assert!(remaining > std::time::Duration::ZERO);
+        }
+        _ => panic!("request inside the cooldown window must be rejected"),
+    }
+
+    // Still cooling down just before the deadline.
+    tokio::time::advance(AUTO_LAUNCH_FAILURE_COOLDOWN - std::time::Duration::from_millis(1)).await;
+    assert!(matches!(
+        room.try_begin_auto_launch(),
+        AutoLaunchAdmission::CoolingDown { .. }
+    ));
+
+    // Past the deadline the next attempt is admitted.
+    tokio::time::advance(std::time::Duration::from_millis(2)).await;
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.succeed(),
+        _ => panic!("retry after the cooldown must be admitted"),
+    }
+}
+
+/// Success reopens the gate immediately with no cooldown: the running kernel
+/// (not the gate) is what stops later connects from auto-launching again.
+#[tokio::test(start_paused = true)]
+async fn auto_launch_gate_success_reopens_without_cooldown() {
+    let (_tmp, room) = gate_test_room();
+
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.succeed(),
+        _ => panic!("first request must be admitted"),
+    }
+    assert!(matches!(
+        room.try_begin_auto_launch(),
+        AutoLaunchAdmission::Admitted(_)
+    ));
+}
+
+/// Benign aborts (no peers left, kernel already present) release the gate
+/// with no cooldown so the next connect can launch without waiting.
+#[tokio::test(start_paused = true)]
+async fn auto_launch_gate_benign_release_reopens_without_cooldown() {
+    let (_tmp, room) = gate_test_room();
+
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.release_without_cooldown(),
+        _ => panic!("first request must be admitted"),
+    }
+    assert!(matches!(
+        room.try_begin_auto_launch(),
+        AutoLaunchAdmission::Admitted(_)
+    ));
+}
+
+/// A successful attempt after a failed one clears the stale cooldown state:
+/// the failure deadline must not outlive the attempt that succeeded.
+#[tokio::test(start_paused = true)]
+async fn auto_launch_gate_admission_clears_stale_cooldown() {
+    let (_tmp, room) = gate_test_room();
+
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => drop(a),
+        _ => panic!("first request must be admitted"),
+    }
+    tokio::time::advance(AUTO_LAUNCH_FAILURE_COOLDOWN + std::time::Duration::from_millis(1)).await;
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(a) => a.succeed(),
+        _ => panic!("post-cooldown request must be admitted"),
+    }
+    assert!(
+        matches!(
+            room.try_begin_auto_launch(),
+            AutoLaunchAdmission::Admitted(_)
+        ),
+        "success must not inherit the earlier failure's cooldown"
+    );
 }


### PR DESCRIPTION
A client reconnect loop turned every connect into a runtime-agent spawn. In the incident behind this (#4065), that produced 121 spawns and 118 SIGKILL reaps in seconds, each new spawn superseding the previous mid-launch, ending in daemon-wide fd exhaustion (`Too many open files` on the accept loop).

Auto-launch admission now goes through a per-room gate, `NotebookRoom::try_begin_auto_launch`. At most one auto-launch attempt runs per room: a connect that arrives while an attempt is in flight observes it through RuntimeStateDoc instead of spawning another runtime agent, and a failed attempt closes the gate for a 5s cooldown so a tight client reconnect loop can't respawn agents at connect frequency.

The gate hands the admitted caller an owned `AutoLaunchAttempt` token that has to travel with the attempt end to end. Dropping the token is the failure path, so every early return and panic in `auto_launch_kernel` arms the cooldown without per-site handling. Success and benign aborts (no peers left, agent already present) reopen the gate immediately instead of falling into cooldown.

One race needed a second pass. A benign no-peers abort releases the token and resets the lifecycle, but a reconnect can land inside that window, see the gate InFlight, and get refused with no retry trigger of its own. The fix orders the peers re-check after the token release: if a peer is waiting when the abort finishes, the aborting task re-admits itself and loops back into `auto_launch_kernel` with a fresh token instead of stranding the peer at NotStarted forever.

The explicit `LaunchKernel` request path is untouched by design. The gate governs only the connect-triggered auto-launch path; an explicit request is user intent and should never be throttled.

Tests pin token disposition at every exit class: the no-peers abort through the real `auto_launch_kernel` entry point, the raced-abort readmit, and the success path.
