### PR TITLE
fix(runtimed): unindent doc list continuations in property_tests module doc

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/durability/property_tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability/property_tests.rs
@@ -12,9 +12,9 @@
 //!    (a) DurablyStaged/Ready (joinable via the recovered-source path),
 //!    (b) Pending with no peer changes (safe to regenerate),
 //!    (c) an unresolved pending file-checkpoint intent (resolvable via
-//!        [`RoomDurability::resolve_recovered_file_checkpoint`]),
+//!    [`RoomDurability::resolve_recovered_file_checkpoint`]),
 //!    (d) Pending/Failed with peer changes and durable heads strictly beyond
-//!        exported heads (requires explicit reconciliation).
+//!    exported heads (requires explicit reconciliation).
 //!    Case (d) is legal only when durable heads differ from exported heads,
 //!    and a manifest with a full-coverage checkpoint and no unresolved intent
 //!    must always land in (a) (the shared baseline normalization applied by


### PR DESCRIPTION
clippy 1.94's doc_overindented_list_items fires under the post-merge Build lane's -D warnings on two continuation lines in the property_tests module doc; the PR-lane clippy config did not surface it, so #4073 landed green and main's Build went red. Two-line indent fix, no code change. Verified with cargo clippy -p runtimed --lib --tests locally clean.