### PR TITLE
fix(notebook): status pill holds last loaded runtime status through reconnect

### DIFF
--- a/packages/runtimed/src/runtime-state-store.ts
+++ b/packages/runtimed/src/runtime-state-store.ts
@@ -25,12 +25,13 @@
 import {
   Observable,
   type SchedulerLike,
+  combineLatest,
   defer,
   distinctUntilChanged,
   map,
   of,
+  scan,
   shareReplay,
-  startWith,
   switchMap,
   timer,
 } from "rxjs";
@@ -59,6 +60,13 @@ import {
  * sees a "busy" flash for trivial executions.
  */
 export const BUSY_THROTTLE_MS = 60;
+
+const INITIAL_UNLOADED_STATUS_KEY = RUNTIME_STATUS.CONNECTING;
+
+interface RuntimeStatusGateState {
+  lastLoadedStatusKey: RuntimeStatusKey | null;
+  visibleStatusKey: RuntimeStatusKey;
+}
 
 /**
  * Hold back `RUNNING_BUSY` so quick execute→idle cycles never flash "busy".
@@ -126,22 +134,36 @@ export class RuntimeStateStore extends ObservableStore<RuntimeState> {
   );
 
   /**
+   * Runtime status for visible UI. During reconnect/reset the state snapshot
+   * returns to the default `NotStarted`, but `loaded$` is false, so that
+   * default is not authoritative. Hold the last loaded status key until a new
+   * RuntimeStateDoc snapshot opens the gate again. A first session with no
+   * prior loaded state uses a neutral connecting treatment until the first
+   * real snapshot arrives.
+   */
+  readonly visibleStatusKey$: Observable<RuntimeStatusKey> = combineLatest([
+    this.statusKey$,
+    this.loaded$,
+  ]).pipe(
+    scan(retainLastLoadedStatusKey, {
+      lastLoadedStatusKey: null,
+      visibleStatusKey: INITIAL_UNLOADED_STATUS_KEY,
+    } satisfies RuntimeStatusGateState),
+    map((state) => state.visibleStatusKey),
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: false }),
+  );
+
+  /**
    * Lifecycle status key with the busy flash suppressed
    * ([`throttleBusyStatus`], window [`BUSY_THROTTLE_MS`]). This is the
    * stream UI status indicators should render.
    *
    * Shared (`shareReplay`) so all subscribers ride one throttle pipeline
-   * and late subscribers get the current value synchronously. Seeded with
-   * the raw key at first subscribe — matching the old hook, a mount during
-   * a busy phase shows busy immediately; only *transitions* into busy are
-   * held back.
+   * and late subscribers get the current visible value synchronously.
    */
   readonly throttledStatusKey$: Observable<RuntimeStatusKey> = defer(() =>
-    this.statusKey$.pipe(
-      throttleBusyStatus(),
-      startWith(runtimeStatusKey(this.snapshot.kernel.lifecycle)),
-      distinctUntilChanged(),
-    ),
+    this.visibleStatusKey$.pipe(throttleBusyStatus(), distinctUntilChanged()),
   ).pipe(shareReplay({ bufferSize: 1, refCount: false }));
 
   /**
@@ -190,6 +212,28 @@ function envSyncStateEquals(a: EnvSyncState | null, b: EnvSyncState | null): boo
     arrayEquals(a.diff.added, b.diff.added) &&
     arrayEquals(a.diff.removed, b.diff.removed)
   );
+}
+
+function retainLastLoadedStatusKey(
+  previous: RuntimeStatusGateState,
+  [statusKey, loaded]: readonly [RuntimeStatusKey, boolean],
+): RuntimeStatusGateState {
+  if (loaded) {
+    return {
+      lastLoadedStatusKey: statusKey,
+      visibleStatusKey: statusKey,
+    };
+  }
+
+  const visibleStatusKey = previous.lastLoadedStatusKey ?? INITIAL_UNLOADED_STATUS_KEY;
+  if (previous.visibleStatusKey === visibleStatusKey && previous.lastLoadedStatusKey !== null) {
+    return previous;
+  }
+
+  return {
+    lastLoadedStatusKey: previous.lastLoadedStatusKey,
+    visibleStatusKey,
+  };
 }
 
 function arrayEquals(a: readonly string[], b: readonly string[]): boolean {

--- a/packages/runtimed/tests/runtime-state-store.test.ts
+++ b/packages/runtimed/tests/runtime-state-store.test.ts
@@ -56,6 +56,50 @@ describe("RuntimeStateStore", () => {
     expect(seen).toEqual(["NotStarted", "Running"]);
   });
 
+  it("keeps the pill status while reconnect resets the store", () => {
+    const store = new RuntimeStateStore();
+    const seen = collect(store.throttledStatusKey$);
+
+    store.set(runningState("Idle"));
+    store.reset();
+
+    expect(store.isLoaded).toBe(false);
+    expect(store.snapshot).toBe(DEFAULT_RUNTIME_STATE);
+    expect(seen).toEqual([RUNTIME_STATUS.CONNECTING, RUNTIME_STATUS.RUNNING_IDLE]);
+  });
+
+  it("updates the pill status when the loaded gate reopens with fresh data", () => {
+    const store = new RuntimeStateStore();
+    const seen = collect(store.throttledStatusKey$);
+
+    store.set(runningState("Idle"));
+    store.reset();
+    store.set(
+      stateWith({
+        kernel: {
+          ...DEFAULT_RUNTIME_STATE.kernel,
+          lifecycle: { lifecycle: "Launching" },
+        },
+      }),
+    );
+
+    expect(seen).toEqual([
+      RUNTIME_STATUS.CONNECTING,
+      RUNTIME_STATUS.RUNNING_IDLE,
+      RUNTIME_STATUS.LAUNCHING,
+    ]);
+  });
+
+  it("shows a fresh session's real initial pill status once loaded", () => {
+    const store = new RuntimeStateStore();
+    const seen = collect(store.throttledStatusKey$);
+
+    store.set(DEFAULT_RUNTIME_STATE);
+
+    expect(store.isLoaded).toBe(true);
+    expect(seen).toEqual([RUNTIME_STATUS.CONNECTING, RUNTIME_STATUS.NOT_STARTED]);
+  });
+
   it("kernelInfo$ emits only when kernel type or env source changes", () => {
     const store = new RuntimeStateStore();
     const seen = collect(store.kernelInfo$);

--- a/src/components/notebook/state/runtime-state.ts
+++ b/src/components/notebook/state/runtime-state.ts
@@ -96,7 +96,9 @@ export function useWorkstationAttachment(): WorkstationAttachmentState | null {
 
 /**
  * Lifecycle status key with the busy flash suppressed by the shared
- * `throttleBusyStatus` pipeline.
+ * `throttleBusyStatus` pipeline. The underlying store gates reset windows on
+ * `loaded$`, so reconnects retain the last loaded runtime status until fresh
+ * RuntimeStateDoc data arrives.
  */
 export function useThrottledStatusKey(): RuntimeStatusKey {
   return useRuntimeProjection(runtimeStateStore.throttledStatusKey$);


### PR DESCRIPTION
Closes #4067.

After a daemon reconnect the client resets to an empty bootstrap state; the runtime stores empty out before sync repopulates them, and the status pill painted its default over a live kernel: "Initializing" next to a daemon reporting has_kernel true.

The store now derives visibleStatusKey$, which gates on loaded$ per the frontend-sync-bridge doctrine: while the loaded gate is closed the projection holds the last loaded status key, and a genuinely fresh session shows a neutral connecting state until the first real RuntimeStateDoc snapshot arrives. throttledStatusKey$ (what the pill renders through useThrottledStatusKey) rides the gated stream, so reconnect windows keep last-known-good instead of the default.

Store-level tests cover the reconnect hold, the gate reopening with fresh data, and the fresh-session initial state.
