### PR TITLE
fix(cli): daemon start kickstarts launchd and confirms the daemon is up

### DIFF
--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -773,20 +773,19 @@ pub fn launchd_bootstrap_only() -> Result<(), String> {
     launchd_bootstrap(&plist, &domain)
 }
 
-/// Kickstart the daemon's launchd service.
-///
-/// Unlike `launchd_start()` which uses `bootstrap` (requires a plist file),
-/// `kickstart` works for SMAppService-registered agents where the plist is
-/// inside the app bundle and managed by the system. The `-k` flag kills any
-/// currently running instance before starting a new one.
 #[cfg(target_os = "macos")]
-pub fn launchd_kickstart() -> Result<(), String> {
+fn launchd_kickstart_inner(restart_running: bool) -> Result<(), String> {
     let uid = launchd_uid()?;
     let label = daemon_launchd_label();
     let service_target = format!("gui/{uid}/{label}");
 
-    let output = Command::new("launchctl")
-        .args(["kickstart", "-k", &service_target])
+    let mut command = Command::new("launchctl");
+    command.arg("kickstart");
+    if restart_running {
+        command.arg("-k");
+    }
+    let output = command
+        .arg(&service_target)
         .output()
         .map_err(|e| format!("Failed to run launchctl kickstart: {e}"))?;
 
@@ -796,6 +795,22 @@ pub fn launchd_kickstart() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Kickstart the daemon's launchd service without restarting a running daemon.
+///
+/// Unlike `launchd_start()` which uses `bootstrap` (requires a plist file),
+/// `kickstart` works for SMAppService-registered agents where the plist is
+/// inside the app bundle and managed by the system.
+#[cfg(target_os = "macos")]
+pub fn launchd_kickstart_start_only() -> Result<(), String> {
+    launchd_kickstart_inner(false)
+}
+
+/// Kickstart the daemon's launchd service, replacing any running instance.
+#[cfg(target_os = "macos")]
+pub fn launchd_kickstart() -> Result<(), String> {
+    launchd_kickstart_inner(true)
 }
 
 /// Check whether the daemon's launchd service is currently loaded.

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -9,6 +9,7 @@ mod workstation_cli;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use std::ffi::OsString;
+use std::future::Future;
 use std::time::Duration;
 use tabled::{settings::Style, Table, Tabled};
 
@@ -1212,6 +1213,112 @@ fn legacy_daemon_info_path() -> PathBuf {
     runt_workspace::daemon_base_dir().join("daemon.json")
 }
 
+const DAEMON_START_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+const DAEMON_START_CONFIRM_INTERVAL: Duration = Duration::from_millis(250);
+const DAEMON_START_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DaemonStartupStatus {
+    Running,
+    NotRunning { detail: String },
+}
+
+impl DaemonStartupStatus {
+    fn is_running(&self) -> bool {
+        matches!(self, Self::Running)
+    }
+
+    fn detail(&self) -> &str {
+        match self {
+            Self::Running => "running",
+            Self::NotRunning { detail } => detail,
+        }
+    }
+}
+
+async fn probe_daemon_startup_status() -> DaemonStartupStatus {
+    let socket_path = runt_workspace::default_socket_path();
+    let daemon_info = tokio::time::timeout(
+        DAEMON_START_PROBE_TIMEOUT,
+        runtimed_client::singleton::query_daemon_info(socket_path.clone()),
+    )
+    .await;
+
+    let Some(info) = (match daemon_info {
+        Ok(info) => info,
+        Err(_) => {
+            return DaemonStartupStatus::NotRunning {
+                detail: format!(
+                    "timed out waiting for daemon info on {}",
+                    shorten_path(&socket_path)
+                ),
+            };
+        }
+    }) else {
+        return DaemonStartupStatus::NotRunning {
+            detail: format!(
+                "daemon socket {} did not return live daemon info",
+                shorten_path(&socket_path)
+            ),
+        };
+    };
+
+    let client = runtimed::client::PoolClient::new(PathBuf::from(&info.endpoint));
+    match tokio::time::timeout(DAEMON_START_PROBE_TIMEOUT, client.ping_version()).await {
+        Ok(Ok(_)) => DaemonStartupStatus::Running,
+        Ok(Err(error)) => DaemonStartupStatus::NotRunning {
+            detail: format!("daemon at {} did not answer ping: {error}", info.endpoint),
+        },
+        Err(_) => DaemonStartupStatus::NotRunning {
+            detail: format!("timed out pinging daemon at {}", info.endpoint),
+        },
+    }
+}
+
+async fn wait_for_daemon_start_confirmation<F, Fut>(
+    timeout: Duration,
+    poll_interval: Duration,
+    mut status_probe: F,
+) -> DaemonStartupStatus
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = DaemonStartupStatus>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let status = status_probe().await;
+        if status.is_running() || tokio::time::Instant::now() >= deadline {
+            return status;
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let sleep_for = if poll_interval.is_zero() {
+            Duration::from_millis(1)
+        } else {
+            poll_interval.min(remaining)
+        };
+        tokio::time::sleep(sleep_for).await;
+    }
+}
+
+async fn confirm_daemon_started() -> Result<()> {
+    match wait_for_daemon_start_confirmation(
+        DAEMON_START_CONFIRM_TIMEOUT,
+        DAEMON_START_CONFIRM_INTERVAL,
+        probe_daemon_startup_status,
+    )
+    .await
+    {
+        DaemonStartupStatus::Running => Ok(()),
+        status => Err(anyhow::anyhow!(
+            "daemon did not become ready within {}s: {}",
+            DAEMON_START_CONFIRM_TIMEOUT.as_secs(),
+            status.detail()
+        )),
+    }
+}
+
 /// Three-step hybrid stop: socket shutdown → service manager → signal escalation.
 async fn stop_daemon_smart(
     manager: &mut runtimed_service::ServiceManager,
@@ -1555,6 +1662,10 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                 runt_workspace::daemon_service_basename()
             );
             manager.start()?;
+            if let Err(e) = confirm_daemon_started().await {
+                eprintln!("Failed to start daemon: {e}");
+                std::process::exit(1);
+            }
             println!("Service started.");
         }
         DaemonCommands::Stop => {
@@ -1615,6 +1726,10 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
 
             // Start via service manager
             manager.start()?;
+            if let Err(e) = confirm_daemon_started().await {
+                eprintln!("Failed to restart daemon: {e}");
+                std::process::exit(1);
+            }
             println!("Service restarted.");
         }
         DaemonCommands::Install { binary } => {
@@ -4857,6 +4972,54 @@ mod tests {
         assert!(
             result.is_ok(),
             "Stopping non-existent process should succeed (already dead)"
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_start_confirmation_returns_after_running_probe() {
+        let attempts = std::cell::Cell::new(0);
+
+        let status = super::wait_for_daemon_start_confirmation(
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+            || {
+                let attempt = attempts.get() + 1;
+                attempts.set(attempt);
+                async move {
+                    if attempt == 3 {
+                        DaemonStartupStatus::Running
+                    } else {
+                        DaemonStartupStatus::NotRunning {
+                            detail: format!("attempt {attempt} not ready"),
+                        }
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(status, DaemonStartupStatus::Running);
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[tokio::test]
+    async fn daemon_start_confirmation_reports_last_probe_state_on_timeout() {
+        let status = super::wait_for_daemon_start_confirmation(
+            Duration::ZERO,
+            Duration::from_millis(1),
+            || async {
+                DaemonStartupStatus::NotRunning {
+                    detail: "launchd loaded service without a pid".to_string(),
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            DaemonStartupStatus::NotRunning {
+                detail: "launchd loaded service without a pid".to_string(),
+            }
         );
     }
 

--- a/crates/runtimed-service/src/lib.rs
+++ b/crates/runtimed-service/src/lib.rs
@@ -548,13 +548,14 @@ impl ServiceManager {
         }
 
         if start_after {
-            // Bootstrap only. The stop() call above is best-effort and may have
-            // already performed the launchd bootout, but upgrade intentionally
-            // does not issue another bootout here. Using launchd_start() would
-            // add a second bootout attempt and can put launchd into a
-            // transient error-5 state.
+            // Registering the launchd job is separate from waking the daemon.
+            // Avoid an extra bootout here because stop() already handled it.
             #[cfg(target_os = "macos")]
-            runt_workspace::launchd_bootstrap_only().map_err(ServiceError::StartFailed)?;
+            {
+                runt_workspace::launchd_bootstrap_only().map_err(ServiceError::StartFailed)?;
+                runt_workspace::launchd_kickstart_start_only()
+                    .map_err(ServiceError::StartFailed)?;
+            }
 
             #[cfg(not(target_os = "macos"))]
             self.start()?;
@@ -821,6 +822,8 @@ impl ServiceManager {
         } else {
             info!("[service] Launchd service already loaded");
         }
+        runt_workspace::launchd_kickstart_start_only().map_err(ServiceError::StartFailed)?;
+        info!("[service] Kickstarted launchd service");
         Ok(())
     }
 


### PR DESCRIPTION
Closes #4068.

`daemon start` printed "Service started." after registering the launchd job, but registration alone does not spawn an on-demand agent: launchd loaded the service and waited, `daemon status` showed "Daemon running: no", and the user had to issue `launchctl kickstart` by hand. Hit live during the #4065 incident recovery.

Two changes:

The service manager now follows bootstrap with a start-only kickstart (no `-k`, so a running daemon is never killed by `start`), on both the fresh-bootstrap and already-loaded branches. The existing `-k` kickstart remains for restart semantics.

The CLI only prints success after confirming the daemon is actually up: it polls for up to 5s (250ms interval), each probe querying live daemon info from the expected socket and pinging the returned endpoint. If readiness never confirms, `daemon start`/`daemon restart` exit non-zero with the last observed state instead of claiming success.

The polling and decision logic is unit-tested with an injected probe. The live launchctl interaction stays untested since it mutates the user's launchd session.
