### PR TITLE
fix(onboarding): keep pool readiness polling live

### DIFF
--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -2,17 +2,13 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { AlertTriangle, ArrowLeft, Check, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import type { PoolState } from "runtimed";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "@/components/environment";
-import {
-  hasOnboardingPoolError,
-  isOnboardingPoolReady,
-  onboardingPoolErrorMessage,
-  type OnboardingPoolState,
-  type PythonEnv,
-} from "./pool-readiness";
+import { observeOnboardingPool, type OnboardingPoolGate } from "./pool-polling";
+import type { PythonEnv } from "./pool-readiness";
 import type { DaemonStatus } from "./types";
 
 type Runtime = "python" | "deno";
@@ -154,8 +150,6 @@ const BRAND_COLORS = {
   },
 };
 
-const IDLE_POOL_POLL_ATTEMPTS = 10;
-const WARMING_POOL_POLL_ATTEMPTS = 180;
 const LEARN_MORE_URL = "https://nteract.io/telemetry";
 const PYTHON_ENV_LABELS: Record<PythonEnv, string> = {
   uv: "UV",
@@ -182,8 +176,7 @@ export default function App() {
   ]);
   const [daemonReady, setDaemonReady] = useState(false);
   const [daemonFailed, setDaemonFailed] = useState(false);
-  const [selectedPoolReady, setSelectedPoolReady] = useState(false);
-  const [poolWaitTimedOut, setPoolWaitTimedOut] = useState(false);
+  const [poolGate, setPoolGate] = useState<OnboardingPoolGate | null>(null);
   const [setupComplete, setSetupComplete] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -251,109 +244,21 @@ export default function App() {
     if (!daemonReady || !pythonEnv) return;
 
     const envLabel = PYTHON_ENV_LABELS[pythonEnv];
-    setSelectedPoolReady(false);
-    setPoolWaitTimedOut(false);
-    setErrorMessage(null);
-    setSteps((prev) =>
-      prev.map((s) =>
-        s.id === "tools"
-          ? { ...s, label: `Checking ${envLabel} runtime`, status: "in_progress" }
-          : s,
-      ),
-    );
+    const subscription = observeOnboardingPool({
+      pythonEnv,
+      envLabel,
+      fetchPoolState: () => invoke<PoolState>("get_pool_status"),
+    }).subscribe((gate) => {
+      setPoolGate(gate);
+      setErrorMessage(gate.errorMessage);
+      setSteps((prev) =>
+        prev.map((step) =>
+          step.id === "tools" ? { ...step, label: gate.label, status: gate.stepStatus } : step,
+        ),
+      );
+    });
 
-    let cancelled = false;
-    let attempts = 0;
-    const pollPool = async () => {
-      while (!cancelled) {
-        attempts += 1;
-        try {
-          const state = await invoke<OnboardingPoolState>("get_pool_status");
-
-          const selected = state[pythonEnv] ?? { available: 0, warming: 0 };
-          const warming = selected.warming ?? 0;
-
-          if (isOnboardingPoolReady(pythonEnv, state)) {
-            setSelectedPoolReady(true);
-            setErrorMessage(null);
-            setSteps((prev) =>
-              prev.map((s) =>
-                s.id === "tools"
-                  ? { ...s, label: `${envLabel} runtime ready`, status: "completed" }
-                  : s,
-              ),
-            );
-            return;
-          }
-
-          // A recorded warm-env failure means the daemon hit a real problem
-          // (bad package, import error, timeout, missing runtime). Surface it
-          // instead of spinning on "warming" until the poll cap — the daemon
-          // keeps retrying with backoff, so the user can still continue.
-          if (hasOnboardingPoolError(pythonEnv, state)) {
-            setPoolWaitTimedOut(true);
-            setErrorMessage(onboardingPoolErrorMessage(envLabel, selected));
-            setSteps((prev) =>
-              prev.map((s) =>
-                s.id === "tools"
-                  ? { ...s, label: `${envLabel} runtime setup failed`, status: "failed" }
-                  : s,
-              ),
-            );
-            return;
-          }
-
-          if (warming > 0) {
-            setSteps((prev) =>
-              prev.map((s) =>
-                s.id === "tools"
-                  ? { ...s, label: `Warming ${envLabel} runtime`, status: "in_progress" }
-                  : s,
-              ),
-            );
-            if (attempts >= WARMING_POOL_POLL_ATTEMPTS) {
-              setPoolWaitTimedOut(true);
-              setSteps((prev) =>
-                prev.map((s) =>
-                  s.id === "tools"
-                    ? { ...s, label: `Still warming ${envLabel} runtime`, status: "failed" }
-                    : s,
-                ),
-              );
-              return;
-            }
-          } else if (attempts >= IDLE_POOL_POLL_ATTEMPTS) {
-            setPoolWaitTimedOut(true);
-            setSteps((prev) =>
-              prev.map((s) =>
-                s.id === "tools"
-                  ? { ...s, label: `Waiting for ${envLabel} runtime`, status: "failed" }
-                  : s,
-              ),
-            );
-            return;
-          }
-        } catch {
-          if (attempts >= IDLE_POOL_POLL_ATTEMPTS) {
-            setPoolWaitTimedOut(true);
-            setSteps((prev) =>
-              prev.map((s) =>
-                s.id === "tools"
-                  ? { ...s, label: `Waiting for ${envLabel} runtime`, status: "failed" }
-                  : s,
-              ),
-            );
-            return;
-          }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
-    };
-
-    pollPool();
-    return () => {
-      cancelled = true;
-    };
+    return () => subscription.unsubscribe();
   }, [daemonReady, pythonEnv]);
 
   // Handle runtime selection
@@ -371,8 +276,7 @@ export default function App() {
   // Handle Python env selection with auto-advance to ready state
   const handlePythonEnvSelect = useCallback((selected: PythonEnv) => {
     setPythonEnv(selected);
-    setSelectedPoolReady(false);
-    setPoolWaitTimedOut(false);
+    setPoolGate(null);
     setErrorMessage(null);
     setSteps((prev) =>
       prev.map((s) =>
@@ -405,7 +309,7 @@ export default function App() {
     async (telemetryEnabled: boolean) => {
       if (!runtime || !pythonEnv) return;
       if (!daemonReady) return;
-      if (!selectedPoolReady && !poolWaitTimedOut) return;
+      if (!poolGate?.canContinue) return;
       if (isSubmitting) return;
       setIsSubmitting(true);
 
@@ -451,7 +355,7 @@ export default function App() {
         setErrorMessage("Failed to save settings. Please try again.");
       }
     },
-    [daemonReady, runtime, pythonEnv, selectedPoolReady, poolWaitTimedOut, isSubmitting],
+    [daemonReady, runtime, pythonEnv, poolGate?.canContinue, isSubmitting],
   );
 
   // Fallback path when the daemon failed to install. Still records the
@@ -487,7 +391,7 @@ export default function App() {
     runtime !== null &&
     pythonEnv !== null &&
     daemonReady &&
-    (selectedPoolReady || poolWaitTimedOut) &&
+    poolGate?.canContinue === true &&
     !setupComplete;
 
   // Page titles based on selections

--- a/apps/notebook/onboarding/pool-polling.ts
+++ b/apps/notebook/onboarding/pool-polling.ts
@@ -1,0 +1,260 @@
+import { createPoll, type PoolState } from "runtimed";
+import {
+  defer,
+  distinctUntilChanged,
+  map,
+  of,
+  scan,
+  startWith,
+  takeWhile,
+  type Observable,
+  type SchedulerLike,
+} from "rxjs";
+import {
+  hasOnboardingPoolError,
+  isOnboardingPoolReady,
+  onboardingPoolErrorMessage,
+  type PythonEnv,
+} from "./pool-readiness";
+
+export type OnboardingPoolGate =
+  | {
+      kind: "checking" | "warming";
+      canContinue: false;
+      label: string;
+      stepStatus: "in_progress";
+      errorMessage: null;
+    }
+  | {
+      kind: "slow" | "unavailable";
+      canContinue: true;
+      label: string;
+      stepStatus: "failed";
+      errorMessage: null;
+    }
+  | {
+      kind: "failed";
+      canContinue: true;
+      label: string;
+      stepStatus: "failed";
+      errorMessage: string;
+    }
+  | {
+      kind: "retrying";
+      canContinue: true;
+      label: string;
+      stepStatus: "in_progress";
+      errorMessage: null;
+    }
+  | {
+      kind: "ready";
+      canContinue: true;
+      label: string;
+      stepStatus: "completed";
+      errorMessage: null;
+    };
+
+type PoolPollOutcome =
+  | { kind: "state"; state: PoolState }
+  | { kind: "unavailable"; error: unknown };
+
+type PoolPollAccumulator = {
+  attempts: number;
+  bypassAllowed: boolean;
+  gate: OnboardingPoolGate;
+};
+
+export type ObserveOnboardingPoolOptions = {
+  pythonEnv: PythonEnv;
+  envLabel: string;
+  fetchPoolState: (signal: AbortSignal) => Promise<PoolState>;
+  pollIntervalMs?: number;
+  idlePollAttempts?: number;
+  warmingPollAttempts?: number;
+  scheduler?: SchedulerLike;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_IDLE_POLL_ATTEMPTS = 10;
+const DEFAULT_WARMING_POLL_ATTEMPTS = 180;
+
+function checkingGate(envLabel: string): OnboardingPoolGate {
+  return {
+    kind: "checking",
+    canContinue: false,
+    label: `Checking ${envLabel} runtime`,
+    stepStatus: "in_progress",
+    errorMessage: null,
+  };
+}
+
+function gatesEqual(left: OnboardingPoolGate, right: OnboardingPoolGate): boolean {
+  return (
+    left.kind === right.kind &&
+    left.canContinue === right.canContinue &&
+    left.label === right.label &&
+    left.stepStatus === right.stepStatus &&
+    left.errorMessage === right.errorMessage
+  );
+}
+const _ONBOARDING_POOL_GATE_FIELDS = {
+  kind: true,
+  canContinue: true,
+  label: true,
+  stepStatus: true,
+  errorMessage: true,
+} satisfies Record<keyof OnboardingPoolGate, true>;
+void _ONBOARDING_POOL_GATE_FIELDS;
+
+function projectPoolGate({
+  outcome,
+  pythonEnv,
+  envLabel,
+  attempts,
+  bypassAllowed,
+  idlePollAttempts,
+  warmingPollAttempts,
+}: {
+  outcome: PoolPollOutcome;
+  pythonEnv: PythonEnv;
+  envLabel: string;
+  attempts: number;
+  bypassAllowed: boolean;
+  idlePollAttempts: number;
+  warmingPollAttempts: number;
+}): OnboardingPoolGate {
+  if (outcome.kind === "unavailable") {
+    if (bypassAllowed || attempts >= idlePollAttempts) {
+      return {
+        kind: "unavailable",
+        canContinue: true,
+        label: `Waiting for ${envLabel} runtime`,
+        stepStatus: "failed",
+        errorMessage: null,
+      };
+    }
+    return checkingGate(envLabel);
+  }
+
+  const selected = outcome.state[pythonEnv];
+  if (isOnboardingPoolReady(pythonEnv, outcome.state)) {
+    return {
+      kind: "ready",
+      canContinue: true,
+      label: `${envLabel} runtime ready`,
+      stepStatus: "completed",
+      errorMessage: null,
+    };
+  }
+
+  if (selected.warming > 0 && bypassAllowed) {
+    return {
+      kind: "retrying",
+      canContinue: true,
+      label: `Retrying ${envLabel} runtime`,
+      stepStatus: "in_progress",
+      errorMessage: null,
+    };
+  }
+
+  if (hasOnboardingPoolError(pythonEnv, outcome.state)) {
+    return {
+      kind: "failed",
+      canContinue: true,
+      label: `${envLabel} runtime setup failed`,
+      stepStatus: "failed",
+      errorMessage: onboardingPoolErrorMessage(envLabel, selected),
+    };
+  }
+
+  if (selected.warming > 0) {
+    if (attempts >= warmingPollAttempts) {
+      return {
+        kind: "slow",
+        canContinue: true,
+        label: `Still warming ${envLabel} runtime`,
+        stepStatus: "failed",
+        errorMessage: null,
+      };
+    }
+    return {
+      kind: "warming",
+      canContinue: false,
+      label: `Warming ${envLabel} runtime`,
+      stepStatus: "in_progress",
+      errorMessage: null,
+    };
+  }
+
+  if (bypassAllowed || attempts >= idlePollAttempts) {
+    return {
+      kind: "unavailable",
+      canContinue: true,
+      label: `Waiting for ${envLabel} runtime`,
+      stepStatus: "failed",
+      errorMessage: null,
+    };
+  }
+
+  return checkingGate(envLabel);
+}
+
+/**
+ * Poll the selected runtime pool until it becomes ready.
+ *
+ * A slow or failed pool unlocks "continue anyway" without ending observation.
+ * Unsubscribing drops an in-flight result, so switching environments cannot
+ * apply a stale response to the new selection.
+ */
+export function observeOnboardingPool({
+  pythonEnv,
+  envLabel,
+  fetchPoolState,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  idlePollAttempts = DEFAULT_IDLE_POLL_ATTEMPTS,
+  warmingPollAttempts = DEFAULT_WARMING_POLL_ATTEMPTS,
+  scheduler,
+}: ObserveOnboardingPoolOptions): Observable<OnboardingPoolGate> {
+  const initialGate = checkingGate(envLabel);
+
+  return defer(() =>
+    createPoll<PoolPollOutcome>({
+      strategy: "fixed-rate",
+      interval$: of(pollIntervalMs),
+      wakeups$: of(undefined),
+      scheduler,
+      fetch: async (signal) => {
+        try {
+          return { kind: "state", state: await fetchPoolState(signal) };
+        } catch (error) {
+          return { kind: "unavailable", error };
+        }
+      },
+    }).pipe(
+      scan<PoolPollOutcome, PoolPollAccumulator>(
+        (accumulator, outcome) => {
+          const attempts = accumulator.attempts + 1;
+          const gate = projectPoolGate({
+            outcome,
+            pythonEnv,
+            envLabel,
+            attempts,
+            bypassAllowed: accumulator.bypassAllowed,
+            idlePollAttempts,
+            warmingPollAttempts,
+          });
+          return {
+            attempts,
+            bypassAllowed: accumulator.bypassAllowed || gate.canContinue,
+            gate,
+          };
+        },
+        { attempts: 0, bypassAllowed: false, gate: initialGate },
+      ),
+      map(({ gate }) => gate),
+      startWith(initialGate),
+      distinctUntilChanged(gatesEqual),
+      takeWhile((gate) => gate.kind !== "ready", true),
+    ),
+  );
+}

--- a/apps/notebook/onboarding/pool-readiness.ts
+++ b/apps/notebook/onboarding/pool-readiness.ts
@@ -1,32 +1,15 @@
-export type PythonEnv = "uv" | "conda" | "pixi";
+import type { PoolState, RuntimePoolState } from "runtimed";
 
-export type OnboardingPoolRuntimeState = {
-  available?: number;
-  warming?: number;
-  pool_size?: number;
-  /** Human-readable error message from the daemon (absent if healthy). */
-  error?: string;
-  /** Package that failed to install, when the daemon could identify one. */
-  failed_package?: string;
-  /** Error classification: "timeout" | "invalid_package" | "import_error" | "setup_failed". */
-  error_kind?: string;
-  /** Consecutive warm-env failures (0 if healthy). */
-  consecutive_failures?: number;
-  /** Seconds until the daemon retries warming (0 if imminent or healthy). */
-  retry_in_secs?: number;
-};
+export type PythonEnv = keyof PoolState;
 
-export type OnboardingPoolState = Partial<Record<PythonEnv, OnboardingPoolRuntimeState>>;
-
-export function isOnboardingPoolReady(pythonEnv: PythonEnv, state: OnboardingPoolState): boolean {
+export function isOnboardingPoolReady(pythonEnv: PythonEnv, state: PoolState): boolean {
   const selected = state[pythonEnv];
-  if (!selected) return false;
 
-  if ((selected.pool_size ?? 1) === 0) {
+  if (selected.pool_size === 0) {
     return true;
   }
 
-  return (selected.available ?? 0) > 0;
+  return selected.available > 0;
 }
 
 /**
@@ -34,20 +17,16 @@ export function isOnboardingPoolReady(pythonEnv: PythonEnv, state: OnboardingPoo
  * transient "still warming"). True when the daemon recorded at least one
  * warm-env failure and no environment is available yet.
  */
-export function hasOnboardingPoolError(pythonEnv: PythonEnv, state: OnboardingPoolState): boolean {
+export function hasOnboardingPoolError(pythonEnv: PythonEnv, state: PoolState): boolean {
   const selected = state[pythonEnv];
-  if (!selected) return false;
   if (isOnboardingPoolReady(pythonEnv, state)) return false;
-  return (selected.consecutive_failures ?? 0) > 0 && Boolean(selected.error);
+  return selected.consecutive_failures > 0 && Boolean(selected.error);
 }
 
 /**
  * Build a user-facing message from a failed pool's error fields.
  */
-export function onboardingPoolErrorMessage(
-  envLabel: string,
-  selected: OnboardingPoolRuntimeState,
-): string {
+export function onboardingPoolErrorMessage(envLabel: string, selected: RuntimePoolState): string {
   if (selected.error_kind === "invalid_package" && selected.failed_package) {
     return `${envLabel} setup failed: package "${selected.failed_package}" could not be installed.`;
   }

--- a/apps/notebook/src/__tests__/onboarding-pool-polling.test.ts
+++ b/apps/notebook/src/__tests__/onboarding-pool-polling.test.ts
@@ -1,0 +1,147 @@
+import type { PoolState, RuntimePoolState } from "runtimed";
+import { VirtualAction, VirtualTimeScheduler } from "rxjs";
+import { describe, expect, it } from "vitest";
+import { observeOnboardingPool, type OnboardingPoolGate } from "../../onboarding/pool-polling";
+
+const DEFAULT_RUNTIME_POOL: RuntimePoolState = {
+  available: 0,
+  warming: 0,
+  pool_size: 1,
+  consecutive_failures: 0,
+  retry_in_secs: 0,
+};
+
+function poolState(overrides: Partial<RuntimePoolState>): PoolState {
+  return {
+    uv: { ...DEFAULT_RUNTIME_POOL },
+    conda: { ...DEFAULT_RUNTIME_POOL, ...overrides },
+    pixi: { ...DEFAULT_RUNTIME_POOL },
+  };
+}
+
+function newScheduler(): VirtualTimeScheduler {
+  return new VirtualTimeScheduler(VirtualAction, Infinity);
+}
+
+function advanceBy(scheduler: VirtualTimeScheduler, milliseconds: number): void {
+  const target = scheduler.frame + milliseconds;
+  scheduler.maxFrames = target;
+  scheduler.schedule(() => {}, milliseconds);
+  scheduler.flush();
+}
+
+async function drainMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("observeOnboardingPool", () => {
+  it("keeps observing from failure through retry to ready", async () => {
+    const scheduler = newScheduler();
+    const states = [
+      poolState({
+        consecutive_failures: 1,
+        error_kind: "timeout",
+        error: "warm-env timed out after 900s",
+      }),
+      poolState({
+        warming: 1,
+        consecutive_failures: 1,
+        error_kind: "timeout",
+        error: "warm-env timed out after 900s",
+      }),
+      poolState({ available: 1 }),
+    ];
+    const gates: OnboardingPoolGate[] = [];
+    let completed = false;
+
+    observeOnboardingPool({
+      pythonEnv: "conda",
+      envLabel: "Conda",
+      pollIntervalMs: 1_000,
+      scheduler,
+      fetchPoolState: async () => states.shift() ?? poolState({ available: 1 }),
+    }).subscribe({
+      next: (gate) => gates.push(gate),
+      complete: () => {
+        completed = true;
+      },
+    });
+
+    await drainMicrotasks();
+    expect(gates.map(({ kind }) => kind)).toEqual(["checking", "failed"]);
+    expect(gates.at(-1)?.canContinue).toBe(true);
+
+    advanceBy(scheduler, 1_000);
+    await drainMicrotasks();
+    expect(gates.at(-1)).toMatchObject({
+      kind: "retrying",
+      canContinue: true,
+      errorMessage: null,
+    });
+
+    advanceBy(scheduler, 1_000);
+    await drainMicrotasks();
+    expect(gates.at(-1)).toMatchObject({ kind: "ready", canContinue: true });
+    expect(completed).toBe(true);
+  });
+
+  it("keeps polling after the warming threshold unlocks continue", async () => {
+    const scheduler = newScheduler();
+    const states = [
+      poolState({ warming: 1 }),
+      poolState({ warming: 1 }),
+      poolState({ available: 1 }),
+    ];
+    const gates: OnboardingPoolGate[] = [];
+
+    observeOnboardingPool({
+      pythonEnv: "conda",
+      envLabel: "Conda",
+      pollIntervalMs: 1_000,
+      warmingPollAttempts: 2,
+      scheduler,
+      fetchPoolState: async () => states.shift() ?? poolState({ available: 1 }),
+    }).subscribe((gate) => gates.push(gate));
+
+    await drainMicrotasks();
+    expect(gates.at(-1)?.kind).toBe("warming");
+
+    advanceBy(scheduler, 1_000);
+    await drainMicrotasks();
+    expect(gates.at(-1)).toMatchObject({ kind: "slow", canContinue: true });
+
+    advanceBy(scheduler, 1_000);
+    await drainMicrotasks();
+    expect(gates.at(-1)?.kind).toBe("ready");
+  });
+
+  it("drops an in-flight result after the selection unsubscribes", async () => {
+    const scheduler = newScheduler();
+    let resolveFetch: ((state: PoolState) => void) | undefined;
+    let capturedSignal: AbortSignal | undefined;
+    const gates: OnboardingPoolGate[] = [];
+
+    const subscription = observeOnboardingPool({
+      pythonEnv: "conda",
+      envLabel: "Conda",
+      pollIntervalMs: 1_000,
+      scheduler,
+      fetchPoolState: (signal) => {
+        capturedSignal = signal;
+        return new Promise<PoolState>((resolve) => {
+          resolveFetch = resolve;
+        });
+      },
+    }).subscribe((gate) => gates.push(gate));
+
+    expect(gates.map(({ kind }) => kind)).toEqual(["checking"]);
+    subscription.unsubscribe();
+    expect(capturedSignal?.aborted).toBe(true);
+
+    resolveFetch?.(poolState({ available: 1 }));
+    await drainMicrotasks();
+    expect(gates.map(({ kind }) => kind)).toEqual(["checking"]);
+  });
+});

--- a/apps/notebook/src/__tests__/onboarding-pool-readiness.test.ts
+++ b/apps/notebook/src/__tests__/onboarding-pool-readiness.test.ts
@@ -1,114 +1,122 @@
 import { describe, expect, it } from "vitest";
+import type { PoolState, RuntimePoolState } from "runtimed";
 import {
   hasOnboardingPoolError,
   isOnboardingPoolReady,
   onboardingPoolErrorMessage,
 } from "../../onboarding/pool-readiness";
 
+const DEFAULT_RUNTIME_POOL: RuntimePoolState = {
+  available: 0,
+  warming: 0,
+  pool_size: 1,
+  consecutive_failures: 0,
+  retry_in_secs: 0,
+};
+
+function runtimePool(overrides: Partial<RuntimePoolState>): RuntimePoolState {
+  return { ...DEFAULT_RUNTIME_POOL, ...overrides };
+}
+
+function poolState(pythonEnv: keyof PoolState, overrides: Partial<RuntimePoolState>): PoolState {
+  return {
+    uv: runtimePool({}),
+    conda: runtimePool({}),
+    pixi: runtimePool({}),
+    [pythonEnv]: runtimePool(overrides),
+  };
+}
+
 describe("onboarding pool readiness", () => {
   it("does not treat a warming selected pool as ready", () => {
-    expect(
-      isOnboardingPoolReady("uv", {
-        uv: { available: 0, warming: 1, pool_size: 2 },
-      }),
-    ).toBe(false);
+    expect(isOnboardingPoolReady("uv", poolState("uv", { warming: 1, pool_size: 2 }))).toBe(false);
   });
 
   it("does not treat an idle empty selected pool as ready", () => {
-    expect(
-      isOnboardingPoolReady("uv", {
-        uv: { available: 0, warming: 0, pool_size: 2 },
-      }),
-    ).toBe(false);
+    expect(isOnboardingPoolReady("uv", poolState("uv", { pool_size: 2 }))).toBe(false);
   });
 
   it("treats the selected pool as ready when at least one env is available", () => {
     expect(
-      isOnboardingPoolReady("uv", {
-        uv: { available: 1, warming: 1, pool_size: 2 },
-      }),
+      isOnboardingPoolReady("uv", poolState("uv", { available: 1, warming: 1, pool_size: 2 })),
     ).toBe(true);
   });
 
   it("treats a disabled selected pool as ready", () => {
-    expect(
-      isOnboardingPoolReady("uv", {
-        uv: { available: 0, warming: 0, pool_size: 0 },
-      }),
-    ).toBe(true);
+    expect(isOnboardingPoolReady("uv", poolState("uv", { pool_size: 0 }))).toBe(true);
   });
 });
 
 describe("onboarding pool error", () => {
   it("flags a failed pool with a recorded error", () => {
     expect(
-      hasOnboardingPoolError("conda", {
-        conda: {
-          available: 0,
-          warming: 0,
-          pool_size: 1,
+      hasOnboardingPoolError(
+        "conda",
+        poolState("conda", {
           consecutive_failures: 2,
           error: "warm-env timed out after 900s",
-        },
-      }),
+        }),
+      ),
     ).toBe(true);
   });
 
   it("does not flag an error while still warming without a failure", () => {
-    expect(
-      hasOnboardingPoolError("conda", {
-        conda: { available: 0, warming: 1, pool_size: 1 },
-      }),
-    ).toBe(false);
+    expect(hasOnboardingPoolError("conda", poolState("conda", { warming: 1 }))).toBe(false);
   });
 
   it("does not flag an error once an env is available", () => {
     expect(
-      hasOnboardingPoolError("conda", {
-        conda: {
+      hasOnboardingPoolError(
+        "conda",
+        poolState("conda", {
           available: 1,
-          warming: 0,
-          pool_size: 1,
           consecutive_failures: 3,
           error: "stale error",
-        },
-      }),
+        }),
+      ),
     ).toBe(false);
   });
 
   it("does not flag a failure with no recorded message", () => {
-    expect(
-      hasOnboardingPoolError("conda", {
-        conda: { available: 0, warming: 0, pool_size: 1, consecutive_failures: 1 },
-      }),
-    ).toBe(false);
+    expect(hasOnboardingPoolError("conda", poolState("conda", { consecutive_failures: 1 }))).toBe(
+      false,
+    );
   });
 
   it("names the failed package for invalid_package errors", () => {
     expect(
-      onboardingPoolErrorMessage("Conda", {
-        error_kind: "invalid_package",
-        failed_package: "bogus-pkg",
-        error: "No solution found",
-      }),
+      onboardingPoolErrorMessage(
+        "Conda",
+        runtimePool({
+          error_kind: "invalid_package",
+          failed_package: "bogus-pkg",
+          error: "No solution found",
+        }),
+      ),
     ).toContain("bogus-pkg");
   });
 
   it("gives a network-friendly message for timeouts", () => {
-    const message = onboardingPoolErrorMessage("Conda", {
-      error_kind: "timeout",
-      error: "warm-env subprocess timed out after 900s",
-    });
+    const message = onboardingPoolErrorMessage(
+      "Conda",
+      runtimePool({
+        error_kind: "timeout",
+        error: "warm-env subprocess timed out after 900s",
+      }),
+    );
     expect(message).toContain("timed out");
     expect(message).toContain("retrying");
   });
 
   it("falls back to the raw error detail", () => {
     expect(
-      onboardingPoolErrorMessage("UV", {
-        error_kind: "setup_failed",
-        error: "disk full",
-      }),
+      onboardingPoolErrorMessage(
+        "UV",
+        runtimePool({
+          error_kind: "setup_failed",
+          error: "disk full",
+        }),
+      ),
     ).toContain("disk full");
   });
 });


### PR DESCRIPTION
## Summary

- replace the onboarding effect's hand-rolled loop with an onboarding-local RxJS pool gate built on the shared `createPoll` primitive
- keep observing after a soft timeout or daemon-reported failure so the UI can move from failed, to retrying, to ready without relocking "continue anyway"
- unsubscribe the selected environment's stream on selection changes so late pool-status responses cannot update the new selection
- consume the shared `PoolState` type instead of maintaining a parallel optional onboarding shape

Focused follow-up to #4064. The larger `PoolDoc` progress and terminal-rendering surface remains separate.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm test:run` (2,778 passed, 6 skipped)
