### PR TITLE
fix(cloud): recover from stale deployment assets

### DIFF
--- a/apps/notebook-cloud/test/stale-deployment-recovery.test.ts
+++ b/apps/notebook-cloud/test/stale-deployment-recovery.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { installStaleDeploymentRecovery } from "../viewer/stale-deployment-recovery.ts";
+
+describe("stale deployment recovery", () => {
+  it("reloads once when Vite reports a missing lazy asset", () => {
+    const target = new EventTarget();
+    const storage = new MemoryStorage();
+    const warnings: Array<[string, unknown]> = [];
+    let reloads = 0;
+    const dispose = installStaleDeploymentRecovery({
+      target,
+      storage,
+      reload: () => {
+        reloads += 1;
+      },
+      now: () => 1_000,
+      warn: (message, error) => warnings.push([message, error]),
+    });
+    const error = new Error(
+      "Failed to fetch dynamically imported module: /assets/notebook-route-old.js",
+    );
+    const event = preloadErrorEvent(error);
+
+    target.dispatchEvent(event);
+
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(reloads, 1);
+    assert.deepEqual(warnings, [
+      ["[notebook-cloud] stale deployment asset detected; reloading viewer", error],
+    ]);
+    dispose();
+  });
+
+  it("lets a repeated failure reach the error boundary instead of reloading in a loop", () => {
+    const target = new EventTarget();
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    let now = 1_000;
+    installStaleDeploymentRecovery({
+      target,
+      storage,
+      reload: () => {
+        reloads += 1;
+      },
+      now: () => now,
+      warn: () => {},
+    });
+
+    const first = preloadErrorEvent(new Error("missing old chunk"));
+    target.dispatchEvent(first);
+    now += 30_000;
+    const repeated = preloadErrorEvent(new Error("deployment is still broken"));
+    target.dispatchEvent(repeated);
+
+    assert.equal(first.defaultPrevented, true);
+    assert.equal(repeated.defaultPrevented, false);
+    assert.equal(reloads, 1);
+  });
+
+  it("suppresses recovery inside the cooldown and allows it at the boundary", () => {
+    const target = new EventTarget();
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    let now = 1_000;
+    installStaleDeploymentRecovery({
+      target,
+      storage,
+      reload: () => {
+        reloads += 1;
+      },
+      now: () => now,
+      warn: () => {},
+    });
+
+    target.dispatchEvent(preloadErrorEvent(new Error("first stale deployment")));
+    now += 59_999;
+    const insideCooldown = preloadErrorEvent(new Error("still inside cooldown"));
+    target.dispatchEvent(insideCooldown);
+    now += 1;
+    const atBoundary = preloadErrorEvent(new Error("later stale deployment"));
+    target.dispatchEvent(atBoundary);
+
+    assert.equal(insideCooldown.defaultPrevented, false);
+    assert.equal(atBoundary.defaultPrevented, true);
+    assert.equal(reloads, 2);
+  });
+
+  it("does not risk a reload loop when session storage is unavailable", () => {
+    const target = new EventTarget();
+    let reloads = 0;
+    installStaleDeploymentRecovery({
+      target,
+      storage: {
+        getItem: () => {
+          throw new DOMException("blocked", "SecurityError");
+        },
+        setItem: () => {
+          throw new DOMException("blocked", "SecurityError");
+        },
+      },
+      reload: () => {
+        reloads += 1;
+      },
+      now: () => 1_000,
+      warn: () => {},
+    });
+    const event = preloadErrorEvent(new Error("missing chunk"));
+
+    target.dispatchEvent(event);
+
+    assert.equal(event.defaultPrevented, false);
+    assert.equal(reloads, 0);
+  });
+
+  it("removes the listener when disposed", () => {
+    const target = new EventTarget();
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    const dispose = installStaleDeploymentRecovery({
+      target,
+      storage,
+      reload: () => {
+        reloads += 1;
+      },
+      now: () => 1_000,
+      warn: () => {},
+    });
+
+    dispose();
+    target.dispatchEvent(preloadErrorEvent(new Error("missing chunk")));
+
+    assert.equal(reloads, 0);
+  });
+});
+
+function preloadErrorEvent(error: Error): Event {
+  const event = new Event("vite:preloadError", { cancelable: true });
+  Object.defineProperty(event, "payload", { value: error });
+  return event;
+}
+
+class MemoryStorage implements Pick<Storage, "getItem" | "setItem"> {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -21,7 +21,10 @@ import { cloudNotebookRouteTitleFromPathname } from "./cloud-notebook-title-stat
 import { CloudHomeView } from "./home-view";
 import { CloudNotebookListView } from "./notebook-list-view";
 import { loadNotebookRouteModule } from "./notebook-route-preload";
+import { installStaleDeploymentRecovery } from "./stale-deployment-recovery";
 import "./index.css";
+
+installStaleDeploymentRecovery();
 
 const NotebookRoute = lazy(() =>
   loadNotebookRouteModule().then((module) => ({ default: module.NotebookRoute })),

--- a/apps/notebook-cloud/viewer/stale-deployment-recovery.ts
+++ b/apps/notebook-cloud/viewer/stale-deployment-recovery.ts
@@ -1,0 +1,104 @@
+const STALE_DEPLOYMENT_RECOVERY_KEY = "nteract:cloud:stale-deployment-recovery";
+const STALE_DEPLOYMENT_RECOVERY_COOLDOWN_MS = 60_000;
+
+interface StaleDeploymentRecoveryOptions {
+  target?: EventTarget;
+  storage?: Pick<Storage, "getItem" | "setItem">;
+  reload?: () => void;
+  now?: () => number;
+  warn?: (message: string, error: unknown) => void;
+}
+
+interface StaleDeploymentRecoveryAttempt {
+  attemptedAt: number;
+  message: string;
+}
+
+/**
+ * Vite emits `vite:preloadError` when a lazy import or one of its preloaded
+ * dependencies cannot be fetched. A tab left open across a deployment can
+ * retain the old entry module in memory after its content-hashed lazy chunks
+ * have been retired. The deployed host serves notebook HTML with `no-store`
+ * and the stable viewer entrypoint with revalidation semantics, so reloading
+ * picks up the current asset graph.
+ *
+ * Keep the attempt in sessionStorage across the reload. If the new deployment
+ * is itself broken, a second preload failure inside the cooldown falls through
+ * to the root error boundary instead of creating a reload loop.
+ */
+export function installStaleDeploymentRecovery(
+  options: StaleDeploymentRecoveryOptions = {},
+): () => void {
+  const target = options.target ?? window;
+  const storage = options.storage ?? window.sessionStorage;
+  const reload = options.reload ?? (() => window.location.reload());
+  const now = options.now ?? (() => Date.now());
+  const warn =
+    options.warn ??
+    ((message: string, error: unknown) => {
+      console.warn(message, error);
+    });
+
+  const onPreloadError = (event: Event) => {
+    const error = preloadErrorPayload(event);
+    if (!claimStaleDeploymentRecovery(storage, now(), error)) {
+      return;
+    }
+
+    event.preventDefault();
+    warn("[notebook-cloud] stale deployment asset detected; reloading viewer", error);
+    reload();
+  };
+
+  target.addEventListener("vite:preloadError", onPreloadError);
+  return () => target.removeEventListener("vite:preloadError", onPreloadError);
+}
+
+function claimStaleDeploymentRecovery(
+  storage: Pick<Storage, "getItem" | "setItem">,
+  attemptedAt: number,
+  error: unknown,
+): boolean {
+  try {
+    const previous = parseRecoveryAttempt(storage.getItem(STALE_DEPLOYMENT_RECOVERY_KEY));
+    // The boundary is intentionally exclusive: a new recovery may run once
+    // the full cooldown duration has elapsed.
+    if (
+      previous &&
+      attemptedAt >= previous.attemptedAt &&
+      attemptedAt - previous.attemptedAt < STALE_DEPLOYMENT_RECOVERY_COOLDOWN_MS
+    ) {
+      return false;
+    }
+
+    const attempt: StaleDeploymentRecoveryAttempt = {
+      attemptedAt,
+      message: error instanceof Error ? error.message : String(error),
+    };
+    storage.setItem(STALE_DEPLOYMENT_RECOVERY_KEY, JSON.stringify(attempt));
+    return true;
+  } catch {
+    // Without durable loop protection, leave the failure to the error boundary.
+    return false;
+  }
+}
+
+function parseRecoveryAttempt(value: string | null): StaleDeploymentRecoveryAttempt | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as Partial<StaleDeploymentRecoveryAttempt>;
+    return typeof parsed.attemptedAt === "number" &&
+      Number.isFinite(parsed.attemptedAt) &&
+      typeof parsed.message === "string"
+      ? { attemptedAt: parsed.attemptedAt, message: parsed.message }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function preloadErrorPayload(event: Event): unknown {
+  return "payload" in event ? (event as Event & { payload: unknown }).payload : event;
+}


### PR DESCRIPTION
## Summary

- recover long-lived hosted viewer tabs when a Vite lazy chunk was retired by a newer deployment
- install the recovery listener before lazy routes initialize
- persist a one-minute recovery cooldown in session storage so a broken deployment falls through to the error boundary instead of reloading forever
- add focused coverage for first recovery, loop prevention, cooldown boundaries, unavailable storage, and listener disposal

## Root cause

A tab left open across a deployment retained the previous viewer entry module in memory. When it later loaded the notebook route, it requested a retired content-hashed chunk and received a 404. Reloading worked because notebook HTML is served with `no-store` and the stable viewer entrypoint revalidates to the current asset graph.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/stale-deployment-recovery.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- `cargo xtask lint --fix`
- confirmed the production bundle contains the `vite:preloadError` recovery listener

The full notebook-cloud suite also surfaced existing failures in OIDC callback copy assertions and workstation `accelerators: null` serialization; this PR does not touch those paths.

## External review

Reviewed through the repository's opencode-backed Amazon Bedrock harness with Claude Opus 4.6. The useful cooldown-boundary and deterministic-clock suggestions were applied. Remaining review entries were withdrawn or dispositioned as non-issues against Vite's typed browser event contract.
