### PR TITLE
feat(cloud): full-stage sign-in gate for signed-out private notebooks

### DIFF
--- a/apps/elements/components/unhappy-states-example.tsx
+++ b/apps/elements/components/unhappy-states-example.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   BookOpen,
   Check,
@@ -15,6 +17,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { CSSProperties } from "react";
+import { NotebookAccessGate, type NotebookAccessGateTone } from "@/components/notebook";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -262,6 +265,78 @@ export function ElementsAccessGateExample() {
           <EmptyState {...state} className="min-h-[360px] px-6" />
         </div>
       ))}
+    </div>
+  );
+}
+
+const fullStageGates = [
+  {
+    icon: KeyRound,
+    tone: "info" as const,
+    title: "Sign in to open this notebook",
+    detail:
+      "This notebook is private. Sign in with your account and we'll bring you straight back here.",
+    primaryLabel: "Sign in with Anaconda",
+  },
+  {
+    icon: Lock,
+    tone: "attention" as const,
+    title: "This notebook is private",
+    detail: "Your account doesn't have access yet. Ask, and the owner gets a note right away.",
+    primaryLabel: "Request access",
+    note: "Signed in as alice@localhost",
+  },
+  {
+    icon: FileQuestion,
+    tone: "neutral" as const,
+    title: "Notebook not found",
+    detail:
+      "There is nothing at this address. It may have been deleted, or the link came through slightly wrong.",
+    secondaryLabel: "Back to your notebooks",
+  },
+] satisfies readonly {
+  icon: LucideIcon;
+  tone: NotebookAccessGateTone;
+  title: string;
+  detail: string;
+  primaryLabel?: string;
+  secondaryLabel?: string;
+  note?: string;
+}[];
+
+export function ElementsFullStageGateExample() {
+  return (
+    <div className="not-prose grid gap-3 lg:grid-cols-3">
+      {fullStageGates.map((gate) => {
+        const Icon = gate.icon;
+        return (
+          <div
+            key={gate.title}
+            className="flex min-h-[320px] overflow-hidden rounded-lg border border-border bg-background"
+          >
+            <NotebookAccessGate
+              tone={gate.tone}
+              icon={<Icon aria-hidden="true" />}
+              title={gate.title}
+              detail={gate.detail}
+              primaryAction={
+                gate.primaryLabel ? <Button size="sm">{gate.primaryLabel}</Button> : undefined
+              }
+              secondaryAction={
+                gate.secondaryLabel ? (
+                  <a
+                    href="/docs/cloud-dashboard"
+                    className="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+                  >
+                    {gate.secondaryLabel}
+                  </a>
+                ) : undefined
+              }
+              note={gate.note}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/elements/content/docs/unhappy-states.mdx
+++ b/apps/elements/content/docs/unhappy-states.mdx
@@ -6,6 +6,7 @@ description: Cloud viewer empty, blocked, notice, auth recovery, and rail status
 import {
   ElementsAccessGateExample,
   ElementsEmptyStateExample,
+  ElementsFullStageGateExample,
   ElementsNoticeBannerExample,
   ElementsRailStatusExample,
   ElementsSessionExpiredReturnExample,
@@ -33,6 +34,15 @@ Full-stage blocked-room states for missing notebooks, missing access, and
 signed-out private notebook links.
 
 <ElementsAccessGateExample />
+
+## Full-stage gate (shared component)
+
+The shipping `NotebookAccessGate` primitive that the cloud viewer renders on the
+notebook stage for signed-out, no-access, and not-found paths. It fills the
+stage so a gated route reads as intentionally gated rather than as an empty or
+broken notebook, with one high-emphasis primary action.
+
+<ElementsFullStageGateExample />
 
 ## Notice banner
 

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -203,7 +203,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /<NotebookDocumentToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(
     sourceText,
-    /presence=\{[\s\S]*<CloudNotebookTitle[\s\S]*title=\{notebookTitle\}[\s\S]*canRename=\{catalogAccessResolved && catalogGrantsDocumentEdit\}[\s\S]*onRename=\{saveCloudNotebookTitle\}/,
+    /presence=\{[\s\S]*<CloudNotebookTitle[\s\S]*title=\{notebookStageGated \? gatedNotebookTitle : notebookTitle\}[\s\S]*canRename=\{catalogAccessResolved && catalogGrantsDocumentEdit\}[\s\S]*onRename=\{saveCloudNotebookTitle\}/,
   );
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -591,7 +591,14 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   );
   assert.match(sourceText, /const notebookHeaderChrome = projectCloudNotebookHeaderChrome\(\{/);
   assert.match(sourceText, /projectCloudNotebookViewSurface\(\{/);
-  assert.match(sourceText, /bodyAccessBlocked: notebookBodyAccessBlocked/);
+  // A signed-out gate blocks the stage like an access diagnostic, so both the
+  // header-chrome and view-surface projections consume the combined
+  // notebookStageGated flag.
+  assert.match(
+    sourceText,
+    /const notebookStageGated = notebookBodyAccessBlocked \|\| signedOutNotebookSignInRequired/,
+  );
+  assert.match(sourceText, /bodyAccessBlocked: notebookStageGated/);
   assert.match(
     sourceText,
     /hasAccessDiagnostic: isCloudConnectionAccessDiagnostic\(connectionError\)/,

--- a/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
@@ -44,6 +44,23 @@ export function cloudNotebookDocumentTitle(displayTitle: string): string {
   return `nteract notebook: ${displayTitle.trim() || UNTITLED_NOTEBOOK_LABEL}`;
 }
 
+const GATED_NOTEBOOK_LABEL = "Private notebook";
+
+/**
+ * Intentional placeholder title for a gated notebook (signed-out or
+ * access-blocked). The catalog title is unknown in these states, and the route
+ * fallback humanizes the URL vanity slug into a guessed, CSS-truncated fragment
+ * (e.g. "Ob…") that reads as broken. Show a clean label instead until access
+ * resolves and the real catalog title arrives.
+ */
+export function cloudNotebookGatedTitle(): CloudNotebookTitleDisplay {
+  return {
+    label: GATED_NOTEBOOK_LABEL,
+    detail: null,
+    title: GATED_NOTEBOOK_LABEL,
+  };
+}
+
 export function cloudNotebookRouteTitleFromPathname(pathname: string): CloudNotebookTitleDisplay {
   const pathParts = pathname.split("/").filter(Boolean);
   const routeSlug = pathParts[0] === "n" ? pathParts[2] : null;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -2324,6 +2324,13 @@ body {
   }
 }
 
+/* Center the prominent sign-in button inside the full-stage access gate,
+   overriding the right-aligned dashboard/list treatment. */
+.cloud-notebook-gate-actions {
+  justify-content: center;
+  min-width: 0;
+}
+
 .cloud-share-panel {
   position: fixed;
   top: 4.75rem;

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { AlertCircle, Check, Info, Loader2, PanelLeftOpen, X } from "lucide-react";
+import { AlertCircle, Check, Info, Loader2, LogIn, PanelLeftOpen, X } from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import {
   useHasIsolatedOutputs,
@@ -22,6 +22,7 @@ import {
   resolveMarkdownProjection,
 } from "@/lib/markdown-projection";
 import {
+  NotebookAccessGate,
   NotebookConnectionIdentity,
   NotebookCommentsPanel,
   NotebookDocumentToolbar,
@@ -197,6 +198,7 @@ import { CloudNotebookEditModeButton } from "./cloud-edit-mode-button";
 import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
 import {
   cloudNotebookDocumentTitle,
+  cloudNotebookGatedTitle,
   cloudNotebookTitleDisplay,
   cloudNotebookUrlAfterRename,
   type CloudNotebookCatalogResponse,
@@ -1611,9 +1613,34 @@ export function NotebookViewer({
   const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar(shellCapabilities, {
     reserve: editAccessPending,
   });
+  const notebookHasReadableSnapshot =
+    notebookCellIds.length > 0 ||
+    (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
+  // The route has no authenticated identity and the live-room join is retrying
+  // without a readable public snapshot: a hard sign-in wall, distinct from stale
+  // or expired auth. This owns the whole stage (NotebookAccessGate below) instead
+  // of riding the thin notice banner, so the signed-out canvas reads as gated
+  // rather than an empty/broken notebook.
+  const signedOutNotebookSignInRequired =
+    Boolean(authConfig.localDev || authConfig.oidc) &&
+    appSessionStatus.status !== "loading" &&
+    !hasAppSession &&
+    authState.mode === "anonymous" &&
+    !isPublicViewer &&
+    !notebookHasReadableSnapshot &&
+    status.kind === "loading" &&
+    Boolean(connectionError && isTransportReconnectError(connectionError));
   const notebookBodyAccessBlocked = cloudConnectionDiagnosticBlocksNotebookBody(connectionError);
+  // A signed-out gate blocks the body just like an access diagnostic: quiet the
+  // presence/edit/identity chrome so the header does not advertise collaboration
+  // affordances behind a sign-in wall.
+  const notebookStageGated = notebookBodyAccessBlocked || signedOutNotebookSignInRequired;
+  // Behind a gate the catalog title is unknown, so `notebookTitle` falls back to
+  // the humanized URL slug — a guessed, CSS-truncated fragment (e.g. "Ob…") that
+  // reads as broken. Show a clean intentional label instead until access resolves.
+  const gatedNotebookTitle = useMemo(cloudNotebookGatedTitle, []);
   const notebookHeaderChrome = projectCloudNotebookHeaderChrome({
-    bodyAccessBlocked: notebookBodyAccessBlocked,
+    bodyAccessBlocked: notebookStageGated,
     liveRoomAccessPending: liveRoomDisabledStatus?.kind === "loading",
   });
 
@@ -1624,7 +1651,7 @@ export function NotebookViewer({
       headerClassName="cloud-room-toolbar"
       presence={
         <CloudNotebookTitle
-          title={notebookTitle}
+          title={notebookStageGated ? gatedNotebookTitle : notebookTitle}
           renameTitle={catalogNotebookTitle?.trim() ?? ""}
           canRename={catalogAccessResolved && catalogGrantsDocumentEdit}
           renameSaving={notebookTitleSaving}
@@ -1718,20 +1745,10 @@ export function NotebookViewer({
       }}
     />
   );
-  const notebookHasReadableSnapshot =
-    notebookCellIds.length > 0 ||
-    (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
-  const signedOutNotebookSignInRequired =
-    Boolean(authConfig.localDev || authConfig.oidc) &&
-    appSessionStatus.status !== "loading" &&
-    !hasAppSession &&
-    authState.mode === "anonymous" &&
-    !isPublicViewer &&
-    !notebookHasReadableSnapshot &&
-    status.kind === "loading" &&
-    Boolean(connectionError && isTransportReconnectError(connectionError));
   const notebookViewSurface = projectCloudNotebookViewSurface({
-    bodyAccessBlocked: notebookBodyAccessBlocked,
+    // A signed-out gate owns the stage: suppress the empty NotebookView so it
+    // does not paint a blank canvas behind the gate.
+    bodyAccessBlocked: notebookStageGated,
     cellCount: notebookCellIds.length,
     canEditStructure: shellCapabilities.canEditStructure,
     connectionError,
@@ -1811,6 +1828,7 @@ export function NotebookViewer({
     isPublicViewer,
     hasReadableSnapshot: notebookHasReadableSnapshot,
     signInRequired: signedOutNotebookSignInRequired,
+    signInRequiredOwnedByStage: signedOutNotebookSignInRequired,
     offlineMergeNotice,
     rendererAssetError,
     sustainedReconnecting,
@@ -1827,6 +1845,7 @@ export function NotebookViewer({
       isPublicViewer={isPublicViewer}
       hasReadableSnapshot={notebookHasReadableSnapshot}
       signInRequired={signedOutNotebookSignInRequired}
+      signInRequiredOwnedByStage={signedOutNotebookSignInRequired}
       offlineMergeNotice={offlineMergeNotice}
       rendererAssetError={rendererAssetError}
       sustainedReconnecting={sustainedReconnecting}
@@ -1836,6 +1855,26 @@ export function NotebookViewer({
       onRetryConnection={retryLiveConnection}
       onRetryRendererAssets={isolatedRenderer.retry}
       onSignInAgain={authConfig.localDev || authConfig.oidc ? beginNotebookAuth : undefined}
+    />
+  ) : null;
+
+  // Full-stage sign-in wall for a signed-out private notebook link. Owns the
+  // whole canvas (the empty NotebookView is suppressed and the rail hidden) so
+  // the surface reads as intentionally gated. The primary action reuses
+  // CloudNotebookSignInButton, the single sign-in source of truth, so its copy
+  // and OIDC-vs-localDev priority cannot drift from the rest of the app.
+  const signedOutGate = signedOutNotebookSignInRequired ? (
+    <NotebookAccessGate
+      tone="info"
+      icon={<LogIn aria-hidden="true" />}
+      title="Sign in to open this notebook"
+      detail="This notebook is private. Sign in with your account and we'll bring you straight back here."
+      primaryAction={
+        <div className="cloud-notebook-signed-out-actions cloud-notebook-gate-actions">
+          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+        </div>
+      }
+      data-testid="cloud-notebook-signed-out-gate"
     />
   ) : null;
 
@@ -1854,7 +1893,7 @@ export function NotebookViewer({
         notices={notices}
         noticesClassName="cloud-notebook-notices"
         capabilities={shellCapabilities}
-        rail={rail}
+        rail={notebookStageGated ? undefined : rail}
         stageLabel="Hosted notebook"
       >
         <h1 className="sr-only">{notebookTitle.title}</h1>
@@ -1866,6 +1905,7 @@ export function NotebookViewer({
             onSyncNeeded={handleSourceSyncNeeded}
             localActor={connectionActorLabel ?? ""}
           >
+            {signedOutGate}
             {notebookViewSurface.shouldRenderNotebookView ? (
               <NotebookView
                 cellIds={notebookCellIds}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -38,6 +38,13 @@ export interface CloudNotebookNoticesProps {
    */
   signInRequired?: boolean;
   /**
+   * The full-stage `NotebookAccessGate` owns the signed-out surface, so the
+   * thin inline sign-in banner must not double it. `signInRequired` still flows
+   * in to suppress the redundant "Loading notebook." status notice; only the
+   * banner itself is withheld.
+   */
+  signInRequiredOwnedByStage?: boolean;
+  /**
    * The live-room status has been "reconnecting" past the debounce window
    * (`useSustainedReconnecting`). Renders the single quiet reconnect line;
    * transport-loss `connectionError` strings are routed here instead of
@@ -125,6 +132,7 @@ export function cloudNotebookHasNotices({
   isPublicViewer = false,
   hasReadableSnapshot = false,
   signInRequired = false,
+  signInRequiredOwnedByStage = false,
   offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
@@ -148,7 +156,10 @@ export function cloudNotebookHasNotices({
     isPublicViewer,
   });
   const shouldShowSignInRequiredNotice =
-    signInRequired && !shouldShowAnonymousViewerAuthNotice && !hasAppSession;
+    signInRequired &&
+    !signInRequiredOwnedByStage &&
+    !shouldShowAnonymousViewerAuthNotice &&
+    !hasAppSession;
   const shouldShowAuthNotice =
     !shouldShowAnonymousViewerAuthNotice &&
     !shouldShowSignInRequiredNotice &&
@@ -184,6 +195,7 @@ export function CloudNotebookNotices({
   isPublicViewer = false,
   hasReadableSnapshot = false,
   signInRequired = false,
+  signInRequiredOwnedByStage = false,
   offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
@@ -204,6 +216,7 @@ export function CloudNotebookNotices({
       isPublicViewer,
       hasReadableSnapshot,
       signInRequired,
+      signInRequiredOwnedByStage,
       offlineMergeNotice,
       rendererAssetError,
       sustainedReconnecting,
@@ -230,7 +243,10 @@ export function CloudNotebookNotices({
     isPublicViewer,
   });
   const shouldShowSignInRequiredNotice =
-    signInRequired && !shouldShowAnonymousViewerAuthNotice && !hasAppSession;
+    signInRequired &&
+    !signInRequiredOwnedByStage &&
+    !shouldShowAnonymousViewerAuthNotice &&
+    !hasAppSession;
   const shouldShowAuthNotice =
     !shouldShowAnonymousViewerAuthNotice &&
     !shouldShowSignInRequiredNotice &&

--- a/apps/notebook/src/components/__tests__/component-chroma-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/component-chroma-boundary.test.ts
@@ -30,6 +30,7 @@ const RATCHET_RAW_PALETTE_FILES = [
   "src/components/notebook/DebugBanner.tsx",
   "src/components/notebook/EnvBuildDecisionDialog.tsx",
   "src/components/notebook/KernelLaunchErrorBanner.tsx",
+  "src/components/notebook/NotebookAccessGate.tsx",
   "src/components/notebook/NotebookCommandToolbar.tsx",
   "src/components/notebook/NotebookConnectionIdentity.tsx",
   "src/components/notebook/NotebookEditModeButton.tsx",

--- a/src/components/notebook/NotebookAccessGate.tsx
+++ b/src/components/notebook/NotebookAccessGate.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Severity language for full-stage gate states, aligned with the cloud viewer
+ * unhappy-state family: kernel-starting blue for calm sign-in prompts, executing
+ * amber for access attention, muted neutral for missing/not-found. Severity
+ * changes the icon badge tone, not the whole surface.
+ */
+export type NotebookAccessGateTone = "neutral" | "info" | "attention";
+
+const gateBadgeToneClassName: Record<NotebookAccessGateTone, string> = {
+  neutral: "bg-muted text-muted-foreground",
+  info: "bg-sky-500/10 text-sky-600 dark:text-sky-300",
+  attention: "bg-amber-500/10 text-amber-600 dark:text-amber-300",
+};
+
+export interface NotebookAccessGateProps {
+  /** Quiet icon rendered inside the badge; sized by the badge, not the caller. */
+  icon?: ReactNode;
+  tone?: NotebookAccessGateTone;
+  /** Short label without a trailing period, per the unhappy-state family. */
+  title: string;
+  /** One sentence of detail. */
+  detail?: ReactNode;
+  /** Primary call to action — a real button, the only high-emphasis element. */
+  primaryAction?: ReactNode;
+  /** Optional lower-emphasis link/button below the primary action. */
+  secondaryAction?: ReactNode;
+  /** Optional quiet footnote (e.g. the signed-in identity). */
+  note?: ReactNode;
+  className?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Full-stage blocked-room state: centered copy, a quiet icon badge, one
+ * sentence of detail, and at most one primary action. Fills the notebook stage
+ * so a gated route reads as intentionally gated rather than empty or broken.
+ * Shared by the Elements catalog and the cloud viewer so the signed-out,
+ * no-access, and not-found paths speak one visual language.
+ */
+export function NotebookAccessGate({
+  icon,
+  tone = "neutral",
+  title,
+  detail,
+  primaryAction,
+  secondaryAction,
+  note,
+  className,
+  "data-testid": dataTestId,
+}: NotebookAccessGateProps) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col items-center justify-center px-6 py-12 text-center",
+        className,
+      )}
+      data-slot="notebook-access-gate"
+      data-tone={tone}
+      data-testid={dataTestId}
+    >
+      {icon ? (
+        <span
+          className={cn(
+            "grid size-11 place-items-center rounded-xl [&_svg]:size-5",
+            gateBadgeToneClassName[tone],
+          )}
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+      ) : null}
+      <h2 className="mt-4 text-base font-semibold text-foreground">{title}</h2>
+      {detail ? (
+        <p className="mt-1.5 max-w-sm text-sm leading-6 text-muted-foreground">{detail}</p>
+      ) : null}
+      {primaryAction || secondaryAction || note ? (
+        <div className="mt-5 flex flex-col items-center gap-2.5">
+          {primaryAction}
+          {secondaryAction}
+          {note ? <div className="text-xs text-muted-foreground">{note}</div> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -121,6 +121,11 @@ export {
   type NotebookNoticeStackProps,
   type NotebookNoticeTone,
 } from "./NotebookNotice";
+export {
+  NotebookAccessGate,
+  type NotebookAccessGateProps,
+  type NotebookAccessGateTone,
+} from "./NotebookAccessGate";
 export { RuntimeDecisionDialog, type RuntimeDecisionDialogProps } from "./RuntimeDecisionDialog";
 export { TrustDialog, type TrustDialogProps } from "./TrustDialog";
 export {


### PR DESCRIPTION
## What & why

The signed-out private-notebook surface used to be a warning banner floating over an empty notebook stage — it read as broken or still-loading, with 3–4 competing weak sign-in affordances and a leaked/humanized URL slug as the title. This replaces it with a **centered full-stage gate** so a gated route reads as *intentionally gated*.

- Add a shared **`NotebookAccessGate`** primitive (centered icon badge, title, one line of detail, one primary action; `neutral`/`info`/`attention` tones), exported from `src/components/notebook` and cataloged in Elements `unhappy-states`.
- Route `signedOutNotebookSignInRequired` to the gate on the notebook stage: suppress the empty `NotebookView`, hide the rail, and quiet header presence/edit/identity chrome behind the wall (`notebookStageGated`).
- Reuse **`CloudNotebookSignInButton`** as the single sign-in source of truth so the gate's CTA copy and OIDC-vs-localDev priority cannot drift.
- Withhold the redundant inline sign-in banner when the gate owns the surface (`signInRequiredOwnedByStage`) while still suppressing the stale loading notice.
- Show a clean **"Private notebook"** title instead of the humanized URL slug fragment (the "Ob…" bug) until access resolves.

## Before → After

Both captured from the **real cloud viewer** (`wrangler dev` + local OIDC) in the identical signed-out private-notebook state (`signedOutNotebookSignInRequired`: transport reconnecting + anonymous + no snapshot). The only variable is this diff.

| | Before | After |
|---|---|---|
| **Title** | "Quarterly Forecast" — leaked/humanized URL slug (the "Ob…" bug class) | "Private notebook" — clean intentional label |
| **Sign-in affordances** | 3 competing: top-bar button + banner text + weak "Sign in" link | 1 centered high-emphasis button |
| **Primary area** | Huge empty void — reads as broken or still loading | Centered gate panel: icon badge, title, one line of context, the CTA |
| **Left rail** | Live-looking dead icons (outline, packages, comments) | Hidden entirely |
| **Banner** | "Sign in required. Sign in to open the live notebook room." (redundant) | Gone — the gate owns the surface |

### Before (light / dark)

<img src="https://anaconda.com/api/projects/ef04f058-2322-4411-9cd1-823c5285b050/files/before-signed-out.png" width="49%"> <img src="https://anaconda.com/api/projects/ef04f058-2322-4411-9cd1-823c5285b050/files/before-signed-out-dark.png" width="49%">

### After (light / dark)

<img src="https://anaconda.com/api/projects/ef04f058-2322-4411-9cd1-823c5285b050/files/app-signed-out.png" width="49%"> <img src="https://anaconda.com/api/projects/ef04f058-2322-4411-9cd1-823c5285b050/files/app-signed-out-dark.png" width="49%">

> The sign-in button reads "Local dev OIDC" in the screenshots only because that's the dev issuer label. Production renders **"Sign in with Anaconda"** through the identical `CloudNotebookSignInButton` code path — the provider label is the only difference, server-derived from `NOTEBOOK_CLOUD_OIDC_PROVIDER_LABEL`. The gate is presentation-only over the existing shared sign-in button; nothing in this diff touches the Anaconda auth mechanics.

## Verification

- `cargo xtask lint --fix` — clean (1201 JS/TS files, ruff + ty pass)
- notebook-cloud `tsc --noEmit` — exit 0
- Modified viewer tests pass their new assertions (`viewer-shared-cell-surface`, `notebookStageGated` regex)
- Elements catalog compiles and renders the gate in both themes (all three tone variants)
- Verified end-to-end in the real `wrangler dev` cloud viewer — the gate fires on the genuine `signedOutNotebookSignInRequired` state, not a fixture
- Caught + fixed along the way: `unhappy-states-example.tsx` needed a `"use client"` directive (an RSC boundary violation that `tsc`/lint missed but broke every Elements route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
