### PR TITLE
fix(runtimed): stage full-coverage save baselines

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -924,18 +924,28 @@ impl RoomDurability {
                 )));
             }
         }
-        if state.has_durable_record && mutation_is_already_reflected(&state.manifest, &mutation) {
+        let already_reflected =
+            state.has_durable_record && mutation_is_already_reflected(&state.manifest, &mutation);
+        let mut manifest = state.manifest.clone();
+        if !already_reflected {
+            apply_mutation_to_manifest(&mut manifest, mutation);
+        }
+        // A successful ordinary save that exports every durable head is the
+        // same complete source baseline that restore and intent resolution
+        // already recognize. Stage it in the save's commit record so a room
+        // created at a path is joinable before it has to restart once.
+        if state.degraded.is_none() {
+            promote_full_coverage_checkpoint_baseline(&mut manifest);
+        }
+        if already_reflected && manifest == state.manifest {
             return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
                 &state,
             )));
         }
-
-        let mut manifest = state.manifest.clone();
         manifest.sequence = manifest
             .sequence
             .checked_add(1)
             .ok_or(RoomDurabilityError::SequenceExhausted)?;
-        apply_mutation_to_manifest(&mut manifest, mutation);
 
         if let Some(journal) = self.journal() {
             if let Err(error) = journal.append(&manifest, &state.durable_snapshot) {
@@ -1295,6 +1305,10 @@ fn status_from_state(state: &DurabilityState) -> RoomDurabilityStatus {
 /// dedicated resolution path owns the transition) or when any durable head is
 /// missing from the export. Callers gate on their degraded state: a journal
 /// with preserved corrupt data must not be promoted.
+///
+/// This normalization changes only `source_phase`. In particular it preserves
+/// both `source_generation` and journal `sequence`; the caller owns the append
+/// sequence for the record carrying the transition.
 fn promote_full_coverage_checkpoint_baseline(manifest: &mut RecoveryManifest) {
     if matches!(
         manifest.source_phase,
@@ -1497,12 +1511,11 @@ mod tests {
         assert_eq!(recovered.record.automerge_snapshot, snapshot);
     }
 
-    /// A notebook created at a path never stages a source generation, so its
-    /// journal reads Pending with peer changes. When the file checkpoint
-    /// exported every durable head, the export is a complete baseline and
-    /// recovery must restore it as durably staged, not source_degraded.
+    /// A notebook created at a path has no separately staged source
+    /// generation. Its first full-coverage file checkpoint is itself the
+    /// complete baseline and must become durably staged in the same commit.
     #[test]
-    fn recovered_full_coverage_checkpoint_restores_as_staged_baseline() {
+    fn full_coverage_checkpoint_commits_as_staged_baseline() {
         let directory = tempfile::tempdir().unwrap();
         let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
         let path = PathBuf::from("/tmp/notebook.ipynb");
@@ -1532,7 +1545,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             durability.manifest().source_phase,
-            RecoverySourcePhase::Pending
+            RecoverySourcePhase::DurablyStaged
         );
 
         let recovered = match journal.load(exported).unwrap() {
@@ -1541,8 +1554,56 @@ mod tests {
         };
         assert_eq!(
             recovered.record.manifest.source_phase,
-            RecoverySourcePhase::Pending
+            RecoverySourcePhase::DurablyStaged
         );
+
+        let reloaded = RoomDurability::recovered(journal, recovered);
+        assert_eq!(
+            reloaded.manifest().source_phase,
+            RecoverySourcePhase::DurablyStaged
+        );
+        reloaded.commit_source_ready(0).unwrap();
+        assert_eq!(reloaded.manifest().source_phase, RecoverySourcePhase::Ready);
+    }
+
+    /// Journals written before save-side baseline staging can still contain a
+    /// full-coverage Pending or Failed checkpoint. Restore promotes both
+    /// legacy shapes without changing their source generation.
+    #[test]
+    fn recovered_legacy_full_coverage_checkpoint_restores_as_staged_baseline() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(path.clone()),
+            source_fingerprint(b""),
+            0,
+            genesis,
+        );
+        let (snapshot, heads, _encoded_heads, change_hash) = snapshot_with_change(7);
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads.clone(),
+                DurableMutation::Peer {
+                    change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        let exported = source_fingerprint(b"exported ipynb bytes");
+        durability
+            .commit_file_checkpoint(path, exported, heads, 1)
+            .unwrap();
+
+        let mut recovered = match journal.load(exported).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        recovered.record.manifest.source_phase = RecoverySourcePhase::Pending;
 
         // No code path writes Failed today, but it is a serialized variant of
         // the on-disk journal format, and restore already treats it exactly
@@ -1555,7 +1616,6 @@ mod tests {
         let manifest = reloaded.manifest();
         assert_eq!(manifest.source_phase, RecoverySourcePhase::DurablyStaged);
         assert!(manifest.file_checkpoint_covers_durable_heads());
-        // The restored baseline completes the normal recovered-source path.
         reloaded.commit_source_ready(0).unwrap();
         assert_eq!(reloaded.manifest().source_phase, RecoverySourcePhase::Ready);
 
@@ -1566,11 +1626,81 @@ mod tests {
         );
     }
 
-    /// A durable peer change committed after the last export means disk is a
-    /// stale prefix, not a complete baseline. Recovery must not claim it as
-    /// staged.
+    /// A checkpoint committed while the room is degraded remains Pending even
+    /// when it covers every durable head. Once the degradation is cleared,
+    /// recommitting that already-recorded checkpoint appends the missing staged
+    /// transition exactly once, then becomes idempotent. This is the durability
+    /// path used by an `AlreadyCurrent` save.
     #[test]
-    fn recovered_checkpoint_with_unexported_tail_stays_pending() {
+    fn repeated_full_coverage_checkpoint_stages_legacy_pending_record_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let mut genesis_doc = AutoCommit::new();
+        let genesis = genesis_doc.save();
+        let durability = RoomDurability::journaled(
+            journal.clone(),
+            Uuid::nil(),
+            Some(path.clone()),
+            source_fingerprint(b""),
+            0,
+            genesis,
+        );
+        let (snapshot, heads, _encoded_heads, change_hash) = snapshot_with_change(7);
+        durability
+            .commit_snapshot(
+                &snapshot,
+                heads.clone(),
+                DurableMutation::Peer {
+                    change_hashes: vec![change_hash],
+                },
+            )
+            .unwrap();
+        let exported = source_fingerprint(b"exported ipynb bytes");
+        durability.mark_degraded(
+            DegradationKind::SourceState,
+            "source projection unavailable",
+        );
+        durability
+            .commit_file_checkpoint(path.clone(), exported, heads.clone(), 1)
+            .unwrap();
+        assert_eq!(
+            durability.manifest().source_phase,
+            RecoverySourcePhase::Pending
+        );
+        let pending = match journal.load(exported).unwrap() {
+            RecoveryLoadOutcome::Match(recovered) => recovered,
+            other => panic!("expected matching recovery, got {other:?}"),
+        };
+        assert_eq!(
+            pending.record.manifest.source_phase,
+            RecoverySourcePhase::Pending
+        );
+
+        durability.clear_degraded();
+        let before_sequence = durability.manifest().sequence;
+        let promoted = durability
+            .commit_file_checkpoint(path.clone(), exported, heads.clone(), 1)
+            .unwrap();
+        assert!(matches!(promoted, DurableCommitOutcome::Committed(_)));
+        assert_eq!(
+            durability.manifest().source_phase,
+            RecoverySourcePhase::DurablyStaged
+        );
+        assert_eq!(durability.manifest().sequence, before_sequence + 1);
+
+        let repeated = durability
+            .commit_file_checkpoint(path, exported, heads, 1)
+            .unwrap();
+        assert!(matches!(repeated, DurableCommitOutcome::AlreadyDurable(_)));
+        assert_eq!(durability.manifest().sequence, before_sequence + 1);
+    }
+
+    /// A durable peer change committed after an already-staged baseline means
+    /// disk is a stale prefix, but the baseline remains valid: recovery can
+    /// replay the durable peer tail on top of it.
+    #[test]
+    fn recovered_checkpoint_with_unexported_tail_keeps_staged_baseline() {
         let directory = tempfile::tempdir().unwrap();
         let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
         let path = PathBuf::from("/tmp/notebook.ipynb");
@@ -1622,7 +1752,7 @@ mod tests {
         durability
             .commit_snapshot(
                 &second_snapshot,
-                second_heads,
+                second_heads.clone(),
                 DurableMutation::Peer {
                     change_hashes: vec![second_hash],
                 },
@@ -1636,7 +1766,13 @@ mod tests {
         let reloaded = RoomDurability::recovered(journal, recovered);
         let manifest = reloaded.manifest();
         assert!(!manifest.file_checkpoint_covers_durable_heads());
-        assert_eq!(manifest.source_phase, RecoverySourcePhase::Pending);
+        assert_eq!(manifest.source_phase, RecoverySourcePhase::DurablyStaged);
+        let required_heads = second_heads
+            .iter()
+            .copied()
+            .map(ChangeHash)
+            .collect::<Vec<_>>();
+        assert!(snapshot_contains_heads(&reloaded.durable_snapshot(), &required_heads).unwrap());
     }
 
     /// An unresolved checkpoint intent owns its recovery through

--- a/crates/runtimed/src/notebook_sync_server/durability/property_tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability/property_tests.rs
@@ -359,6 +359,16 @@ impl Runner {
         self.model.exported_heads = heads;
         self.model.has_checkpoint = true;
         self.model.peer_after_last_checkpoint = false;
+        // Mirror `promote_full_coverage_checkpoint_baseline`: direct commits
+        // have no pending intent or degradation in this model, and promotion
+        // preserves both generation and sequence.
+        if matches!(
+            self.model.phase,
+            RecoverySourcePhase::Pending | RecoverySourcePhase::Failed
+        ) && self.model.expected_coverage()
+        {
+            self.model.phase = RecoverySourcePhase::DurablyStaged;
+        }
     }
 
     fn apply_prepare_checkpoint(&mut self) {
@@ -417,6 +427,15 @@ impl Runner {
         self.model.has_checkpoint = true;
         self.model.pending = None;
         self.model.peer_after_last_checkpoint = false;
+        // Mirror `promote_full_coverage_checkpoint_baseline` after the commit
+        // clears the prepared intent.
+        if matches!(
+            self.model.phase,
+            RecoverySourcePhase::Pending | RecoverySourcePhase::Failed
+        ) && self.model.expected_coverage()
+        {
+            self.model.phase = RecoverySourcePhase::DurablyStaged;
+        }
     }
 
     fn apply_abort_prepared(&mut self) {
@@ -662,7 +681,7 @@ impl Runner {
 // --- Fixed sequences validating the model against known-good behavior ---
 
 /// The full recovered-baseline arc as one deterministic sequence: peer edits,
-/// a covering checkpoint, a crash, the normalized DurablyStaged restore, and
+/// a covering checkpoint, its immediate DurablyStaged baseline, a crash, and
 /// the source-ready completion to Ready.
 #[test]
 fn fixed_covering_checkpoint_reloads_joinable_and_completes_ready() {
@@ -683,11 +702,10 @@ fn fixed_covering_checkpoint_reloads_joinable_and_completes_ready() {
     assert_eq!(runner.model.phase, RecoverySourcePhase::Ready);
 }
 
-/// A peer commit after the last checkpoint makes disk a stale prefix: the
-/// reload must classify it as needing explicit reconciliation, never as a
-/// joinable baseline.
+/// A peer commit after a staged checkpoint makes disk a stale prefix, but the
+/// staged checkpoint remains a valid baseline for replaying the durable tail.
 #[test]
-fn fixed_unexported_peer_tail_needs_reconciliation() {
+fn fixed_unexported_peer_tail_keeps_staged_baseline() {
     let mut runner = Runner::new();
     runner.apply(&Op::PeerChange { concurrent: false });
     runner.apply(&Op::DirectCheckpoint);
@@ -696,7 +714,7 @@ fn fixed_unexported_peer_tail_needs_reconciliation() {
         replace_landed: false,
     });
     let manifest = runner.durability.manifest();
-    assert_eq!(classify(&manifest), RecoveryCase::NeedsReconciliation);
+    assert_eq!(classify(&manifest), RecoveryCase::Joinable);
     assert_ne!(
         sorted(&manifest.durable_heads),
         sorted(&manifest.exported_heads)

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -691,18 +691,17 @@ pub(crate) async fn save_notebook_to_disk_with_claim_and_intent(
         super::file_checkpoint::SaveOutcome::Saved { checkpoint } => checkpoint,
         super::file_checkpoint::SaveOutcome::AlreadyCurrent { checkpoint, .. } => {
             // The coordinator skips its commit callback for an already-current
-            // file. Reconciliation still has new durable meaning: commit the
-            // selected source generation before restoring capabilities.
-            if matches!(intent, FileSaveIntent::Reconcile { .. }) {
-                commit_file_checkpoint_for_intent(
-                    &room.durability,
-                    &room.lifecycle,
-                    &room.state,
-                    &checkpoint,
-                    intent,
-                )
-                .map_err(SaveError::Retryable)?;
-            }
+            // file. The checkpoint can still have new durable meaning: an
+            // ordinary save may establish the room's first complete baseline,
+            // while reconciliation commits the selected source generation.
+            commit_file_checkpoint_for_intent(
+                &room.durability,
+                &room.lifecycle,
+                &room.state,
+                &checkpoint,
+                intent,
+            )
+            .map_err(SaveError::Retryable)?;
             let exported_heads = checkpoint_heads_hex(&checkpoint.exported_heads);
             debug!(
                 "[notebook-sync] File checkpoint already current for {:?} at sequence {}",

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3004,6 +3004,11 @@ async fn already_current_save_does_not_advance_checkpoint_or_saved_timestamp() {
     let first = save_notebook_to_disk(&room, None).await.unwrap();
     assert!(matches!(first, FileSaveOutcome::Saved { .. }));
     let first_runtime = room.state.read(|state| state.read_state()).unwrap();
+    let first_manifest = room.durability.manifest();
+    assert_eq!(
+        first_manifest.source_phase,
+        super::recovery::RecoverySourcePhase::DurablyStaged
+    );
 
     let second = save_notebook_to_disk(&room, None).await.unwrap();
     assert!(matches!(
@@ -3019,6 +3024,11 @@ async fn already_current_save_does_not_advance_checkpoint_or_saved_timestamp() {
         first_runtime.file_checkpoint
     );
     assert_eq!(second_runtime.last_saved, first_runtime.last_saved);
+    assert_eq!(
+        room.durability.manifest().sequence,
+        first_manifest.sequence,
+        "an already-current save must not append another journal record"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #4065.

## Summary

- promote an ordinary file checkpoint to `DurablyStaged` in the same journal record when it exports every durable head
- let an `AlreadyCurrent` ordinary save append a missing promotion once, while keeping later no-op saves journal-idempotent
- preserve the existing source generation, including generation 0 for created-at-path rooms, matching the landed restore/resolver normalization instead of introducing a second async lifecycle publication transaction
- keep a staged baseline valid when later durable peer changes form a replayable tail

## Verification

- `cargo test -p runtimed full_coverage_checkpoint --lib` (4 passed)
- `cargo test -p runtimed recovered_checkpoint_with_unexported_tail --lib` (1 passed)
- `cargo test -p runtimed already_current_save_does_not_advance_checkpoint_or_saved_timestamp --lib` (1 passed)
- `cargo test -p runtimed notebook_sync_server::durability::property_tests --lib` (7 passed)
- `cargo xtask lint --fix`
- `git diff --check`

## Review

Bedrock Claude Opus 4.6 architecture review is clear after one remediation pass. The final review specifically challenged generation-0 preservation, crash/idempotence, degraded and `AlreadyCurrent` paths, and peer-tail replay; it found no correctness blockers.

This remains draft so the narrower generation-preserving choice is easy to review against the larger generation-claim alternative described in the issue.