### PR TITLE
fix(runtimed): rebuild captured env after launch failure

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -386,7 +386,9 @@ async fn prepare_environment_unified_inner(
 
     tokio::fs::create_dir_all(cache_dir).await?;
 
-    // Try lock-based rebuild before full re-creation
+    // Try lock-based rebuild before full re-creation. A forced rebuild enters
+    // this path even when Python exists because the launch handshake already
+    // proved the otherwise-usable environment cannot start a kernel.
     if env_path.exists() && (force_rebuild || !python_path.exists()) {
         if let Some(lock) = crate::lock::LockFile::read_from(&env_path).await {
             let expected_specs = build_spec_strings(deps);

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1539,6 +1539,8 @@ mod tests {
         assert!(unified_cache_is_reusable(false, true, true));
         assert!(!unified_cache_is_reusable(true, true, true));
         assert!(unified_lock_rebuild_is_applicable(true, true, true));
+        assert!(!unified_lock_rebuild_is_applicable(true, false, true));
+        assert!(!unified_lock_rebuild_is_applicable(true, false, false));
     }
 
     #[test]

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -334,6 +334,18 @@ pub async fn rebuild_environment_unified(
     prepare_environment_unified_inner(deps, env_id, cache_dir, handler, true).await
 }
 
+fn unified_cache_is_reusable(force_rebuild: bool, env_exists: bool, python_exists: bool) -> bool {
+    !force_rebuild && env_exists && python_exists
+}
+
+fn unified_lock_rebuild_is_applicable(
+    force_rebuild: bool,
+    env_exists: bool,
+    python_exists: bool,
+) -> bool {
+    env_exists && (force_rebuild || !python_exists)
+}
+
 async fn prepare_environment_unified_inner(
     deps: &CondaDependencies,
     env_id: &str,
@@ -357,7 +369,7 @@ async fn prepare_environment_unified_inner(
     let python_path = env_path.join("bin").join("python");
 
     // Cache hit
-    if !force_rebuild && env_path.exists() && python_path.exists() {
+    if unified_cache_is_reusable(force_rebuild, env_path.exists(), python_path.exists()) {
         info!("Using cached unified conda env at {:?}", env_path);
         crate::gc::touch_last_used(&env_path).await;
         crate::launcher::vendor_into_venv(&python_path)
@@ -389,7 +401,7 @@ async fn prepare_environment_unified_inner(
     // Try lock-based rebuild before full re-creation. A forced rebuild enters
     // this path even when Python exists because the launch handshake already
     // proved the otherwise-usable environment cannot start a kernel.
-    if env_path.exists() && (force_rebuild || !python_path.exists()) {
+    if unified_lock_rebuild_is_applicable(force_rebuild, env_path.exists(), python_path.exists()) {
         if let Some(lock) = crate::lock::LockFile::read_from(&env_path).await {
             let expected_specs = build_spec_strings(deps);
             let expected_channels = if deps.channels.is_empty() {
@@ -1520,6 +1532,13 @@ mod tests {
         let h1 = compute_unified_env_hash(&deps, "notebook-1");
         let h2 = compute_unified_env_hash(&deps, "notebook-2");
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn forced_unified_rebuild_bypasses_cache_and_uses_lock_path_when_available() {
+        assert!(unified_cache_is_reusable(false, true, true));
+        assert!(!unified_cache_is_reusable(true, true, true));
+        assert!(unified_lock_rebuild_is_applicable(true, true, true));
     }
 
     #[test]

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -317,6 +317,30 @@ pub async fn prepare_environment_unified(
     cache_dir: &Path,
     handler: Arc<dyn ProgressHandler>,
 ) -> Result<CondaEnvironment> {
+    prepare_environment_unified_inner(deps, env_id, cache_dir, handler, false).await
+}
+
+/// Force-rebuild a notebook-captured Conda environment at its unified hash.
+///
+/// A matching lock sidecar is consumed before the existing environment is
+/// removed, preserving the normal lock-assisted rebuild path. The target path
+/// remains derived exclusively from the captured declaration and `env_id`.
+pub async fn rebuild_environment_unified(
+    deps: &CondaDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<CondaEnvironment> {
+    prepare_environment_unified_inner(deps, env_id, cache_dir, handler, true).await
+}
+
+async fn prepare_environment_unified_inner(
+    deps: &CondaDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+    handler: Arc<dyn ProgressHandler>,
+    force_rebuild: bool,
+) -> Result<CondaEnvironment> {
     let hash = compute_unified_env_hash(deps, env_id);
     let env_path = cache_dir.join(&hash);
 
@@ -333,7 +357,7 @@ pub async fn prepare_environment_unified(
     let python_path = env_path.join("bin").join("python");
 
     // Cache hit
-    if env_path.exists() && python_path.exists() {
+    if !force_rebuild && env_path.exists() && python_path.exists() {
         info!("Using cached unified conda env at {:?}", env_path);
         crate::gc::touch_last_used(&env_path).await;
         crate::launcher::vendor_into_venv(&python_path)
@@ -363,7 +387,7 @@ pub async fn prepare_environment_unified(
     tokio::fs::create_dir_all(cache_dir).await?;
 
     // Try lock-based rebuild before full re-creation
-    if env_path.exists() && !python_path.exists() {
+    if env_path.exists() && (force_rebuild || !python_path.exists()) {
         if let Some(lock) = crate::lock::LockFile::read_from(&env_path).await {
             let expected_specs = build_spec_strings(deps);
             let expected_channels = if deps.channels.is_empty() {

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -433,6 +433,30 @@ pub async fn prepare_environment_unified(
     cache_dir: &Path,
     handler: Arc<dyn ProgressHandler>,
 ) -> Result<UvEnvironment> {
+    prepare_environment_unified_inner(deps, env_id, cache_dir, handler, false).await
+}
+
+/// Force-rebuild a notebook-captured UV environment at its unified hash.
+///
+/// Unlike [`prepare_environment_unified`], this skips the Python-exists cache
+/// hit. The path is still derived exclusively from the captured dependency
+/// declaration and `env_id`.
+pub async fn rebuild_environment_unified(
+    deps: &UvDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<UvEnvironment> {
+    prepare_environment_unified_inner(deps, env_id, cache_dir, handler, true).await
+}
+
+async fn prepare_environment_unified_inner(
+    deps: &UvDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+    handler: Arc<dyn ProgressHandler>,
+    force_rebuild: bool,
+) -> Result<UvEnvironment> {
     let hash = compute_unified_env_hash(deps, env_id);
     let venv_path = cache_dir.join(&hash);
 
@@ -449,7 +473,7 @@ pub async fn prepare_environment_unified(
     let python_path = venv_path.join("bin").join("python");
 
     // Cache hit
-    if venv_path.exists() && python_path.exists() {
+    if !force_rebuild && venv_path.exists() && python_path.exists() {
         info!("Using cached unified UV env at {:?}", venv_path);
         crate::gc::touch_last_used(&venv_path).await;
         crate::launcher::vendor_into_venv(&python_path)

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -450,6 +450,10 @@ pub async fn rebuild_environment_unified(
     prepare_environment_unified_inner(deps, env_id, cache_dir, handler, true).await
 }
 
+fn unified_cache_is_reusable(force_rebuild: bool, env_exists: bool, python_exists: bool) -> bool {
+    !force_rebuild && env_exists && python_exists
+}
+
 async fn prepare_environment_unified_inner(
     deps: &UvDependencies,
     env_id: &str,
@@ -473,7 +477,7 @@ async fn prepare_environment_unified_inner(
     let python_path = venv_path.join("bin").join("python");
 
     // Cache hit
-    if !force_rebuild && venv_path.exists() && python_path.exists() {
+    if unified_cache_is_reusable(force_rebuild, venv_path.exists(), python_path.exists()) {
         info!("Using cached unified UV env at {:?}", venv_path);
         crate::gc::touch_last_used(&venv_path).await;
         crate::launcher::vendor_into_venv(&python_path)
@@ -1353,6 +1357,12 @@ mod tests {
         let h1 = compute_unified_env_hash(&deps, "abc");
         let h2 = compute_unified_env_hash(&deps, "abc");
         assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn forced_unified_rebuild_bypasses_an_otherwise_reusable_cache() {
+        assert!(unified_cache_is_reusable(false, true, true));
+        assert!(!unified_cache_is_reusable(true, true, true));
     }
 
     #[test]

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -1362,6 +1362,8 @@ mod tests {
     #[test]
     fn forced_unified_rebuild_bypasses_an_otherwise_reusable_cache() {
         assert!(unified_cache_is_reusable(false, true, true));
+        // UV has no lock sidecar: bypassing this cache hit falls through to
+        // the backend's remove-and-recreate path.
         assert!(!unified_cache_is_reusable(true, true, true));
     }
 

--- a/crates/runtimed/src/kernel_launch_failure.rs
+++ b/crates/runtimed/src/kernel_launch_failure.rs
@@ -22,6 +22,24 @@ pub(crate) fn uses_fresh_port_retry(kind: KernelLaunchFailureKind) -> bool {
     )
 }
 
+/// Whether a launch failure from a notebook-captured environment may be
+/// repaired by rebuilding that environment once.
+pub(crate) fn uses_captured_env_rebuild(kind: KernelLaunchFailureKind) -> bool {
+    matches!(
+        kind,
+        KernelLaunchFailureKind::ProcessExited
+            | KernelLaunchFailureKind::StartupTimeout
+            | KernelLaunchFailureKind::ToolBootstrap
+    )
+}
+
+/// Runtime-agent launch failures for which the coordinator owns a retry
+/// decision. The agent must not publish a terminal lifecycle before that
+/// decision is made.
+pub(crate) fn coordinator_may_retry(kind: KernelLaunchFailureKind) -> bool {
+    uses_fresh_port_retry(kind) || uses_captured_env_rebuild(kind)
+}
+
 fn classify_message(message: &str) -> KernelLaunchFailureKind {
     let lower = message.to_ascii_lowercase();
 
@@ -173,5 +191,44 @@ mod tests {
         ));
         assert!(!uses_fresh_port_retry(KernelLaunchFailureKind::Unsupported));
         assert!(!uses_fresh_port_retry(KernelLaunchFailureKind::Other));
+    }
+
+    #[test]
+    fn captured_env_rebuild_applies_only_to_environment_infrastructure_failures() {
+        assert!(uses_captured_env_rebuild(
+            KernelLaunchFailureKind::ProcessExited
+        ));
+        assert!(uses_captured_env_rebuild(
+            KernelLaunchFailureKind::StartupTimeout
+        ));
+        assert!(uses_captured_env_rebuild(
+            KernelLaunchFailureKind::ToolBootstrap
+        ));
+
+        for kind in [
+            KernelLaunchFailureKind::RetryableStartupTransport,
+            KernelLaunchFailureKind::PortBind,
+            KernelLaunchFailureKind::Misconfiguration,
+            KernelLaunchFailureKind::Unsupported,
+            KernelLaunchFailureKind::Other,
+        ] {
+            assert!(
+                !uses_captured_env_rebuild(kind),
+                "unexpected retry: {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn coordinator_owns_all_retryable_launch_failures() {
+        for kind in [
+            KernelLaunchFailureKind::RetryableStartupTransport,
+            KernelLaunchFailureKind::PortBind,
+            KernelLaunchFailureKind::ProcessExited,
+            KernelLaunchFailureKind::StartupTimeout,
+            KernelLaunchFailureKind::ToolBootstrap,
+        ] {
+            assert!(coordinator_may_retry(kind), "missing retry owner: {kind:?}");
+        }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1838,6 +1838,12 @@ pub(crate) async fn rebuild_captured_environment(
         *active_path = Some(env.venv_path.clone());
     }
 
+    // The runtime agent repeats this transition when it accepts the request,
+    // but publish it before the retry send so the rebuild's PreparingEnv state
+    // cannot remain visible during transport handoff.
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))?;
+
     Ok(env)
 }
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1784,6 +1784,63 @@ pub(crate) fn captured_env_disk_state(captured: &CapturedEnv) -> CapturedEnvDisk
     )
 }
 
+/// Force-rebuild an already-resolved notebook-captured environment.
+///
+/// The captured dependency snapshot and `env_id` are the sole identity input;
+/// callers must retain the snapshot from the original launch resolution rather
+/// than re-reading mutable notebook metadata after a failed handshake.
+pub(crate) async fn rebuild_captured_environment(
+    room: &NotebookRoom,
+    captured: &CapturedEnv,
+) -> anyhow::Result<crate::PooledEnv> {
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))?;
+
+    let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
+        crate::inline_env::RuntimeDocProgressHandler::new(room.state.clone()),
+    );
+
+    let env = match captured {
+        CapturedEnv::Uv { deps, env_id } => {
+            let rebuilt = kernel_env::uv::rebuild_environment_unified(
+                deps,
+                env_id,
+                &kernel_env::uv::default_cache_dir_uv(),
+                progress_handler,
+            )
+            .await?;
+            crate::PooledEnv {
+                env_type: crate::EnvType::Uv,
+                venv_path: rebuilt.venv_path,
+                python_path: rebuilt.python_path,
+                prewarmed_packages: deps.dependencies.clone(),
+            }
+        }
+        CapturedEnv::Conda { deps, env_id } => {
+            let rebuilt = kernel_env::conda::rebuild_environment_unified(
+                deps,
+                env_id,
+                &kernel_env::conda::default_cache_dir_conda(),
+                progress_handler,
+            )
+            .await?;
+            crate::PooledEnv {
+                env_type: crate::EnvType::Conda,
+                venv_path: rebuilt.env_path,
+                python_path: rebuilt.python_path,
+                prewarmed_packages: deps.dependencies.clone(),
+            }
+        }
+    };
+
+    {
+        let mut active_path = room.runtime_agent_env_path.write().await;
+        *active_path = Some(env.venv_path.clone());
+    }
+
+    Ok(env)
+}
+
 /// Test-friendly form of [`captured_env_disk_state`] that accepts explicit
 /// cache dirs instead of using the channel defaults. The production call
 /// site always passes the defaults; tests pass tmpdirs.
@@ -4334,8 +4391,10 @@ async fn auto_launch_kernel_attempt(
                 launch_env_vars
                     .extend(crate::uv_project::uv_offline_env_vars(uv_pyproject_offline));
                 launch_env_vars.extend(crate::pixi_project::pixi_frozen_env_vars(pixi_toml_frozen));
-                match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
-                    notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
+                match send_runtime_agent_request_with_captured_env_repair(
+                    room,
+                    captured_for_config,
+                    |kernel_ports| notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: kernel_type.to_string(),
                         env_source: env_source.clone(),
                         notebook_path: notebook_path_opt
@@ -4345,8 +4404,8 @@ async fn auto_launch_kernel_attempt(
                         kernel_ports,
                         env_vars: launch_env_vars.clone(),
                         redact_env_values_in_outputs,
-                    }
-                })
+                    },
+                )
                 .await
                 {
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1789,6 +1789,11 @@ pub(crate) fn captured_env_disk_state(captured: &CapturedEnv) -> CapturedEnvDisk
 /// The captured dependency snapshot and `env_id` are the sole identity input;
 /// callers must retain the snapshot from the original launch resolution rather
 /// than re-reading mutable notebook metadata after a failed handshake.
+///
+/// The caller must own the room's single-flight launch admission for the full
+/// rebuild and retry. This helper deliberately publishes `PreparingEnv` and
+/// then `Launching`; if the retry fails, the caller's terminal response arm
+/// replaces `Launching` with its contextual error/reset outcome.
 pub(crate) async fn rebuild_captured_environment(
     room: &NotebookRoom,
     captured: &CapturedEnv,

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -133,7 +133,7 @@ where
 {
     run_with_one_captured_env_repair(
         captured.cloned(),
-        || send_runtime_agent_request_with_kernel_ports(room, |ports| build_request(ports)),
+        || send_runtime_agent_request_with_kernel_ports(room, &build_request),
         |captured| async move {
             rebuild_captured_environment(room, &captured)
                 .await

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -81,10 +81,10 @@ pub(crate) async fn send_runtime_agent_request(
 /// failure.
 pub(crate) async fn send_runtime_agent_request_with_kernel_ports<F>(
     room: &NotebookRoom,
-    mut build_request: F,
+    build_request: F,
 ) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse>
 where
-    F: FnMut(
+    F: Fn(
         notebook_protocol::protocol::KernelPorts,
     ) -> notebook_protocol::protocol::RuntimeAgentRequest,
 {
@@ -113,6 +113,112 @@ where
     }
 
     unreachable!("kernel port launch retry loop must return from the final attempt")
+}
+
+/// Send a launch/restart request and, for a captured environment only, force
+/// one environment rebuild and one relaunch after a qualifying infrastructure
+/// failure. The existing fresh-port retry loop remains inside each launch
+/// attempt.
+pub(crate) async fn send_runtime_agent_request_with_captured_env_repair<F>(
+    room: &NotebookRoom,
+    captured: Option<&CapturedEnv>,
+    build_request: F,
+) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse>
+where
+    F: Fn(
+        notebook_protocol::protocol::KernelPorts,
+    ) -> notebook_protocol::protocol::RuntimeAgentRequest,
+{
+    run_with_one_captured_env_repair(
+        captured.cloned(),
+        || send_runtime_agent_request_with_kernel_ports(room, &build_request),
+        |captured| async move {
+            rebuild_captured_environment(room, &captured)
+                .await
+                .map(|_| ())
+        },
+    )
+    .await
+}
+
+async fn run_with_one_captured_env_repair<Send, SendFuture, Repair, RepairFuture>(
+    captured: Option<CapturedEnv>,
+    mut send: Send,
+    repair: Repair,
+) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse>
+where
+    Send: FnMut() -> SendFuture,
+    SendFuture: std::future::Future<
+        Output = anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse>,
+    >,
+    Repair: FnOnce(CapturedEnv) -> RepairFuture,
+    RepairFuture: std::future::Future<Output = anyhow::Result<()>>,
+{
+    use notebook_protocol::protocol::RuntimeAgentResponse;
+
+    let first_response = send().await?;
+    let RuntimeAgentResponse::KernelLaunchFailed {
+        kind,
+        error: original_error,
+    } = &first_response
+    else {
+        return Ok(first_response);
+    };
+
+    if !crate::kernel_launch_failure::uses_captured_env_rebuild(*kind) {
+        return Ok(first_response);
+    }
+
+    let Some(captured) = captured else {
+        return Ok(first_response);
+    };
+    let original_kind = *kind;
+    let original_error = original_error.clone();
+
+    warn!(
+        "[notebook-sync] Captured environment for env_id={} failed during kernel startup; rebuilding once",
+        captured.env_id()
+    );
+
+    if let Err(rebuild_error) = repair(captured).await {
+        return Ok(captured_env_repair_terminal_response(
+            original_kind,
+            &original_error,
+            &format!("the rebuild failed: {rebuild_error}"),
+        ));
+    }
+
+    match send().await {
+        Ok(RuntimeAgentResponse::KernelLaunchFailed {
+            error: retry_error, ..
+        })
+        | Ok(RuntimeAgentResponse::Error { error: retry_error }) => {
+            Ok(captured_env_repair_terminal_response(
+                original_kind,
+                &original_error,
+                &format!("the retry failed: {retry_error}"),
+            ))
+        }
+        Ok(response) => Ok(response),
+        Err(retry_error) => Ok(captured_env_repair_terminal_response(
+            original_kind,
+            &original_error,
+            &format!("the retry could not be sent: {retry_error}"),
+        )),
+    }
+}
+
+fn captured_env_repair_terminal_response(
+    original_kind: notebook_protocol::protocol::KernelLaunchFailureKind,
+    original_error: &str,
+    retry_detail: &str,
+) -> notebook_protocol::protocol::RuntimeAgentResponse {
+    notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunchFailed {
+        kind: original_kind,
+        error: format!(
+            "{original_error}\nAutomatic captured-environment rebuild was attempted, but {retry_detail}."
+        ),
+    }
 }
 
 fn kernel_launch_retry_delay(
@@ -160,6 +266,10 @@ fn kernel_launch_failure_error(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use kernel_env::UvDependencies;
     use notebook_protocol::protocol::{KernelLaunchFailureKind, RuntimeAgentResponse};
 
     use super::*;
@@ -248,5 +358,208 @@ mod tests {
         };
 
         assert_eq!(kernel_launch_retry_delay(&response, 1, 4), None);
+    }
+
+    fn captured_uv() -> CapturedEnv {
+        CapturedEnv::Uv {
+            deps: UvDependencies {
+                dependencies: vec!["pandas".to_string()],
+                requires_python: None,
+                prerelease: None,
+            },
+            env_id: "captured-test".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn captured_env_failure_rebuilds_and_relaunches_exactly_once() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let repairs = Arc::new(AtomicUsize::new(0));
+
+        let response = run_with_one_captured_env_repair(
+            Some(captured_uv()),
+            {
+                let sends = sends.clone();
+                move || {
+                    let attempt = sends.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if attempt == 0 {
+                            Ok(RuntimeAgentResponse::KernelLaunchFailed {
+                                kind: KernelLaunchFailureKind::ProcessExited,
+                                error: "original launch failure".to_string(),
+                            })
+                        } else {
+                            Ok(RuntimeAgentResponse::KernelLaunched {
+                                env_source: notebook_protocol::connection::EnvSource::parse(
+                                    "uv:prewarmed",
+                                ),
+                            })
+                        }
+                    }
+                }
+            },
+            {
+                let repairs = repairs.clone();
+                move |_| {
+                    repairs.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(()))
+                }
+            },
+        )
+        .await
+        .expect("retry should complete");
+
+        assert!(matches!(
+            response,
+            RuntimeAgentResponse::KernelLaunched { .. }
+        ));
+        assert_eq!(sends.load(Ordering::SeqCst), 2);
+        assert_eq!(repairs.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn non_captured_launch_never_rebuilds_or_retries() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let repairs = Arc::new(AtomicUsize::new(0));
+
+        let response = run_with_one_captured_env_repair(
+            None,
+            {
+                let sends = sends.clone();
+                move || {
+                    sends.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(RuntimeAgentResponse::KernelLaunchFailed {
+                        kind: KernelLaunchFailureKind::ProcessExited,
+                        error: "original launch failure".to_string(),
+                    }))
+                }
+            },
+            {
+                let repairs = repairs.clone();
+                move |_| {
+                    repairs.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(()))
+                }
+            },
+        )
+        .await
+        .expect("failure response should be returned");
+
+        assert!(matches!(
+            response,
+            RuntimeAgentResponse::KernelLaunchFailed { .. }
+        ));
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+        assert_eq!(repairs.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn fresh_port_failure_never_enters_captured_env_rebuild_layer() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let repairs = Arc::new(AtomicUsize::new(0));
+
+        let response = run_with_one_captured_env_repair(
+            Some(captured_uv()),
+            {
+                let sends = sends.clone();
+                move || {
+                    sends.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(RuntimeAgentResponse::KernelLaunchFailed {
+                        kind: KernelLaunchFailureKind::PortBind,
+                        error: "fresh-port retries exhausted".to_string(),
+                    }))
+                }
+            },
+            {
+                let repairs = repairs.clone();
+                move |_| {
+                    repairs.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(()))
+                }
+            },
+        )
+        .await
+        .expect("port failure should be returned");
+
+        assert!(matches!(
+            response,
+            RuntimeAgentResponse::KernelLaunchFailed {
+                kind: KernelLaunchFailureKind::PortBind,
+                ..
+            }
+        ));
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+        assert_eq!(repairs.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn second_failure_preserves_original_error_without_a_retry_loop() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let repairs = Arc::new(AtomicUsize::new(0));
+
+        let response = run_with_one_captured_env_repair(
+            Some(captured_uv()),
+            {
+                let sends = sends.clone();
+                move || {
+                    let attempt = sends.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(RuntimeAgentResponse::KernelLaunchFailed {
+                        kind: KernelLaunchFailureKind::ProcessExited,
+                        error: if attempt == 0 {
+                            "original launch failure".to_string()
+                        } else {
+                            "different retry failure".to_string()
+                        },
+                    }))
+                }
+            },
+            {
+                let repairs = repairs.clone();
+                move |_| {
+                    repairs.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(()))
+                }
+            },
+        )
+        .await
+        .expect("terminal response should be returned");
+
+        let RuntimeAgentResponse::KernelLaunchFailed { error, .. } = response else {
+            panic!("expected terminal launch failure");
+        };
+        assert!(error.starts_with("original launch failure"));
+        assert!(error.contains("Automatic captured-environment rebuild was attempted"));
+        assert!(error.contains("different retry failure"));
+        assert_eq!(sends.load(Ordering::SeqCst), 2);
+        assert_eq!(repairs.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rebuild_failure_preserves_original_error_without_relaunching() {
+        let sends = Arc::new(AtomicUsize::new(0));
+
+        let response = run_with_one_captured_env_repair(
+            Some(captured_uv()),
+            {
+                let sends = sends.clone();
+                move || {
+                    sends.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(RuntimeAgentResponse::KernelLaunchFailed {
+                        kind: KernelLaunchFailureKind::ToolBootstrap,
+                        error: "original launch failure".to_string(),
+                    }))
+                }
+            },
+            |_| std::future::ready(Err(anyhow::anyhow!("package index unavailable"))),
+        )
+        .await
+        .expect("terminal response should be returned");
+
+        let RuntimeAgentResponse::KernelLaunchFailed { error, .. } = response else {
+            panic!("expected terminal launch failure");
+        };
+        assert!(error.starts_with("original launch failure"));
+        assert!(error.contains("package index unavailable"));
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -81,10 +81,10 @@ pub(crate) async fn send_runtime_agent_request(
 /// failure.
 pub(crate) async fn send_runtime_agent_request_with_kernel_ports<F>(
     room: &NotebookRoom,
-    build_request: F,
+    mut build_request: F,
 ) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse>
 where
-    F: Fn(
+    F: FnMut(
         notebook_protocol::protocol::KernelPorts,
     ) -> notebook_protocol::protocol::RuntimeAgentRequest,
 {
@@ -131,7 +131,7 @@ where
 {
     run_with_one_captured_env_repair(
         captured.cloned(),
-        || send_runtime_agent_request_with_kernel_ports(room, &build_request),
+        || send_runtime_agent_request_with_kernel_ports(room, |ports| build_request(ports)),
         |captured| async move {
             rebuild_captured_environment(room, &captured)
                 .await
@@ -530,6 +530,50 @@ mod tests {
         assert!(error.starts_with("original launch failure"));
         assert!(error.contains("Automatic captured-environment rebuild was attempted"));
         assert!(error.contains("different retry failure"));
+        assert_eq!(sends.load(Ordering::SeqCst), 2);
+        assert_eq!(repairs.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_transport_failure_preserves_original_error_without_a_third_send() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let repairs = Arc::new(AtomicUsize::new(0));
+
+        let response = run_with_one_captured_env_repair(
+            Some(captured_uv()),
+            {
+                let sends = sends.clone();
+                move || {
+                    let attempt = sends.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if attempt == 0 {
+                            Ok(RuntimeAgentResponse::KernelLaunchFailed {
+                                kind: KernelLaunchFailureKind::ProcessExited,
+                                error: "original launch failure".to_string(),
+                            })
+                        } else {
+                            Err(anyhow::anyhow!("runtime-agent channel closed"))
+                        }
+                    }
+                }
+            },
+            {
+                let repairs = repairs.clone();
+                move |_| {
+                    repairs.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(()))
+                }
+            },
+        )
+        .await
+        .expect("transport failure should be normalized to a terminal response");
+
+        let RuntimeAgentResponse::KernelLaunchFailed { error, .. } = response else {
+            panic!("expected terminal launch failure");
+        };
+        assert!(error.starts_with("original launch failure"));
+        assert!(error.contains("the retry could not be sent"));
+        assert!(error.contains("runtime-agent channel closed"));
         assert_eq!(sends.load(Ordering::SeqCst), 2);
         assert_eq!(repairs.load(Ordering::SeqCst), 1);
     }

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -118,7 +118,9 @@ where
 /// Send a launch/restart request and, for a captured environment only, force
 /// one environment rebuild and one relaunch after a qualifying infrastructure
 /// failure. The existing fresh-port retry loop remains inside each launch
-/// attempt.
+/// attempt. Retry transport errors are normalized to `KernelLaunchFailed` so
+/// every caller's existing failure arm performs its contextual terminal-state
+/// transition after the rebuild's `PreparingEnv -> Launching` sequence.
 pub(crate) async fn send_runtime_agent_request_with_captured_env_repair<F>(
     room: &NotebookRoom,
     captured: Option<&CapturedEnv>,
@@ -208,7 +210,7 @@ where
     }
 }
 
-fn captured_env_repair_terminal_response(
+pub(crate) fn captured_env_repair_terminal_response(
     original_kind: notebook_protocol::protocol::KernelLaunchFailureKind,
     original_error: &str,
     retry_detail: &str,

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -158,6 +158,9 @@ where
 {
     use notebook_protocol::protocol::RuntimeAgentResponse;
 
+    // `send` is called once for the original launch and at most once more
+    // after a successful captured-environment rebuild. Keeping it `FnMut`
+    // expresses that bounded sequential reuse without requiring allocation.
     let first_response = send().await?;
     let RuntimeAgentResponse::KernelLaunchFailed {
         kind,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -11375,6 +11375,47 @@ async fn reset_starting_state_error_variant_writes_details() {
     assert_eq!(state.kernel.error_reason.as_deref(), Some(""));
 }
 
+/// A transport failure while handing the rebuilt environment back to the
+/// runtime agent is normalized to the same `KernelLaunchFailed` variant that
+/// the auto-launch and manual-launch response arms terminalize. Keep the
+/// composed behavior covered so `Launching` cannot become a sticky state.
+#[tokio::test]
+async fn captured_env_retry_transport_failure_response_clears_launching() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "captured-retry-transport.ipynb");
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+        .unwrap();
+
+    let response = captured_env_repair_terminal_response(
+        notebook_protocol::protocol::KernelLaunchFailureKind::ProcessExited,
+        "original launch failure",
+        "the retry could not be sent: runtime-agent channel closed",
+    );
+    let notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunchFailed { error, .. } =
+        response
+    else {
+        panic!("expected normalized launch failure");
+    };
+
+    // This is the terminal response arm shared in shape by all three callers
+    // of send_runtime_agent_request_with_captured_env_repair.
+    reset_starting_state_with_outcome(
+        &room,
+        None,
+        ResetOutcome::Error {
+            reason: None,
+            details: &error,
+        },
+    )
+    .await;
+
+    let state = room.state.with_doc(|sd| Ok(sd.read_state())).unwrap();
+    assert!(matches!(state.kernel.lifecycle, RuntimeLifecycle::Error));
+    assert_eq!(state.kernel.error_details.as_deref(), Some(error.as_str()));
+    assert_eq!(state.env.progress, None);
+}
+
 #[tokio::test]
 async fn publish_environment_launch_error_writes_kernel_error_and_clears_env_progress() {
     let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -34,7 +34,7 @@ use crate::notebook_sync_server::{
     project_environment_build_approved, promote_inline_deps_to_project,
     publish_environment_launch_error, publish_kernel_state_presence, reset_starting_state,
     reset_starting_state_with_outcome, resolve_metadata_snapshot,
-    send_runtime_agent_request_with_kernel_ports, try_conda_pool_for_inline_deps,
+    send_runtime_agent_request_with_captured_env_repair, try_conda_pool_for_inline_deps,
     try_uv_pool_for_inline_deps, CapturedEnvRuntime, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
@@ -1540,8 +1540,10 @@ pub(crate) async fn handle(
                 };
             restart_env_vars.extend(crate::uv_project::uv_offline_env_vars(uv_pyproject_offline));
             restart_env_vars.extend(crate::pixi_project::pixi_frozen_env_vars(pixi_toml_frozen));
-            match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
-                notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
+            match send_runtime_agent_request_with_captured_env_repair(
+                room,
+                captured_env_for_config.as_ref(),
+                |kernel_ports| notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
                     kernel_type: resolved_kernel_type.clone(),
                     env_source: resolved_env_source.clone(),
                     notebook_path: notebook_path
@@ -1551,8 +1553,8 @@ pub(crate) async fn handle(
                     kernel_ports,
                     env_vars: restart_env_vars.clone(),
                     redact_env_values_in_outputs,
-                }
-            })
+                },
+            )
             .await
             {
                 Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelRestarted {
@@ -1704,8 +1706,10 @@ pub(crate) async fn handle(
                 launch_env_vars
                     .extend(crate::uv_project::uv_offline_env_vars(uv_pyproject_offline));
                 launch_env_vars.extend(crate::pixi_project::pixi_frozen_env_vars(pixi_toml_frozen));
-                match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
-                    notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
+                match send_runtime_agent_request_with_captured_env_repair(
+                    room,
+                    captured_env_for_config.as_ref(),
+                    |kernel_ports| notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: resolved_kernel_type.clone(),
                         env_source: resolved_env_source.clone(),
                         notebook_path: notebook_path
@@ -1715,8 +1719,8 @@ pub(crate) async fn handle(
                         kernel_ports,
                         env_vars: launch_env_vars.clone(),
                         redact_env_values_in_outputs,
-                    }
-                })
+                    },
+                )
                 .await
                 {
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -2023,7 +2023,7 @@ async fn handle_runtime_agent_request(
                         e
                     );
                     let error = format!("Failed to launch kernel: {e}");
-                    if !crate::kernel_launch_failure::uses_fresh_port_retry(kind) {
+                    if !crate::kernel_launch_failure::coordinator_may_retry(kind) {
                         if let Err(write_error) = record_kernel_launch_failed_state(
                             ctx,
                             &launch_kernel_type,
@@ -2194,7 +2194,7 @@ async fn handle_runtime_agent_request(
                         e
                     );
                     let error = format!("Failed to restart kernel: {e}");
-                    if !crate::kernel_launch_failure::uses_fresh_port_retry(kind) {
+                    if !crate::kernel_launch_failure::coordinator_may_retry(kind) {
                         if let Err(write_error) = record_kernel_launch_failed_state(
                             ctx,
                             &launch_kernel_type,


### PR DESCRIPTION
## Summary

- add backend-owned force rebuilds for captured UV and Conda environments
- rebuild and relaunch exactly once after captured-environment startup infrastructure failures
- apply the policy to auto-launch, manual fresh launch, and manual restart
- preserve the original launch error and avoid publishing an intermediate terminal lifecycle

Fixes #1969.

## Root cause

Captured environments were considered usable when their Python executable existed. If packages or `ipykernel` later became corrupt, the runtime agent reported a typed handshake/startup failure, but the coordinator immediately surfaced it without rebuilding the environment from the notebook's captured declaration.

## Implementation

The coordinator retains the `CapturedEnv` resolved for the original launch. For `ProcessExited`, `StartupTimeout`, or `ToolBootstrap`, it force-rebuilds that exact UV/Conda unified identity and sends one more launch or restart request. Each launch attempt retains the existing bounded fresh-port retry policy.

The runtime agent defers terminal lifecycle publication for failure kinds owned by coordinator retry policy. The outer launch handlers publish the final error after the retry decision, so RuntimeStateDoc does not expose `Error` between the first failure and repair.

Conda force rebuilds preserve the existing matching-lock path. UV intentionally recreates from the captured declaration because it has no equivalent environment lock sidecar.

## Validation

- `cargo test -p runtimed notebook_sync_server::runtime_bridge::tests --lib` — 13 passed
- `cargo test -p runtimed kernel_launch_failure::tests` — 8 passed
- `cargo test -p runtimed captured_env_retry_transport_failure_response_clears_launching --lib` — passed
- `cargo test -p kernel-env` — 94 unit tests and launcher E2E passed; 2 doc tests ignored
- `cargo xtask lint --fix` — passed
- US Bedrock Opus 4.6 structured architecture review; its actionable port-retry boundary test was added
- final US Bedrock Opus 4.6 PR review (`ses_07974da64ffe7U8LdD3RJurixa`) — clear, no findings

`cargo test -p runtimed` was also attempted. The host exhausted disk space while rustc linked all examples and integration targets; no test executed or failed in that attempt. Focused runtimed targets compiled and passed before and after the final coverage change.

## Decisions and residual risks

- Rebuild is deliberately limited to captured UV/Conda environments and three infrastructure-oriented failure kinds. Port/transport failures remain owned by the existing fresh-port loop; unsupported, misconfigured, and unknown failures do not trigger destructive repair.
- The dependency declaration and `env_id` are frozen from the initial resolution. Metadata changes during repair apply to a later launch cycle.
- The failed kernel child uses `kill_on_drop(true)` and its watcher is aborted before the failure returns, so the coordinator does not intentionally rebuild under a live kernel process.
- This PR tests retry orchestration with injected send/repair futures and exercises the full backend suites. It does not add a slow end-to-end Conda corruption fixture; lock-assisted and full-solve behavior remain covered at the backend level rather than through a spawned daemon.

## Reviewer dispositions

The final structured review is clear. Earlier findings were fixed or dispositioned with code evidence in PR comments: the retry publishes `PreparingEnv -> Launching`, then all three outer handlers own the terminal outcome; retry transport failures normalize back into `KernelLaunchFailed`, and a direct state test proves `Launching` cannot stick. Cancellation can leave a partial backend directory, which is an existing typed state repaired on the next launch; atomic environment replacement remains outside this issue.
