### PR TITLE
fix(desktop-cloud): surface hosted bridge health

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -379,6 +379,7 @@ function AppContent() {
     getHandle,
     getEngine,
     sessionStatus$,
+    hostedBridgeStatus$,
     notebookDocChanged$,
     triggerSync,
     localActor,
@@ -1091,8 +1092,13 @@ function AppContent() {
   // daemon restarts, and must not claim "reconnecting" while the governor
   // is latched terminal and nothing is redialing).
   const desktopConnectionStatus = useMemo(
-    () => createDesktopConnectionStatusSource(host.daemonEvents, host.daemon.autoReconnect),
-    [host],
+    () =>
+      createDesktopConnectionStatusSource(
+        host.daemonEvents,
+        host.daemon.autoReconnect,
+        hostedBridgeStatus$,
+      ),
+    [host, hostedBridgeStatus$],
   );
   useEffect(() => () => desktopConnectionStatus.dispose(), [desktopConnectionStatus]);
 
@@ -2028,12 +2034,13 @@ function AppContent() {
             // Connection/identity slot: renders nothing for a purely local
             // session (isRemoteNotebookContext) — conditionality is the
             // point. The source derives from daemon lifecycle events (the
-            // IPC transport's status is constant in practice), and the
-            // copy is scoped to the link it measures.
+            // IPC transport's status is constant in practice). Hosted rooms
+            // compose daemon and bridge health, so their copy names the whole
+            // notebook connection rather than only the first hop.
             <NotebookConnectionIdentity
               capabilities={shellCapabilities}
               connectionStatus$={desktopConnectionStatus}
-              connectionLabel="Daemon connection"
+              connectionLabel={hostedNotebookUrl ? "Notebook connection" : "Daemon connection"}
             />
           }
         />

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -694,10 +694,10 @@ describe("connection/identity slot wiring", () => {
     // vp test runs from the repo root.
     const appSource = readFileSync(resolve(process.cwd(), "apps/notebook/src/App.tsx"), "utf8");
     expect(appSource).toMatch(
-      /trailingControls=\{[\s\S]{0,600}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{desktopConnectionStatus\}[\s\S]{0,200}?connectionLabel="Daemon connection"/,
+      /trailingControls=\{[\s\S]{0,600}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{desktopConnectionStatus\}[\s\S]{0,200}?connectionLabel=\{hostedNotebookUrl \? "Notebook connection" : "Daemon connection"\}/,
     );
     expect(appSource).toMatch(
-      /createDesktopConnectionStatusSource\(host\.daemonEvents, host\.daemon\.autoReconnect\)/,
+      /createDesktopConnectionStatusSource\([\s\S]{0,160}?host\.daemonEvents,[\s\S]{0,80}?host\.daemon\.autoReconnect,[\s\S]{0,80}?hostedBridgeStatus\$/,
     );
     expect(appSource).not.toMatch(/connectionStatus\$=\{host\.transport\.connectionStatus\$\}/);
   });

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -198,7 +198,7 @@ export function useNotebook() {
   // source subscribes during render, then the active engine forwards into it.
   // A BehaviorSubject also gives the connection dot an honest first paint.
   const hostedBridgeStatusSubject = useMemo(
-    () => new BehaviorSubject<HostedBridgeStatus>("connecting"),
+    () => new BehaviorSubject<HostedBridgeStatus>("not_applicable"),
     [],
   );
   const hostedBridgeStatus$ = useMemo(
@@ -385,10 +385,12 @@ export function useNotebook() {
     transportRef.current = transport;
     engineRef.current = engine;
 
-    // Start the engine (subscribes to transport frames).
-    engine.start();
+    // Attach before start so even a synchronously replayed transport frame is
+    // visible to the app-level bridge.
     const hostedBridgeStatusSubscription =
       engine.hostedBridgeStatus$.subscribe(hostedBridgeStatusSubject);
+    // Start the engine (subscribes to transport frames).
+    engine.start();
 
     const storeBridge = startNotebookSyncStoreBridge({
       engine,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,8 +1,13 @@
 import { startRelayBootstrapCoordinator, useNotebookHost } from "@nteract/notebook-host";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
+import type {
+  HostedBridgeStatus,
+  NotebookTransport,
+  SessionStatus,
+  SyncableHandle,
+} from "runtimed";
 import { NotebookHandleHost, SyncEngine, isDisplayCapableJupyterOutput } from "runtimed";
-import { Observable } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
 import {
   getBlobPort,
@@ -189,6 +194,17 @@ export function useNotebook() {
   // SyncEngine and transport refs — stable across re-renders.
   const engineRef = useRef<SyncEngine | null>(null);
   const transportRef = useRef<NotebookTransport | null>(null);
+  // This bridge must exist before the engine effect: App's desktop status
+  // source subscribes during render, then the active engine forwards into it.
+  // A BehaviorSubject also gives the connection dot an honest first paint.
+  const hostedBridgeStatusSubject = useMemo(
+    () => new BehaviorSubject<HostedBridgeStatus>("connecting"),
+    [],
+  );
+  const hostedBridgeStatus$ = useMemo(
+    () => hostedBridgeStatusSubject.asObservable(),
+    [hostedBridgeStatusSubject],
+  );
 
   // Refresh blob port on mount.
   useEffect(() => {
@@ -371,6 +387,8 @@ export function useNotebook() {
 
     // Start the engine (subscribes to transport frames).
     engine.start();
+    const hostedBridgeStatusSubscription =
+      engine.hostedBridgeStatus$.subscribe(hostedBridgeStatusSubject);
 
     const storeBridge = startNotebookSyncStoreBridge({
       engine,
@@ -487,6 +505,7 @@ export function useNotebook() {
       // Flush pending local changes before stopping.
       engine.flush();
       engine.stop();
+      hostedBridgeStatusSubscription.unsubscribe();
       // Do NOT call `transport.disconnect()`. The transport is owned by
       // the host (one shared instance across NotebookClient, SyncEngine,
       // frame-types outbound helpers, etc.) and must outlive this hook's
@@ -512,6 +531,7 @@ export function useNotebook() {
     bootstrap,
     handleHost,
     host,
+    hostedBridgeStatusSubject,
     materializeCells,
     notifyRelayReady,
     refreshCanAcceptCellMutations,
@@ -686,6 +706,7 @@ export function useNotebook() {
     getHandle,
     getEngine,
     sessionStatus$,
+    hostedBridgeStatus$,
     notebookDocChanged$,
     triggerSync,
     localActor,

--- a/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
@@ -154,7 +154,7 @@ describe("createDesktopConnectionStatusSource", () => {
     source.dispose();
   });
 
-  it("does not mistake bridge recovery for a latched daemon reconnect", () => {
+  it("does not apply a daemon latch to composed bridge reconnecting", () => {
     const fake = createFakeDaemonEvents();
     const state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
     const bridge$ = new BehaviorSubject<HostedBridgeStatus>("connected");
@@ -166,6 +166,9 @@ describe("createDesktopConnectionStatusSource", () => {
 
     fake.fire("ready");
     bridge$.next("reconnecting");
+    expect(source.getCurrent()).toBe("reconnecting");
+    // The daemon link remains online. The latch must inspect daemonStatus,
+    // not the composed current value supplied by the bridge's second hop.
     state$.next({ kind: "latched", reason: "unrelated terminal daemon state" });
 
     expect(source.getCurrent()).toBe("reconnecting");

--- a/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject } from "rxjs";
 import { describe, expect, it } from "vite-plus/test";
-import type { ConnectionStatus, ReconnectGovernorState } from "runtimed";
+import type { ConnectionStatus, HostedBridgeStatus, ReconnectGovernorState } from "runtimed";
 import { createDesktopConnectionStatusSource } from "../desktop-connection-status";
 
 function createFakeDaemonEvents() {
@@ -65,6 +65,39 @@ describe("createDesktopConnectionStatusSource", () => {
     expect(statuses).toEqual(["connecting", "online"]);
   });
 
+  it("composes hosted bridge health with the live daemon connection", () => {
+    const fake = createFakeDaemonEvents();
+    const bridge$ = new BehaviorSubject<HostedBridgeStatus>("connecting");
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents, undefined, bridge$);
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+
+    fake.fire("ready");
+    bridge$.next("connected");
+    bridge$.next("reconnecting");
+    bridge$.next("connected");
+    bridge$.next("authentication_failed");
+
+    expect(statuses).toEqual(["connecting", "online", "reconnecting", "online", "offline"]);
+    source.dispose();
+  });
+
+  it("keeps daemon loss authoritative over stale bridge state", () => {
+    const fake = createFakeDaemonEvents();
+    const bridge$ = new BehaviorSubject<HostedBridgeStatus>("connected");
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents, undefined, bridge$);
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+
+    fake.fire("ready");
+    fake.fire("disconnected");
+    bridge$.next("connected");
+
+    expect(statuses).toEqual(["connecting", "online", "reconnecting"]);
+    expect(source.getCurrent()).toBe("reconnecting");
+    source.dispose();
+  });
+
   it("replays the current value to subscribers and supports getCurrent", () => {
     const fake = createFakeDaemonEvents();
     const source = createDesktopConnectionStatusSource(fake.daemonEvents);
@@ -121,6 +154,24 @@ describe("createDesktopConnectionStatusSource", () => {
     source.dispose();
   });
 
+  it("does not mistake bridge recovery for a latched daemon reconnect", () => {
+    const fake = createFakeDaemonEvents();
+    const state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
+    const bridge$ = new BehaviorSubject<HostedBridgeStatus>("connected");
+    const source = createDesktopConnectionStatusSource(
+      fake.daemonEvents,
+      { getState: () => state$.getValue(), state$ },
+      bridge$,
+    );
+
+    fake.fire("ready");
+    bridge$.next("reconnecting");
+    state$.next({ kind: "latched", reason: "unrelated terminal daemon state" });
+
+    expect(source.getCurrent()).toBe("reconnecting");
+    source.dispose();
+  });
+
   it("dispose detaches the governor state subscription", () => {
     const fake = createFakeDaemonEvents();
     const state$ = new BehaviorSubject<ReconnectGovernorState>({ kind: "idle" });
@@ -130,6 +181,14 @@ describe("createDesktopConnectionStatusSource", () => {
     });
     source.dispose();
     expect(state$.observed).toBe(false);
+  });
+
+  it("dispose detaches the hosted bridge subscription", () => {
+    const fake = createFakeDaemonEvents();
+    const bridge$ = new BehaviorSubject<HostedBridgeStatus>("not_applicable");
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents, undefined, bridge$);
+    source.dispose();
+    expect(bridge$.observed).toBe(false);
   });
 
   it("unsubscribe and dispose detach cleanly", () => {

--- a/apps/notebook/src/lib/desktop-connection-status.ts
+++ b/apps/notebook/src/lib/desktop-connection-status.ts
@@ -1,5 +1,6 @@
 import type { HostAutoReconnect, HostDaemonEvents } from "@nteract/notebook-host";
-import type { ConnectionStatus } from "runtimed";
+import type { ConnectionStatus, HostedBridgeStatus } from "runtimed";
+import type { Observable } from "rxjs";
 import type { NotebookConnectionStatusSource } from "@/components/notebook";
 
 export interface DesktopConnectionStatusSource extends NotebookConnectionStatusSource {
@@ -16,11 +17,10 @@ export interface DesktopConnectionStatusSource extends NotebookConnectionStatusS
  * but constant in practice — the app never disconnects it, so a dot fed
  * from it could never transition (it would sit emerald through a daemon
  * restart, exactly the window where kernel/execution chrome freezes). The
- * daemon link is the first hop of any remote context the slot renders
- * for, and `daemon:ready` / `daemon:disconnected` / `daemon:unavailable`
- * are the real lifecycle the desktop can report today. Daemon↔room link
- * health is future work; the slot's copy is scoped to the daemon link via
- * its `connectionLabel`.
+ * daemon link is the first hop of any remote context the slot renders.
+ * Hosted notebooks additionally project the daemon-owned outbound bridge
+ * health through the session-control lane, so an online first hop cannot
+ * hide a reconnecting or terminal daemon↔room link.
  *
  * - `onReady` → "online" (the host facade backfills from its cache, so a
  *   source created after the daemon is already up still reaches "online")
@@ -30,12 +30,17 @@ export interface DesktopConnectionStatusSource extends NotebookConnectionStatusS
  * - a governor transition into "latched" demotes a live "reconnecting"
  *   dot to "offline" (covers a latch that lands after the disconnect)
  * - `onUnavailable` → "offline"
+ * - hosted bridge connecting/reconnecting → matching transitional state
+ * - hosted bridge authentication/terminal failure → "offline"
  */
 export function createDesktopConnectionStatusSource(
   daemonEvents: Pick<HostDaemonEvents, "onReady" | "onDisconnected" | "onUnavailable">,
   autoReconnect?: Pick<HostAutoReconnect, "getState" | "state$">,
+  hostedBridgeStatus$?: Observable<HostedBridgeStatus>,
 ): DesktopConnectionStatusSource {
   let current: ConnectionStatus = "connecting";
+  let daemonStatus: ConnectionStatus = "connecting";
+  let hostedBridgeStatus: HostedBridgeStatus = "not_applicable";
   const listeners = new Set<(status: ConnectionStatus) => void>();
   const next = (status: ConnectionStatus) => {
     if (status === current) return;
@@ -45,18 +50,48 @@ export function createDesktopConnectionStatusSource(
     }
   };
 
+  const project = () => {
+    if (daemonStatus !== "online") return daemonStatus;
+    switch (hostedBridgeStatus) {
+      case "not_applicable":
+      case "connected":
+        return "online";
+      case "connecting":
+        return "connecting";
+      case "reconnecting":
+        return "reconnecting";
+      case "authentication_failed":
+      case "terminal_error":
+        return "offline";
+    }
+  };
+  const update = () => next(project());
+
   const unlisteners = [
-    daemonEvents.onReady(() => next("online")),
-    daemonEvents.onDisconnected(() =>
-      next(autoReconnect?.getState().kind === "latched" ? "offline" : "reconnecting"),
-    ),
-    daemonEvents.onUnavailable(() => next("offline")),
+    daemonEvents.onReady(() => {
+      daemonStatus = "online";
+      update();
+    }),
+    daemonEvents.onDisconnected(() => {
+      daemonStatus = autoReconnect?.getState().kind === "latched" ? "offline" : "reconnecting";
+      update();
+    }),
+    daemonEvents.onUnavailable(() => {
+      daemonStatus = "offline";
+      update();
+    }),
   ];
 
   const latchSubscription = autoReconnect?.state$.subscribe((state) => {
-    if (state.kind === "latched" && current === "reconnecting") {
-      next("offline");
+    if (state.kind === "latched" && daemonStatus === "reconnecting") {
+      daemonStatus = "offline";
+      update();
     }
+  });
+
+  const hostedBridgeSubscription = hostedBridgeStatus$?.subscribe((status) => {
+    hostedBridgeStatus = status;
+    update();
   });
 
   return {
@@ -71,6 +106,7 @@ export function createDesktopConnectionStatusSource(
         unlisten();
       }
       latchSubscription?.unsubscribe();
+      hostedBridgeSubscription?.unsubscribe();
       listeners.clear();
     },
   };

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -306,6 +306,18 @@ fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
     ))
 }
 
+fn upgrade_rejection_error(
+    status: tokio_tungstenite::tungstenite::http::StatusCode,
+    body: &str,
+) -> std::io::Error {
+    let message = format!("upgrade rejected: HTTP {status}: {body}");
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        std::io::Error::new(std::io::ErrorKind::PermissionDenied, message)
+    } else {
+        std::io::Error::other(message)
+    }
+}
+
 fn is_recoverable_cloud_frame_rejection_error(error: &std::io::Error) -> bool {
     if error.kind() != std::io::ErrorKind::PermissionDenied {
         return false;
@@ -726,9 +738,7 @@ impl CloudWsFrameTransport {
                     .into_body()
                     .map(|b| String::from_utf8_lossy(&b).into_owned())
                     .unwrap_or_default();
-                return Err(std::io::Error::other(format!(
-                    "upgrade rejected: HTTP {status}: {body}"
-                )));
+                return Err(upgrade_rejection_error(status, &body));
             }
             Err(e) => return Err(std::io::Error::other(format!("websocket connect: {e}"))),
         };
@@ -827,6 +837,24 @@ mod tests {
     #[allow(dead_code)]
     fn cloud_transport_is_a_frame_transport() {
         assert_satisfies_frame_transport::<CloudWsFrameTransport>();
+    }
+
+    #[test]
+    fn upgrade_auth_rejections_are_permission_denied() {
+        use tokio_tungstenite::tungstenite::http::StatusCode;
+
+        assert_eq!(
+            upgrade_rejection_error(StatusCode::UNAUTHORIZED, "expired").kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            upgrade_rejection_error(StatusCode::FORBIDDEN, "scope denied").kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            upgrade_rejection_error(StatusCode::SERVICE_UNAVAILABLE, "retry").kind(),
+            std::io::ErrorKind::Other
+        );
     }
 
     #[test]

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 
 use crate::connection::{EnvSource, LaunchSpec};
 pub use notebook_wire::{
-    InitialLoadPhaseWire, NotebookDocPhaseWire, RuntimeStatePhaseWire, SessionControlMessage,
-    SessionSyncStatusWire,
+    HostedBridgeStatusWire, InitialLoadPhaseWire, NotebookDocPhaseWire, RuntimeStatePhaseWire,
+    SessionControlMessage, SessionSyncStatusWire,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/notebook-protocol/src/typescript.rs
+++ b/crates/notebook-protocol/src/typescript.rs
@@ -67,7 +67,7 @@ pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
     "blob_upload_error",
 ];
 
-pub const SESSION_CONTROL_TYPES: &[&str] = &["sync_status"];
+pub const SESSION_CONTROL_TYPES: &[&str] = &["sync_status", "hosted_bridge_status"];
 pub const NOTEBOOK_DOC_PHASES: &[&str] = &["pending", "syncing", "interactive"];
 pub const RUNTIME_STATE_PHASES: &[&str] = &["pending", "syncing", "ready"];
 pub const INITIAL_LOAD_PHASES: &[&str] = &["not_needed", "streaming", "ready", "failed"];
@@ -582,6 +582,7 @@ export function parseConnectionScope(value: string): ConnectionScope {{
 pub fn generated_protocol_contract_ts() -> String {
     format!(
         r#"{GENERATED_HEADER}import type {{
+  HostedBridgeStatus,
   InitialLoadPhase,
   NotebookDocPhase,
   RuntimeStatePhase,
@@ -616,7 +617,9 @@ export const NOTEBOOK_RESPONSE_RESULTS_EXHAUSTIVE: MissingUnionMember<
   ? true
   : never = true;
 
-export type SessionControlMessage = {{ type: "sync_status" }} & SessionStatus;
+export type SessionControlMessage =
+  | ({{ type: "sync_status" }} & SessionStatus)
+  | {{ type: "hosted_bridge_status"; status: HostedBridgeStatus }};
 
 export const SESSION_CONTROL_TYPES = [
 {}

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -968,6 +968,11 @@ impl SyncReactor {
                             status,
                         );
                     }
+                    SessionControlMessage::HostedBridgeStatus { .. } => {
+                        // Python/Rust notebook clients do not render desktop
+                        // bridge health. Keep the additive control message
+                        // forward-compatible without changing readiness.
+                    }
                 }
                 Ok(())
             }

--- a/crates/notebook-wire/src/lib.rs
+++ b/crates/notebook-wire/src/lib.rs
@@ -211,6 +211,23 @@ pub struct TypedNotebookFrame {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SessionControlMessage {
     SyncStatus(SessionSyncStatusWire),
+    HostedBridgeStatus { status: HostedBridgeStatusWire },
+}
+
+/// Daemon-to-hosted-room bridge health for a notebook room.
+///
+/// This is connection-local control state, not notebook or runtime document
+/// state. Local rooms report `NotApplicable`; hosted rooms advance through the
+/// remaining phases as the daemon's outbound bridge connects and recovers.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HostedBridgeStatusWire {
+    NotApplicable,
+    Connecting,
+    Connected,
+    Reconnecting,
+    AuthenticationFailed,
+    TerminalError,
 }
 
 /// Full connection bootstrap/readiness snapshot.

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -24,7 +24,9 @@ use notebook_doc::mime::{is_binary_mime, ResolvedContentRef};
 use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
 use notebook_doc::{CellSnapshot, NotebookDoc};
-use notebook_wire::{frame_types, SessionControlMessage, SessionSyncStatusWire};
+use notebook_wire::{
+    frame_types, HostedBridgeStatusWire, SessionControlMessage, SessionSyncStatusWire,
+};
 use nteract_identity::{ActorLabel, ConnectionScope, Operator, Principal};
 use runtime_doc::{
     diff_output_ids_in_place, output_ids_for_execution, runtime_state_policy_snapshot,
@@ -281,6 +283,10 @@ pub enum FrameEvent {
     SessionControl {
         /// Full bootstrap/readiness snapshot for this socket.
         status: SessionSyncStatusWire,
+    },
+    /// Daemon-to-hosted-room bridge health.
+    HostedBridgeStatus {
+        hosted_bridge_status: HostedBridgeStatusWire,
     },
     /// Runtime state document was synced — frontend should update runtime state UI.
     RuntimeStateSyncApplied {
@@ -4819,6 +4825,11 @@ impl NotebookHandle {
                 match msg {
                     SessionControlMessage::SyncStatus(status) => {
                         events.push(FrameEvent::SessionControl { status });
+                    }
+                    SessionControlMessage::HostedBridgeStatus { status } => {
+                        events.push(FrameEvent::HostedBridgeStatus {
+                            hosted_bridge_status: status,
+                        });
                     }
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
@@ -222,6 +222,11 @@ async fn run_bridge(
         match transport.connect().await {
             Ok((source, sink)) => {
                 let Some(principal) = transport.principal().map(str::to_string) else {
+                    // Successful CloudWsFrameTransport::connect() promises a
+                    // principal, so this is an invariant failure rather than
+                    // ordinary reconnect churn. Keep retrying to avoid leaving
+                    // a retained dead handle, but report the terminal state
+                    // during backoff so the failure is not hidden.
                     warn!(
                         "[hosted-bridge] {} connected without a principal; retrying",
                         locator

--- a/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
@@ -32,7 +32,7 @@ use automerge::sync;
 use notebook_cloud_transport::CloudWsFrameTransport;
 use notebook_doc::diff::diff_metadata_touched;
 use notebook_protocol::connection::{FrameSink, FrameSource, FrameTransport};
-use notebook_wire::NotebookFrameType;
+use notebook_wire::{HostedBridgeStatusWire, NotebookFrameType};
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
@@ -208,12 +208,16 @@ async fn run_bridge(
     mut request_rx: mpsc::Receiver<Vec<u8>>,
 ) {
     let mut backoff = BACKOFF_INITIAL;
+    let mut connected_once = false;
     loop {
         // A closed principal watch means the daemon dropped the handle; stop
         // dialing on behalf of a room nobody can reach.
         if principal_tx.is_closed() {
             return;
         }
+        room.broadcasts
+            .hosted_bridge_status_tx
+            .send_replace(retrying_status(connected_once));
         let connected_at = tokio::time::Instant::now();
         match transport.connect().await {
             Ok((source, sink)) => {
@@ -222,24 +226,75 @@ async fn run_bridge(
                         "[hosted-bridge] {} connected without a principal; retrying",
                         locator
                     );
+                    room.broadcasts
+                        .hosted_bridge_status_tx
+                        .send_replace(HostedBridgeStatusWire::TerminalError);
                     tokio::time::sleep(backoff).await;
                     backoff = (backoff * 2).min(BACKOFF_MAX);
                     continue;
                 };
                 let _ = principal_tx.send(Some(principal.clone()));
+                connected_once = true;
+                room.broadcasts
+                    .hosted_bridge_status_tx
+                    .send_replace(HostedBridgeStatusWire::Connected);
                 info!(
                     "[hosted-bridge] {} attached as principal {}",
                     locator, principal
                 );
-                if let Err(e) = run_connection(&room, &locator, source, sink, &mut request_rx).await
-                {
-                    warn!("[hosted-bridge] {} connection ended: {}", locator, e);
-                } else {
-                    info!("[hosted-bridge] {} connection closed", locator);
+                match run_connection(&room, &locator, source, sink, &mut request_rx).await {
+                    Err(error) => {
+                        warn!("[hosted-bridge] {} connection ended: {}", locator, error);
+                        match classify_bridge_error(&transport, &error) {
+                            BridgeFailure::Recoverable => {
+                                room.broadcasts
+                                    .hosted_bridge_status_tx
+                                    .send_replace(HostedBridgeStatusWire::Reconnecting);
+                            }
+                            BridgeFailure::Authentication => {
+                                room.broadcasts
+                                    .hosted_bridge_status_tx
+                                    .send_replace(HostedBridgeStatusWire::AuthenticationFailed);
+                            }
+                            BridgeFailure::Terminal => {
+                                room.broadcasts
+                                    .hosted_bridge_status_tx
+                                    .send_replace(HostedBridgeStatusWire::TerminalError);
+                            }
+                        }
+                    }
+                    Ok(()) if transport.clean_eof_is_recoverable() => {
+                        info!(
+                            "[hosted-bridge] {} connection closed; reconnecting",
+                            locator
+                        );
+                        room.broadcasts
+                            .hosted_bridge_status_tx
+                            .send_replace(HostedBridgeStatusWire::Reconnecting);
+                    }
+                    Ok(()) => {
+                        info!("[hosted-bridge] {} connection closed", locator);
+                        room.broadcasts
+                            .hosted_bridge_status_tx
+                            .send_replace(HostedBridgeStatusWire::TerminalError);
+                    }
                 }
             }
-            Err(e) => {
-                warn!("[hosted-bridge] {} connect failed: {}", locator, e);
+            Err(error) => {
+                warn!("[hosted-bridge] {} connect failed: {}", locator, error);
+                match classify_connect_error(&transport, &error) {
+                    BridgeFailure::Recoverable => {}
+                    BridgeFailure::Authentication => {
+                        room.broadcasts
+                            .hosted_bridge_status_tx
+                            .send_replace(HostedBridgeStatusWire::AuthenticationFailed);
+                    }
+                    BridgeFailure::Terminal => {
+                        room.broadcasts
+                            .hosted_bridge_status_tx
+                            .send_replace(HostedBridgeStatusWire::TerminalError);
+                    }
+                }
             }
         }
         if connected_at.elapsed() >= BACKOFF_RESET_AFTER {
@@ -248,6 +303,59 @@ async fn run_bridge(
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(BACKOFF_MAX);
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BridgeFailure {
+    Recoverable,
+    Authentication,
+    Terminal,
+}
+
+fn retrying_status(connected_once: bool) -> HostedBridgeStatusWire {
+    if connected_once {
+        HostedBridgeStatusWire::Reconnecting
+    } else {
+        HostedBridgeStatusWire::Connecting
+    }
+}
+
+fn classify_connect_error(
+    transport: &CloudWsFrameTransport,
+    error: &std::io::Error,
+) -> BridgeFailure {
+    // Some room-side control rejections intentionally use PermissionDenied
+    // while remaining retryable (for example a room that is still warming).
+    // Honor the transport's narrower classification before treating the
+    // remaining permission failures as authentication errors.
+    if transport.stream_error_is_recoverable(error) {
+        BridgeFailure::Recoverable
+    } else if error.kind() == std::io::ErrorKind::PermissionDenied {
+        BridgeFailure::Authentication
+    } else {
+        BridgeFailure::Terminal
+    }
+}
+
+fn classify_stream_error(
+    transport: &CloudWsFrameTransport,
+    error: &std::io::Error,
+) -> BridgeFailure {
+    if transport.stream_error_is_recoverable(error) {
+        BridgeFailure::Recoverable
+    } else {
+        BridgeFailure::Terminal
+    }
+}
+
+fn classify_bridge_error(
+    transport: &CloudWsFrameTransport,
+    error: &anyhow::Error,
+) -> BridgeFailure {
+    error
+        .downcast_ref::<std::io::Error>()
+        .map(|error| classify_stream_error(transport, error))
+        .unwrap_or(BridgeFailure::Terminal)
 }
 
 /// Drive one live cloud connection until it drops.
@@ -712,8 +820,31 @@ mod tests {
         let room = test_room(&tmp);
 
         assert!(!room.is_hosted());
+        assert_eq!(
+            *room.broadcasts.hosted_bridge_status_tx.borrow(),
+            HostedBridgeStatusWire::NotApplicable
+        );
         room.mark_hosted();
         assert!(room.is_hosted());
+        assert_eq!(
+            *room.broadcasts.hosted_bridge_status_tx.borrow(),
+            HostedBridgeStatusWire::Connecting
+        );
+        room.broadcasts
+            .hosted_bridge_status_tx
+            .send_replace(HostedBridgeStatusWire::Connected);
+        room.mark_hosted();
+        assert_eq!(
+            *room.broadcasts.hosted_bridge_status_tx.borrow(),
+            HostedBridgeStatusWire::Connected,
+            "reusing a hosted room must not reset a live bridge to connecting"
+        );
+    }
+
+    #[test]
+    fn retrying_status_distinguishes_initial_connect_from_reconnect() {
+        assert_eq!(retrying_status(false), HostedBridgeStatusWire::Connecting);
+        assert_eq!(retrying_status(true), HostedBridgeStatusWire::Reconnecting);
     }
 
     async fn start_bridge(
@@ -786,6 +917,10 @@ mod tests {
 
         let principal = bridge.wait_for_principal(Duration::from_secs(10)).await;
         assert_eq!(principal.as_deref(), Some(CLOUD_PRINCIPAL));
+        assert_eq!(
+            *room.broadcasts.hosted_bridge_status_tx.borrow(),
+            HostedBridgeStatusWire::Connected
+        );
 
         // Cloud -> local: the fake room's seeded cell reaches the daemon room.
         let room_for_wait = room.clone();

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -107,6 +107,7 @@ where
     if client_protocol_version >= 3 {
         send_session_status(&mut writer, &phases).await?;
     }
+    // Protocol v4 introduced the hosted_bridge_status SessionControl variant.
     if client_protocol_version >= 4 {
         let status = *hosted_bridge_status_rx.borrow_and_update();
         send_hosted_bridge_status(&mut writer, status).await?;
@@ -453,6 +454,7 @@ where
                 }
             }
 
+            // Older peers do not know the v4 hosted_bridge_status variant.
             result = hosted_bridge_status_rx.changed(), if client_protocol_version >= 4 => {
                 if result.is_err() {
                     return Ok(());

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -18,11 +18,13 @@ use super::peer_presence::{
 };
 use super::peer_runtime_sync::{forward_runtime_state_broadcast, handle_runtime_state_frame};
 use super::peer_session::{
-    send_initial_notebook_doc_sync, send_initial_runtime_state_sync, send_session_status,
-    stream_initial_load_with_frame_drain, HandshakePhases, InitialSyncState, PeerSessionContext,
+    send_hosted_bridge_status, send_initial_notebook_doc_sync, send_initial_runtime_state_sync,
+    send_session_status, stream_initial_load_with_frame_drain, HandshakePhases, InitialSyncState,
+    PeerSessionContext,
 };
 use super::peer_writer::{
-    enqueue_notebook_request, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
+    enqueue_notebook_request, queue_hosted_bridge_status, queue_session_status,
+    spawn_peer_request_worker, spawn_peer_writer,
 };
 use super::*;
 use std::collections::VecDeque;
@@ -76,6 +78,7 @@ where
     let mut state_changed_rx = room.state.subscribe();
     let mut comms_changed_rx = room.comms.subscribe();
     let mut comments_changed_rx = room.comments.subscribe();
+    let mut hosted_bridge_status_rx = room.broadcasts.hosted_bridge_status_tx.subscribe();
 
     // PoolDoc — global daemon pool state (UV/Conda availability, errors).
     let mut pool_changed_rx = daemon.pool_doc_changed.subscribe();
@@ -103,6 +106,10 @@ where
 
     if client_protocol_version >= 3 {
         send_session_status(&mut writer, &phases).await?;
+    }
+    if client_protocol_version >= 4 {
+        let status = *hosted_bridge_status_rx.borrow_and_update();
+        send_hosted_bridge_status(&mut writer, status).await?;
     }
 
     // Fresh file-backed rooms stream the file itself as the initial doc sync.
@@ -444,6 +451,14 @@ where
                 {
                     return Ok(());
                 }
+            }
+
+            result = hosted_bridge_status_rx.changed(), if client_protocol_version >= 4 => {
+                if result.is_err() {
+                    return Ok(());
+                }
+                let status = *hosted_bridge_status_rx.borrow_and_update();
+                queue_hosted_bridge_status(&peer_writer, status)?;
             }
 
             // CommsDoc changed — push widget state updates to this client

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -187,6 +187,22 @@ where
     Ok(())
 }
 
+pub(crate) async fn send_hosted_bridge_status<W>(
+    writer: &mut W,
+    status: notebook_protocol::protocol::HostedBridgeStatusWire,
+) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    connection::send_typed_json_frame(
+        writer,
+        NotebookFrameType::SessionControl,
+        &notebook_protocol::protocol::SessionControlMessage::HostedBridgeStatus { status },
+    )
+    .await?;
+    Ok(())
+}
+
 /// State carried from the initial notebook-doc sync into the steady-state loop.
 ///
 /// See [`send_initial_notebook_doc_sync`]. `peer_state` tracks what the
@@ -1078,7 +1094,9 @@ mod tests {
 
         let statuses = decode_session_statuses(&writer.bytes);
         assert_eq!(statuses.len(), 1);
-        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        let SessionControlMessage::SyncStatus(status) = &statuses[0] else {
+            panic!("expected sync status");
+        };
         match &status.initial_load {
             InitialLoadPhaseWire::Failed { reason } => {
                 assert!(
@@ -1122,7 +1140,9 @@ mod tests {
             .contains("Initial materialization failed: source became unreadable"));
         let statuses = decode_session_statuses(&writer.bytes);
         assert_eq!(statuses.len(), 1);
-        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        let SessionControlMessage::SyncStatus(status) = &statuses[0] else {
+            panic!("expected sync status");
+        };
         assert_eq!(
             status.initial_load,
             InitialLoadPhaseWire::Failed {
@@ -1308,7 +1328,9 @@ mod tests {
         assert!(deferred_frames.is_empty());
         let statuses = decode_session_statuses(&writer.bytes);
         assert_eq!(statuses.len(), 1);
-        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        let SessionControlMessage::SyncStatus(status) = &statuses[0] else {
+            panic!("expected sync status");
+        };
         assert!(matches!(
             status.initial_load,
             InitialLoadPhaseWire::Failed { .. }
@@ -1372,7 +1394,9 @@ mod tests {
         ));
         let statuses = decode_session_statuses(&writer.bytes);
         assert_eq!(statuses.len(), 1);
-        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        let SessionControlMessage::SyncStatus(status) = &statuses[0] else {
+            panic!("expected sync status");
+        };
         assert_eq!(status.initial_load, InitialLoadPhaseWire::Ready);
     }
 
@@ -1586,7 +1610,9 @@ mod tests {
 
         let statuses = decode_session_statuses(&writer.bytes);
         assert_eq!(statuses.len(), 1);
-        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        let SessionControlMessage::SyncStatus(status) = &statuses[0] else {
+            panic!("expected sync status");
+        };
         assert_eq!(status.notebook_doc, NotebookDocPhaseWire::Syncing);
         assert_eq!(status.runtime_state, RuntimeStatePhaseWire::Syncing);
         assert_eq!(status.initial_load, InitialLoadPhaseWire::Ready);

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -527,6 +527,16 @@ pub(super) fn queue_session_status(
     )
 }
 
+pub(super) fn queue_hosted_bridge_status(
+    writer: &PeerWriter,
+    status: notebook_protocol::protocol::HostedBridgeStatusWire,
+) -> anyhow::Result<()> {
+    writer.send_json(
+        NotebookFrameType::SessionControl,
+        &notebook_protocol::protocol::SessionControlMessage::HostedBridgeStatus { status },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -310,6 +310,10 @@ pub struct RoomBroadcasts {
     /// Broadcast channel for presence frames (cursor, selection, kernel state).
     /// Carries raw presence bytes plus the peer_id to relay to other peers.
     pub presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    /// Current daemon-to-hosted-room bridge health. This watch channel is
+    /// control-plane state: every peer gets the latest value on attach and
+    /// subsequent transitions without coupling it to output/broadcast load.
+    pub hosted_bridge_status_tx: watch::Sender<notebook_wire::HostedBridgeStatusWire>,
     /// Transient peer state (cursors, selections, kernel status).
     /// Protected by RwLock for concurrent reads from multiple peer loops.
     pub presence: Arc<RwLock<PresenceState>>,
@@ -321,11 +325,14 @@ impl Default for RoomBroadcasts {
         let (file_dirty_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let (presence_tx, _) = broadcast::channel(64);
+        let (hosted_bridge_status_tx, _) =
+            watch::channel(notebook_wire::HostedBridgeStatusWire::NotApplicable);
         Self {
             changed_tx,
             file_dirty_tx,
             kernel_broadcast_tx,
             presence_tx,
+            hosted_bridge_status_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),
         }
     }
@@ -1272,7 +1279,11 @@ impl NotebookRoom {
 
     /// Mark this room as hosted. This flag is monotonic for the room lifetime.
     pub fn mark_hosted(&self) {
-        self.hosted.store(true, Ordering::Relaxed);
+        if !self.hosted.swap(true, Ordering::Relaxed) {
+            self.broadcasts
+                .hosted_bridge_status_tx
+                .send_replace(notebook_wire::HostedBridgeStatusWire::Connecting);
+        }
     }
 
     /// True once an eviction path has finished this room's final save and

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -187,6 +187,7 @@ fn decode_sync_status(
     .expect("valid session control frame")
     {
         notebook_protocol::protocol::SessionControlMessage::SyncStatus(status) => Some(status),
+        notebook_protocol::protocol::SessionControlMessage::HostedBridgeStatus { .. } => None,
     }
 }
 

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -31,6 +31,14 @@ export interface SessionStatus {
   initial_load: InitialLoadPhase;
 }
 
+export type HostedBridgeStatus =
+  | "not_applicable"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "authentication_failed"
+  | "terminal_error";
+
 // ── FrameEvent ───────────────────────────────────────────────────────
 
 /** Attribution for text changes, produced by WASM sync. */
@@ -134,6 +142,7 @@ export interface CommentsProjection {
  * - `broadcast` — Daemon broadcast (kernel status, output, etc.)
  * - `presence` — Remote peer presence update
  * - `session_control` — Connection-local readiness / bootstrap status
+ * - `hosted_bridge_status` — Daemon-to-hosted-room bridge health
  * - `runtime_state_sync_applied` — RuntimeStateDoc sync applied
  * - `comms_doc_sync_applied` — CommsDoc sync applied
  * - `comments_doc_sync_applied` — CommentsDoc sync applied
@@ -158,6 +167,8 @@ export interface FrameEvent {
   projection?: CommentsProjection;
   /** Connection-local session status from SESSION_CONTROL frames. */
   status?: SessionStatus;
+  /** Daemon-to-hosted-room bridge status from SESSION_CONTROL frames. */
+  hosted_bridge_status?: HostedBridgeStatus;
   /**
    * Per-output diff for RuntimeStateSyncApplied events. Each `changed` entry
    * is `[output_id, narrowed_manifest]` — manifests are already MIME-narrowed

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -151,6 +151,7 @@ export type {
   ExecutionViewSnapshot,
   SyncableHandle,
   FrameEvent,
+  HostedBridgeStatus,
   LocalMutationResult,
   InitialLoadPhase,
   NotebookDocPhase,

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -2,6 +2,7 @@
 // Do not edit by hand.
 
 import type {
+  HostedBridgeStatus,
   InitialLoadPhase,
   NotebookDocPhase,
   RuntimeStatePhase,
@@ -83,10 +84,13 @@ export const NOTEBOOK_RESPONSE_RESULTS_EXHAUSTIVE: MissingUnionMember<
   ? true
   : never = true;
 
-export type SessionControlMessage = { type: "sync_status" } & SessionStatus;
+export type SessionControlMessage =
+  | ({ type: "sync_status" } & SessionStatus)
+  | { type: "hosted_bridge_status"; status: HostedBridgeStatus };
 
 export const SESSION_CONTROL_TYPES = [
   "sync_status",
+  "hosted_bridge_status",
 ] as const satisfies readonly SessionControlMessage["type"][];
 
 export const NOTEBOOK_DOC_PHASES = [

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -54,6 +54,7 @@ import type {
   ExecutionQueueProjection,
   ExecutionViewChangeset,
   FrameEvent,
+  HostedBridgeStatus,
   InitialLoadPhase,
   SessionStatus,
   SyncableHandle,
@@ -351,6 +352,9 @@ export class SyncEngine {
   /** Remote peer presence updates (cursor, selection, snapshot, left, heartbeat). */
   readonly presence$: Observable<unknown>;
 
+  /** Daemon-to-hosted-room bridge health for the active room. */
+  readonly hostedBridgeStatus$: Observable<HostedBridgeStatus>;
+
   /** RuntimeState snapshots from the daemon's RuntimeStateDoc. */
   readonly runtimeState$: Observable<RuntimeState>;
 
@@ -485,6 +489,7 @@ export class SyncEngine {
   private readonly _cellChanges$ = new Subject<CellChangeset | null>();
   private readonly _broadcasts$ = new Subject<unknown>();
   private readonly _presence$ = new Subject<unknown>();
+  private readonly _hostedBridgeStatus$ = new ReplaySubject<HostedBridgeStatus>(1);
   private readonly _runtimeState$ = new Subject<RuntimeState>();
   private readonly _poolState$ = new Subject<PoolState>();
   private readonly _executionTransitions$ = new Subject<ExecutionTransition[]>();
@@ -513,6 +518,7 @@ export class SyncEngine {
     this.cellChanges$ = this._cellChanges$.asObservable();
     this.broadcasts$ = this._broadcasts$.asObservable();
     this.presence$ = this._presence$.asObservable();
+    this.hostedBridgeStatus$ = this._hostedBridgeStatus$.asObservable();
     this.runtimeState$ = this._runtimeState$.asObservable();
     this.poolState$ = this._poolState$.asObservable();
     this.executionTransitions$ = this._executionTransitions$.asObservable();
@@ -644,6 +650,21 @@ export class SyncEngine {
           } else {
             log.debug(`[sync-engine] session status: ${formatSessionStatus(next)}`);
           }
+        }),
+    );
+
+    sub.add(
+      frameEvents$
+        .pipe(
+          filter(
+            (event) => event.type === "hosted_bridge_status" && event.hosted_bridge_status != null,
+          ),
+          map((event) => event.hosted_bridge_status as HostedBridgeStatus),
+          distinctUntilChanged(),
+        )
+        .subscribe((status) => {
+          log.debug(`[sync-engine] hosted bridge status: ${status}`);
+          this._hostedBridgeStatus$.next(status);
         }),
     );
 
@@ -1661,6 +1682,9 @@ export class SyncEngine {
     this.commDiffState = { comms: {}, json: {} };
     this.lastRuntimeState = null;
     this.lastCommsState = null;
+    // Do not replay a previous hosted bridge's connected state into the new
+    // relay generation. Local rooms promptly replace this with not_applicable.
+    this._hostedBridgeStatus$.next("connecting");
     this._sessionStatus$.next({
       notebook_doc: "pending",
       runtime_state: "pending",

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -14,7 +14,7 @@ import { DirectTransport } from "../src/direct-transport";
 import { FrameType } from "../src/transport";
 import { mergeChangesets } from "../src/cell-changeset";
 import { diffExecutions } from "../src/runtime-state";
-import type { SessionStatus, SyncableHandle, FrameEvent } from "../src/handle";
+import type { FrameEvent, HostedBridgeStatus, SessionStatus, SyncableHandle } from "../src/handle";
 import type { CellChangeset } from "../src/cell-changeset";
 import type { RuntimeState } from "../src/runtime-state";
 
@@ -101,6 +101,10 @@ function commsDocSyncEvent(state: Record<string, Record<string, unknown>>): Fram
 
 function sessionStatusEvent(status: SessionStatus): FrameEvent {
   return { type: "session_control", status };
+}
+
+function hostedBridgeStatusEvent(status: HostedBridgeStatus): FrameEvent {
+  return { type: "hosted_bridge_status", hosted_bridge_status: status };
 }
 
 function pendingStatus(): SessionStatus {
@@ -340,6 +344,28 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("emits deduplicated hosted bridge status snapshots", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce([hostedBridgeStatusEvent("connecting")])
+        .mockReturnValueOnce([hostedBridgeStatusEvent("connected")])
+        .mockReturnValueOnce([hostedBridgeStatusEvent("connected")])
+        .mockReturnValueOnce([hostedBridgeStatusEvent("reconnecting")]);
+
+      const engine = createEngine();
+      engine.start();
+
+      const statuses: HostedBridgeStatus[] = [];
+      engine.hostedBridgeStatus$.subscribe((status) => statuses.push(status));
+
+      transport.deliver(Array.from([0x07, 1]));
+      transport.deliver(Array.from([0x07, 2]));
+      transport.deliver(Array.from([0x07, 3]));
+      transport.deliver(Array.from([0x07, 4]));
+
+      expect(statuses).toEqual(["connecting", "connected", "reconnecting"]);
+      engine.stop();
+    });
+
     it("resetForBootstrap emits a pending status so stale ready doesn't leak across reconnect", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValueOnce([
         sessionStatusEvent(interactiveStatus()),
@@ -365,6 +391,28 @@ describe("SyncEngine", () => {
       engine.sessionStatus$.subscribe((status) => (lateSeen = status));
       expect(lateSeen!.runtime_state).toBe("pending");
 
+      engine.stop();
+    });
+
+    it("resetForBootstrap does not replay stale connected bridge health", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+        hostedBridgeStatusEvent("connected"),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+      const statuses: HostedBridgeStatus[] = [];
+      engine.hostedBridgeStatus$.subscribe((status) => statuses.push(status));
+
+      transport.deliver(Array.from([0x07, 1]));
+      expect(statuses.at(-1)).toBe("connected");
+
+      engine.resetForBootstrap();
+      expect(statuses.at(-1)).toBe("connecting");
+
+      let lateSeen: HostedBridgeStatus | null = null;
+      engine.hostedBridgeStatus$.subscribe((status) => (lateSeen = status));
+      expect(lateSeen).toBe("connecting");
       engine.stop();
     });
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -357,10 +357,10 @@ describe("SyncEngine", () => {
       const statuses: HostedBridgeStatus[] = [];
       engine.hostedBridgeStatus$.subscribe((status) => statuses.push(status));
 
-      transport.deliver(Array.from([0x07, 1]));
-      transport.deliver(Array.from([0x07, 2]));
-      transport.deliver(Array.from([0x07, 3]));
-      transport.deliver(Array.from([0x07, 4]));
+      transport.deliver(Array.from([FrameType.SESSION_CONTROL, 1]));
+      transport.deliver(Array.from([FrameType.SESSION_CONTROL, 2]));
+      transport.deliver(Array.from([FrameType.SESSION_CONTROL, 3]));
+      transport.deliver(Array.from([FrameType.SESSION_CONTROL, 4]));
 
       expect(statuses).toEqual(["connecting", "connected", "reconnecting"]);
       engine.stop();
@@ -378,7 +378,7 @@ describe("SyncEngine", () => {
       engine.sessionStatus$.subscribe((status) => statuses.push(status));
 
       // First session reaches ready.
-      transport.deliver(Array.from([0x07, 1]));
+      transport.deliver(Array.from([FrameType.SESSION_CONTROL, 1]));
       expect(statuses.at(-1)?.runtime_state).toBe("ready");
 
       // Rebootstrap (daemon:ready path). ReplaySubject(1) must now carry
@@ -404,7 +404,7 @@ describe("SyncEngine", () => {
       const statuses: HostedBridgeStatus[] = [];
       engine.hostedBridgeStatus$.subscribe((status) => statuses.push(status));
 
-      transport.deliver(Array.from([0x07, 1]));
+      transport.deliver(Array.from([FrameType.SESSION_CONTROL, 1]));
       expect(statuses.at(-1)).toBe("connected");
 
       engine.resetForBootstrap();

--- a/src/components/notebook/NotebookConnectionIdentity.tsx
+++ b/src/components/notebook/NotebookConnectionIdentity.tsx
@@ -29,9 +29,10 @@ export interface NotebookConnectionStatusSource {
  * consumer. Runtime-state stores are deliberately not blanked while a
  * transport reconnects, so this dot is what makes frozen kernel/execution
  * chrome interpretable during the offline window — for the link the host
- * actually measures: the cloud room transport on cloud, the daemon link on
- * desktop (daemon↔room health is future work; `connectionLabel` scopes the
- * copy to the measured link so the dot never overclaims).
+ * actually measures: the cloud room transport on cloud, the daemon link for
+ * local desktop notebooks, and the composed app↔daemon↔hosted-room path
+ * for hosted desktop notebooks. `connectionLabel` scopes the copy to that
+ * measured path so the dot never overclaims.
  *
  * Quiet-chrome rules (distilled from the pulled #3273/#3290/#3337/#3349
  * designs — hard constraints, not preferences):


### PR DESCRIPTION
## What changed

- publish daemon-to-hosted-room bridge lifecycle through the reliable session-control path
- expose that typed status through the WASM sync engine and compose it with desktop daemon health
- keep authentication and terminal failures visible during backoff without stranding the retained bridge handle
- preserve local-room behavior and scope the hosted desktop connection copy to the complete notebook path

## Why

Desktop previously reported only app-to-daemon health. A hosted notebook could therefore show Connected while the daemon's outbound room bridge was connecting, reconnecting, or failing authentication.

The bridge is the daemon's observed source of truth for that second hop. Publishing its status as connection-local control state keeps lifecycle signals separate from output transport and avoids duplicating state into notebook documents.

Fixes #3599.

## Validation

- `cargo xtask lint --fix`
- `cargo test -p runtimed hosted_bridge` (13 passed)
- `cargo test -p notebook-wire -p notebook-protocol` (91 passed)
- `cargo test -p notebook-cloud-transport` (33 passed)
- `pnpm test:run` (2,784 passed, 6 skipped)
- `pnpm --dir packages/runtimed typecheck`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
