### PR TITLE
fix(cloud): calm notebook auth and compute states

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -778,16 +778,27 @@ test("cloud notebook list refresh stays on the GET-first session path", () => {
   const routeSourceText = readFileSync(routeSourcePath, "utf8");
 
   assert.match(routeSourceText, /import \{ clearCloudAppSession \}/);
-  assert.match(
+  assert.match(routeSourceText, /const refreshList = \(\) => \{[\s\S]{0,500}?setRefreshIndex/);
+  assert.doesNotMatch(
     routeSourceText,
-    /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*auth\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
-    "manual notebook-list refresh reads session status; pending invites resolve on the cookie-authenticated list fetch itself (syncStoredAppSessionProfile)",
+    /const refreshList = \(\) => \{[\s\S]{0,500}?refreshAppSessionStatus/,
+    "manual refresh should issue one list GET; that response renews the cookie and syncs the stored profile",
   );
   assert.doesNotMatch(
     routeSourceText,
     /establishCloudAppSession/,
     "the list view never re-validates upstream with an establish POST; the missing-session fallback lives in the auth store",
   );
+});
+
+test("readable cloud notebooks leave disconnected compute to the existing runtime controls", () => {
+  const sourcePath = new URL("../viewer/notebook-viewer.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.doesNotMatch(sourceText, /ComputeDisconnectedNotice/);
+  assert.doesNotMatch(sourceText, /shouldRenderComputeDisconnectedNotice/);
+  assert.match(sourceText, /onStartRuntime: handleCloudStartRuntime/);
+  assert.match(sourceText, /workstationAction/);
 });
 
 test("cloud notebook list bounds app-session waits before catalog fetches", () => {

--- a/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
@@ -100,6 +100,51 @@ describe("CloudNotebookListView", () => {
     expect(screen.getByText("No notebooks yet")).toBeTruthy();
   });
 
+  it("keeps a provisional OIDC 401 quiet while the app-session fallback catches up", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "sign in to list notebooks" }), {
+          headers: { "Content-Type": "application/json" },
+          status: 401,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            notebooks: [notebook("nb-recovered", "Recovered Notebook")],
+            current_user_principal: "user:anaconda:alice%40example.test",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200,
+          },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5 });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("status", { name: "Loading notebooks" })).toBeTruthy();
+    expect(screen.queryByText(/sign in to list notebooks/i)).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("Recovered Notebook")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
   it("renders the true total count and visible cap in the dashboard header", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -142,7 +142,18 @@ export function CloudNotebookListView({
     const initialState = seed
       ? { kind: "ready" as const, notebooks: seed.notebooks, totalCount: seed.totalCount }
       : { kind: "loading" as const };
-    const loadNotebookList = async (controller: AbortController, warningLabel: string) => {
+    let appSessionFallbackDeadline: number | null = null;
+    const clearAppSessionFallbackDeadline = () => {
+      if (appSessionFallbackDeadline !== null) {
+        window.clearTimeout(appSessionFallbackDeadline);
+        appSessionFallbackDeadline = null;
+      }
+    };
+    const loadNotebookList = async (
+      controller: AbortController,
+      warningLabel: string,
+      deferUnauthorized = false,
+    ) => {
       try {
         const response = await fetchCloudNotebookList(
           authState,
@@ -153,6 +164,20 @@ export function CloudNotebookListView({
         );
         if (controller.signal.aborted) return;
         if (!response.ok) {
+          if (response.status === 401 && deferUnauthorized && waitingForAppSession && !seed) {
+            // A valid browser OIDC session can briefly outrun its same-origin
+            // app-session exchange. Keep that provisional 401 inside the auth
+            // handshake instead of painting a false signed-out error between
+            // the bearer request and the cookie-backed retry.
+            appSessionFallbackDeadline = window.setTimeout(
+              () => {
+                appSessionFallbackDeadline = null;
+                void loadNotebookList(controller, " after app-session wait deadline", false);
+              },
+              Math.max(0, appSessionWaitDeadline),
+            );
+            return;
+          }
           const responseError = await cloudResponseError(response, "Unable to list notebooks");
           if (controller.signal.aborted) return;
           throw responseError;
@@ -176,6 +201,7 @@ export function CloudNotebookListView({
             ? body.current_user_avatar.trim()
             : null,
         );
+        clearAppSessionFallbackDeadline();
         setListState({ kind: "ready", notebooks: body.notebooks, totalCount });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -204,6 +230,7 @@ export function CloudNotebookListView({
         );
         return () => {
           window.clearTimeout(deadline);
+          clearAppSessionFallbackDeadline();
           controller.abort();
         };
       }
@@ -227,9 +254,10 @@ export function CloudNotebookListView({
 
     const controller = new AbortController();
     setListState(initialState);
-    void loadNotebookList(controller, "");
+    void loadNotebookList(controller, "", true);
 
     return () => {
+      clearAppSessionFallbackDeadline();
       controller.abort();
     };
   }, [
@@ -244,12 +272,9 @@ export function CloudNotebookListView({
   ]);
 
   const refreshList = () => {
-    // GET-first session diet: the status GET renews the cookie server-side
-    // and the auth store's fallback establish covers a truly missing session,
-    // so a manual refresh never re-validates upstream with a POST.
-    if (authState.mode === "oidc" && authState.token) {
-      auth.refreshAppSessionStatus();
-    }
+    // The list GET authenticates directly, renews a live app-session cookie,
+    // and syncs the stored profile. A parallel session-status GET only creates
+    // a second auth transition that can restart this list request mid-refresh.
     setRefreshIndex((value) => value + 1);
   };
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -31,9 +31,7 @@ import {
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
   NotebookWorkstationsPanel,
-  ComputeDisconnectedNotice,
   KernelLaunchErrorBanner,
-  isRuntimePeerDisconnectedErrorDetails,
   projectNotebookCommandRuntimeStatusFromRuntimeState,
   shouldShowKernelLaunchErrorBanner,
   shouldShowNotebookDocumentCommandToolbar,
@@ -1786,20 +1784,6 @@ export function NotebookViewer({
       errorReason: cloudKernelErrorReason,
       runtime: cloudKernelRuntime,
     }) && dismissedLaunchError !== cloudKernelErrorDetails;
-  const shouldRenderComputeDisconnectedNotice =
-    isRuntimePeerDisconnectedErrorDetails(cloudKernelErrorDetails) &&
-    dismissedLaunchError !== cloudKernelErrorDetails;
-  const computeDisconnectedNotice =
-    shouldRenderComputeDisconnectedNotice && cloudKernelErrorDetails ? (
-      <ComputeDisconnectedNotice
-        errorDetails={cloudKernelErrorDetails}
-        onRetry={() => {
-          setDismissedLaunchError(null);
-          handleCloudRestartRuntime();
-        }}
-        onDismiss={() => setDismissedLaunchError(cloudKernelErrorDetails)}
-      />
-    ) : null;
   const kernelLaunchNotice =
     shouldRenderKernelLaunchError && cloudKernelErrorDetails ? (
       <KernelLaunchErrorBanner
@@ -1812,9 +1796,8 @@ export function NotebookViewer({
       />
     ) : null;
   const diagnostics =
-    computeDisconnectedNotice || kernelLaunchNotice || accessRequestNotice ? (
+    kernelLaunchNotice || accessRequestNotice ? (
       <>
-        {computeDisconnectedNotice}
         {kernelLaunchNotice}
         {accessRequestNotice}
       </>


### PR DESCRIPTION
## Summary

- keep a provisional notebook-list `401` inside the OIDC-to-app-session handshake, with one bounded retry instead of flashing a false signed-out error
- make manual notebook-list refresh issue one authoritative list request instead of racing a separate session-status request
- remove the full-width cloud compute-disconnected notice while preserving the existing Start compute, workstation, runtime-status, and real kernel-failure affordances

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test -c vitest.config.ts apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
