### PR TITLE
fix(cloud): re-arm app session after OIDC refresh

### DIFF
--- a/apps/notebook-cloud/test/cloud-auth-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-auth-store.test.ts
@@ -83,6 +83,17 @@ function oidcAuth(): CloudPrototypeAuthState {
   };
 }
 
+function expiredOidcAuth(): CloudPrototypeAuthState {
+  return {
+    mode: "oidc_expired",
+    token: null,
+    user: "OIDC User",
+    oidcClaims: { sub: "subject-1" },
+    requestedScope: "editor",
+    problem: "Stored OIDC session is expired. Sign in again.",
+  };
+}
+
 function appSession(overrides: Partial<CloudAppSession> = {}): CloudAppSession {
   return { provider: "oidc", expires_at: 10_000, cache_key: "cache-a", ...overrides };
 }
@@ -306,6 +317,52 @@ describe("CloudAuthStore OIDC refresh driver", () => {
 });
 
 describe("CloudAuthStore app-session establish driver", () => {
+  it("establishes immediately when OIDC refresh finishes after the session probe", async () => {
+    const scheduler = newScheduler();
+    let currentAuth = expiredOidcAuth();
+    let resolveRefresh: ((token: CloudOidcTokenState) => void) | undefined;
+    const establishes: string[] = [];
+    const store = new CloudAuthStore({ readAuthState: () => currentAuth });
+
+    const dispose = store.activate(
+      { authConfig: { oidc: oidcConfig, localDev: null }, initialSession: null },
+      baseDeps({
+        scheduler,
+        now: () => 100_000,
+        oidcStorage: refreshableOidcStorage(),
+        readAppSessionStatus: async () => ({ ok: true, session: null }),
+        refreshOidcToken: () =>
+          new Promise<CloudOidcTokenState>((resolve) => {
+            resolveRefresh = resolve;
+          }),
+        establishAppSession: async (authState) => {
+          establishes.push(authState.token ?? "");
+        },
+      }),
+    );
+
+    // The initial status GET settles while OIDC refresh is still in flight.
+    // Its settle edge cannot establish from the expired auth snapshot.
+    advanceBy(scheduler, 0);
+    await drainMicrotasks();
+    assert.deepEqual(establishes, []);
+
+    currentAuth = oidcAuth();
+    resolveRefresh?.({
+      accessToken: "oidc-token",
+      refreshToken: "stored-refresh",
+      expiresAt: 99_999,
+      claims: { sub: "subject-1" },
+    });
+    await drainMicrotasks();
+
+    // The refreshed auth transition must re-arm session establishment now,
+    // rather than leaving the page stuck until the 60-second cadence tick.
+    assert.deepEqual(establishes, ["oidc-token"]);
+
+    dispose();
+  });
+
   it("attempts once per token, holds off inside the 5-minute backoff, and retries after it", async () => {
     const scheduler = newScheduler();
     let nowMs = 0;

--- a/apps/notebook-cloud/test/hosted-catalog-auth.test.ts
+++ b/apps/notebook-cloud/test/hosted-catalog-auth.test.ts
@@ -42,6 +42,23 @@ describe("hosted catalog auth projection", () => {
     assert.equal(projection.waitingForAppSession, false);
   });
 
+  it("keeps an expired OIDC identity in recovery while token renewal is active", () => {
+    const projection = projectHostedCatalogAuthState(auth("oidc_expired"), {
+      authRenewal: { kind: "refreshing", message: "Refreshing sign-in..." },
+    });
+
+    assert.equal(projection.signedIn, false);
+    assert.equal(projection.canFetchCatalog, false);
+    assert.equal(projection.showSignIn, false);
+    assert.equal(projection.waitingForAppSession, true);
+
+    const failed = projectHostedCatalogAuthState(auth("oidc_expired"), {
+      authRenewal: { kind: "failed", message: "Sign-in refresh failed." },
+    });
+    assert.equal(failed.showSignIn, true);
+    assert.equal(failed.waitingForAppSession, false);
+  });
+
   it("keeps local dev auth usable without app sessions", () => {
     const projection = projectHostedCatalogAuthState(auth("dev"));
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -769,7 +769,7 @@ test("cloud auth store re-establishes and refreshes cookie-backed state after OI
   );
   assert.match(
     routeSourceText,
-    /\[\s*appSessionStatus\.session,[\s\S]*authState,[\s\S]*bootstrap,[\s\S]*canFetchNotebookList,[\s\S]*refreshIndex,[\s\S]*waitingForAppSession,[\s\S]*\]/,
+    /\[\s*appSessionStatus\.session,[\s\S]*appSessionWaitDeadline,[\s\S]*authState,[\s\S]*bootstrap,[\s\S]*canFetchNotebookList,[\s\S]*refreshIndex,[\s\S]*waitingForAppSession,[\s\S]*\]/,
   );
 });
 
@@ -807,13 +807,13 @@ test("cloud notebook list bounds app-session waits before catalog fetches", () =
 
   assert.match(
     sourceText,
-    /const \{[\s\S]*canFetchCatalog: cookieCanFetchNotebookList,[\s\S]*hasAppSession,[\s\S]*signedIn,[\s\S]*waitingForAppSession,[\s\S]*\} = hostedAuth;/,
+    /const \{[\s\S]*canFetchCatalog: canFetchNotebookList,[\s\S]*hasAppSession,[\s\S]*signedIn,[\s\S]*waitingForAppSession,[\s\S]*\} = hostedAuth;/,
   );
   assert.match(sourceText, /const hostedAuth = useHostedCatalogAuth\(\);/);
-  assert.match(
+  assert.doesNotMatch(
     sourceText,
-    /const canFetchNotebookList =[\s\S]*cookieCanFetchNotebookList \|\|[\s\S]*cloudNotebookListCanUseExistingCredentials\(authState, appSessionStatus\.status\);/,
-    "bearer OIDC and still-loading app-session cookies should race the list fetch before the cookie exchange settles",
+    /cloudNotebookListCanUseExistingCredentials/,
+    "the list should trust the hosted-auth projection instead of speculating that a cookie exists",
   );
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx
@@ -73,7 +73,7 @@ describe("CloudNotebookListView", () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
-  it("starts the list fetch with OIDC credentials before app-session establishment settles", async () => {
+  it("waits for app-session confirmation before issuing the cookie-only list fetch", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(
         JSON.stringify({
@@ -96,53 +96,59 @@ describe("CloudNotebookListView", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("No notebooks yet")).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("status", { name: "Loading notebooks" })).toBeTruthy();
   });
 
-  it("keeps a provisional OIDC 401 quiet while the app-session fallback catches up", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: "sign in to list notebooks" }), {
-          headers: { "Content-Type": "application/json" },
-          status: 401,
+  it("loads as soon as the auth store confirms an app session", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          notebooks: [notebook("nb-recovered", "Recovered Notebook")],
+          current_user_principal: "user:anaconda:alice%40example.test",
         }),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            ok: true,
-            notebooks: [notebook("nb-recovered", "Recovered Notebook")],
-            current_user_principal: "user:anaconda:alice%40example.test",
-          }),
-          {
-            headers: { "Content-Type": "application/json" },
-            status: 200,
-          },
-        ),
-      );
+        {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        },
+      ),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
-    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5 });
+    const store = renderNotebookList(oidcAuth("alice@example.test"), {
+      appSessionWaitDeadlineMs: 5_000,
+    });
 
     await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("status", { name: "Loading notebooks" })).toBeTruthy();
+
+    let dispose = () => {};
+    await act(async () => {
+      dispose = store.activate(
+        {
+          authConfig,
+          initialSession: {
+            provider: "oidc",
+            expires_at: 99_999,
+            cache_key: "session-a",
+          },
+        },
+        { now: () => 0 },
+      );
       await Promise.resolve();
       await Promise.resolve();
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("status", { name: "Loading notebooks" })).toBeTruthy();
-    expect(screen.queryByText(/sign in to list notebooks/i)).toBeNull();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5);
-      await Promise.resolve();
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(screen.getByText("Recovered Notebook")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    dispose();
   });
 
   it("renders the true total count and visible cap in the dashboard header", async () => {
@@ -162,15 +168,30 @@ describe("CloudNotebookListView", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    renderNotebookList(oidcAuth("alice@example.test"), { appSessionWaitDeadlineMs: 5_000 });
+    const store = renderNotebookList(oidcAuth("alice@example.test"), {
+      appSessionWaitDeadlineMs: 5_000,
+    });
 
+    let dispose = () => {};
     await act(async () => {
+      dispose = store.activate(
+        {
+          authConfig,
+          initialSession: {
+            provider: "oidc",
+            expires_at: 99_999,
+            cache_key: "session-a",
+          },
+        },
+        { now: () => 0 },
+      );
       await Promise.resolve();
       await Promise.resolve();
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(screen.getByText("342 notebooks · showing 2 · 0 active now")).toBeTruthy();
+    dispose();
   });
 
   it("keeps cached notebooks visible when revalidation fails", async () => {

--- a/apps/notebook-cloud/viewer/cloud-auth-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-auth-store.ts
@@ -277,9 +277,14 @@ export class CloudAuthStore {
       this.authState$,
       this.appSession$,
       this.appSessionLoading$,
+      this.renewal$,
     ]).pipe(
-      map(([authState, appSession, appSessionLoading]) =>
-        projectHostedCatalogAuthState(authState, { appSession, appSessionLoading }),
+      map(([authState, appSession, appSessionLoading, authRenewal]) =>
+        projectHostedCatalogAuthState(authState, {
+          appSession,
+          appSessionLoading,
+          authRenewal,
+        }),
       ),
       distinctUntilChanged(hostedCatalogAuthEquals),
       shareReplay({ bufferSize: 1, refCount: false }),
@@ -372,6 +377,14 @@ export class CloudAuthStore {
       pairwise(),
       filter(([wasSettled, isSettled]) => !wasSettled && isSettled),
     );
+    // Re-arm the app-session bridge when OIDC refresh turns an expired stored
+    // identity into a usable token. The initial session GET can settle before
+    // the upstream token refresh; without this edge both boot triggers are
+    // already spent and the cookie exchange waits for the 60-second cadence.
+    const oidcTokenChanged$ = this.authState$.pipe(
+      map((authState) => (authState.mode === "oidc" && authState.token ? authState.token : null)),
+      distinctUntilChanged(),
+    );
 
     this.seedAppSession(config.initialSession ?? null);
 
@@ -424,6 +437,7 @@ export class CloudAuthStore {
         focus$,
         visibleRise$,
         appSessionSettled$,
+        oidcTokenChanged$,
       ).subscribe(() => this.renewIfNeeded()),
     );
 

--- a/apps/notebook-cloud/viewer/hosted-catalog-auth.ts
+++ b/apps/notebook-cloud/viewer/hosted-catalog-auth.ts
@@ -4,6 +4,7 @@ import {
   shouldShowCloudHeaderSignIn,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
+import type { CloudAuthRenewalState } from "./notice-types";
 
 export interface HostedCatalogAuthProjection {
   appSessionLoading: boolean;
@@ -20,25 +21,32 @@ export function projectHostedCatalogAuthState(
   options: {
     appSession?: CloudAppSession | null;
     appSessionLoading?: boolean;
+    authRenewal?: CloudAuthRenewalState;
   } = {},
 ): HostedCatalogAuthProjection {
   const appSessionLoading = options.appSessionLoading === true;
+  const authRenewalPending = options.authRenewal?.kind === "refreshing";
   const hasAppSession = Boolean(options.appSession);
   const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
   const canFetchCatalog = cloudBrowserCanUseAuthenticatedApi({
     authState,
     hasAppSession,
   });
-  const waitingForAppSession = authState.mode === "oidc" && !hasAppSession;
+  const waitingForAppSession =
+    !hasAppSession &&
+    (authState.mode === "oidc" ||
+      (authState.mode === "oidc_expired" && (appSessionLoading || authRenewalPending)));
   return {
     appSessionLoading,
     canFetchCatalog,
     hasAppSession,
     hasExplicitAuth,
-    showSignIn: shouldShowCloudHeaderSignIn(authState, {
-      appSessionLoading,
-      hasAppSession,
-    }),
+    showSignIn:
+      !waitingForAppSession &&
+      shouldShowCloudHeaderSignIn(authState, {
+        appSessionLoading,
+        hasAppSession,
+      }),
     signedIn: hasExplicitAuth || hasAppSession,
     waitingForAppSession,
   };

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -75,7 +75,6 @@ import {
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { preloadNotebookRoute } from "./notebook-route-preload";
-import type { CloudAppSessionViewState } from "./use-cloud-auth";
 
 const CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS = 8_000;
 const CLOUD_NOTEBOOK_LIST_FETCH_TIMEOUT_MS = 20_000;
@@ -111,14 +110,11 @@ export function CloudNotebookListView({
   const [renameError, setRenameError] = useState<string | null>(null);
   const hostedAuth = useHostedCatalogAuth();
   const {
-    canFetchCatalog: cookieCanFetchNotebookList,
+    canFetchCatalog: canFetchNotebookList,
     hasAppSession,
     signedIn,
     waitingForAppSession,
   } = hostedAuth;
-  const canFetchNotebookList =
-    cookieCanFetchNotebookList ||
-    cloudNotebookListCanUseExistingCredentials(authState, appSessionStatus.status);
   const appSessionWaitDeadline =
     appSessionWaitDeadlineMs ?? CLOUD_NOTEBOOK_LIST_APP_SESSION_WAIT_DEADLINE_MS;
   const dashboardModel = useMemo(
@@ -142,18 +138,7 @@ export function CloudNotebookListView({
     const initialState = seed
       ? { kind: "ready" as const, notebooks: seed.notebooks, totalCount: seed.totalCount }
       : { kind: "loading" as const };
-    let appSessionFallbackDeadline: number | null = null;
-    const clearAppSessionFallbackDeadline = () => {
-      if (appSessionFallbackDeadline !== null) {
-        window.clearTimeout(appSessionFallbackDeadline);
-        appSessionFallbackDeadline = null;
-      }
-    };
-    const loadNotebookList = async (
-      controller: AbortController,
-      warningLabel: string,
-      deferUnauthorized = false,
-    ) => {
+    const loadNotebookList = async (controller: AbortController, warningLabel: string) => {
       try {
         const response = await fetchCloudNotebookList(
           authState,
@@ -164,20 +149,6 @@ export function CloudNotebookListView({
         );
         if (controller.signal.aborted) return;
         if (!response.ok) {
-          if (response.status === 401 && deferUnauthorized && waitingForAppSession && !seed) {
-            // A valid browser OIDC session can briefly outrun its same-origin
-            // app-session exchange. Keep that provisional 401 inside the auth
-            // handshake instead of painting a false signed-out error between
-            // the bearer request and the cookie-backed retry.
-            appSessionFallbackDeadline = window.setTimeout(
-              () => {
-                appSessionFallbackDeadline = null;
-                void loadNotebookList(controller, " after app-session wait deadline", false);
-              },
-              Math.max(0, appSessionWaitDeadline),
-            );
-            return;
-          }
           const responseError = await cloudResponseError(response, "Unable to list notebooks");
           if (controller.signal.aborted) return;
           throw responseError;
@@ -201,7 +172,6 @@ export function CloudNotebookListView({
             ? body.current_user_avatar.trim()
             : null,
         );
-        clearAppSessionFallbackDeadline();
         setListState({ kind: "ready", notebooks: body.notebooks, totalCount });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -230,7 +200,6 @@ export function CloudNotebookListView({
         );
         return () => {
           window.clearTimeout(deadline);
-          clearAppSessionFallbackDeadline();
           controller.abort();
         };
       }
@@ -254,15 +223,13 @@ export function CloudNotebookListView({
 
     const controller = new AbortController();
     setListState(initialState);
-    void loadNotebookList(controller, "", true);
+    void loadNotebookList(controller, "");
 
     return () => {
-      clearAppSessionFallbackDeadline();
       controller.abort();
     };
   }, [
     appSessionStatus.session,
-    appSessionStatus.status,
     appSessionWaitDeadline,
     authState,
     bootstrap,
@@ -805,19 +772,6 @@ function cloudAuthWithScope(
         ...authState,
         requestedScope,
       };
-}
-
-function cloudNotebookListCanUseExistingCredentials(
-  authState: CloudPrototypeAuthState,
-  appSessionStatus: CloudAppSessionViewState["status"],
-): boolean {
-  if (authState.mode === "oidc" && authState.token) {
-    return true;
-  }
-  // The notebook list endpoint can also succeed with a same-origin app-session
-  // cookie before the status probe confirms it. Once that probe settles without
-  // a session, an expired OIDC token is not a durable fetch credential.
-  return authState.mode === "oidc_expired" && appSessionStatus === "loading";
 }
 
 function initialCloudNotebookListState(


### PR DESCRIPTION
## Summary

- re-arm app-session establishment when an expired stored OIDC identity refreshes into a usable token
- keep actively renewing expired OIDC state inside the hosted-auth recovery projection instead of flashing signed-out chrome
- gate notebook-list requests on the confirmed cookie-backed catalog projection and remove the component-local provisional-401 retry

## Root cause

On a return after the browser credentials had aged out, the same-origin app-session probe could settle before the slower upstream OIDC refresh. The app-session driver saw `oidc_expired` and skipped establishment. When OIDC refresh later produced a valid token, that auth transition did not trigger the session driver, so the next guaranteed attempt was the 60-second cadence tick. Reloading worked because the refreshed token was then present at boot.

The notebook list also bypassed `hostedAuth.canFetchCatalog` and speculatively issued a cookie-only request while no app-session cookie had been confirmed. PR #4090 quieted one form of the resulting 401, but it did not repair the driver ordering and excluded the `oidc_expired` return-after-days path.

This change makes usable OIDC-token transitions a session-driver trigger. Existing single-flight, freshness, and backoff guards still own whether the trigger performs network work. The list now trusts the hosted-auth projection, retains the existing cache/deadline behavior while auth resolves, and fetches immediately when the store confirms the session.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm test:run apps/notebook-cloud/viewer/__tests__/notebook-list-view.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-auth-store.test.ts test/hosted-catalog-auth.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud build`

The full cloud test command completed 1,441 of 1,447 tests successfully. Its six failures are in unchanged current-main surfaces (renderer artifact availability before the prescribed artifact build, workstation accelerator expectation drift, a room-materializer expectation, and standalone callback copy); the focused suites above and production build pass.
