### PR TITLE
styles update: rebuild notebook color tokens from Figma primitives

### DIFF
--- a/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
+++ b/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
@@ -2,24 +2,24 @@ export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
 
 export function viewerThemeFirstPaintStyle(): string {
   return `html {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: #f3f5f8;
+  --foreground: #141820;
   background: var(--background);
   color-scheme: light;
 }
 
 html.light,
 html[data-theme="light"] {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: #f3f5f8;
+  --foreground: #141820;
   background: var(--background);
   color-scheme: light;
 }
 
 html.dark,
 html[data-theme="dark"] {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
+  --background: #141820;
+  --foreground: #fafafa;
   background: var(--background);
   color-scheme: dark;
 }

--- a/apps/notebook-cloud/viewer/oidc-callback-standalone.ts
+++ b/apps/notebook-cloud/viewer/oidc-callback-standalone.ts
@@ -330,14 +330,14 @@ function oidcCallbackStyle(): string {
   return `
 :root {
   color-scheme: light dark;
-  --background: #ffffff;
-  --foreground: oklch(0.145 0 0);
+  --background: #f3f5f8;
+  --foreground: #141820;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
+    --background: #141820;
+    --foreground: #fafafa;
   }
 }
 

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -45,53 +45,53 @@
   --radius-2xl: calc(var(--radius) + 8px);
 }
 
-/* Light mode theme variables (matching main app) */
+/* Light mode theme variables (matching main app, see src/styles/notebook-tokens.css) */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --background: #f3f5f8;
+  --foreground: #141820;
+  --card: #fafafa;
+  --card-foreground: #141820;
+  --popover: #fafafa;
+  --popover-foreground: #141820;
+  --primary: #08ca4a;
+  --primary-foreground: #141820;
+  --secondary: #262626;
+  --secondary-foreground: #f5f5f5;
+  --muted: #fafafa;
+  --muted-foreground: #2d3542;
+  --accent: #e9eef4;
+  --accent-foreground: #2d3542;
+  --destructive: #d00100;
+  --destructive-foreground: #fae6e6;
+  --border: #e1e8f0;
+  --input: #ccd5e1;
+  --ring: #1d4ed8;
   --radius: 0.625rem;
   --markdown-link-underline: color-mix(in oklch, var(--primary) 48%, transparent);
 }
 
-/* Dark mode theme variables (matching main app) */
+/* Dark mode theme variables (matching main app, see src/styles/notebook-tokens.css) */
 .dark,
 [data-theme="dark"] {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --background: #141820;
+  --foreground: #fafafa;
+  --card: #1c2027;
+  --card-foreground: #fafafa;
+  --popover: #1c2027;
+  --popover-foreground: #fafafa;
+  --primary: #96f778;
+  --primary-foreground: #141820;
+  --secondary: #fafafa;
+  --secondary-foreground: #262626;
+  --muted: #1c2027;
+  --muted-foreground: #ccd5e1;
+  --accent: #070707;
+  --accent-foreground: #ccd5e1;
+  --destructive: #d00100;
+  --destructive-foreground: #fae6e6;
+  --border: #37414f;
+  --input: #475569;
+  --ring: #76f050;
   --markdown-link-underline: color-mix(in oklch, var(--primary) 56%, transparent);
 }
 

--- a/src/styles/cream-theme.css
+++ b/src/styles/cream-theme.css
@@ -37,6 +37,46 @@
   --ring: #955f3b;
   --output-document-font: KaTeX_Main, Georgia, "Times New Roman", serif;
 
+  /* ── Semantic tokens added alongside notebook-tokens.css's mode banks.
+     Best-guess warm-palette values derived from the ramps above — not
+     sourced from Figma yet. Revisit against the real cream ramp once one
+     exists. Logo (--logo-mark/--logo-wordmark) is intentionally left
+     un-themed: brand mark stays constant across color themes. ── */
+  --ring-offset: #f5f2ec;
+  --destructive-wash: #f7e6e0;
+  --destructive-wash-foreground: #c4513a;
+  --warning: #f7ecd2;
+  --warning-foreground: #5c4419;
+  --warning-border: #d79921;
+  --info: #e4e9f0;
+  --info-foreground: #324863;
+  --success: #e5e4c4;
+  --success-foreground: #2e2d07;
+  --chart-1: #955f3b;
+  --chart-2: #5e5c0f;
+  --chart-3: #324863;
+  --chart-4: #d79921;
+  --chart-5: #c4513a;
+  --sidebar: #f0ede7;
+  --sidebar-foreground: #1e1a18;
+  --sidebar-primary: #955f3b;
+  --sidebar-primary-foreground: #fffdf9;
+  --sidebar-accent: #ebe6df;
+  --sidebar-accent-foreground: #1e1a18;
+  --sidebar-border: #d8cec3;
+  --sidebar-ring: #955f3b;
+  --alpha-5: #1e1a18f2;
+  --alpha-10: #1e1a18e6;
+  --alpha-20: #1e1a18cc;
+  --alpha-30: #1e1a18b3;
+  --alpha-40: #1e1a1899;
+  --alpha-50: #1e1a1880;
+  --alpha-60: #1e1a1866;
+  --alpha-70: #1e1a184d;
+  --alpha-80: #1e1a1833;
+  --alpha-90: #1e1a181a;
+  --alpha-95: #1e1a180d;
+
   /* ── Gruvbox green (idle status, success) ── */
   --color-green-50: #f4f3e6;
   --color-green-100: #e5e4c4;
@@ -176,6 +216,42 @@
   --ring: #d4896a;
   --output-document-font: KaTeX_Main, Georgia, "Times New Roman", serif;
 
+  /* ── Semantic tokens, best-guess warm-palette values (see light block note) ── */
+  --ring-offset: #1a1816;
+  --destructive-wash: #e07a64;
+  --destructive-wash-foreground: #1a1816;
+  --warning: #d79921;
+  --warning-foreground: #1a1816;
+  --warning-border: #d79921;
+  --info: #3f5878;
+  --info-foreground: #eef0f4;
+  --success: #3d3c0e;
+  --success-foreground: #d5d66c;
+  --chart-1: #d4896a;
+  --chart-2: #b8bb26;
+  --chart-3: #7a96b6;
+  --chart-4: #fabd2f;
+  --chart-5: #e07a64;
+  --sidebar: #201d1b;
+  --sidebar-foreground: #e8e2dc;
+  --sidebar-primary: #d4896a;
+  --sidebar-primary-foreground: #1a1816;
+  --sidebar-accent: #3a3533;
+  --sidebar-accent-foreground: #e8e2dc;
+  --sidebar-border: #3a3533;
+  --sidebar-ring: #d4896a;
+  --alpha-5: #e8e2dcf2;
+  --alpha-10: #e8e2dce6;
+  --alpha-20: #e8e2dccc;
+  --alpha-30: #e8e2dcb3;
+  --alpha-40: #e8e2dc99;
+  --alpha-50: #e8e2dc80;
+  --alpha-60: #e8e2dc66;
+  --alpha-70: #e8e2dc4d;
+  --alpha-80: #e8e2dc33;
+  --alpha-90: #e8e2dc1a;
+  --alpha-95: #e8e2dc0d;
+
   /* ── Gruvbox green (dark) ── */
   --color-green-50: #2a2a0a;
   --color-green-100: #3d3c0e;
@@ -313,6 +389,42 @@
     --border: rgba(255, 255, 255, 0.1);
     --input: rgba(255, 255, 255, 0.15);
     --ring: #d4896a;
+
+    /* ── Semantic tokens, best-guess warm-palette values (see light block note) ── */
+    --ring-offset: #1a1816;
+    --destructive-wash: #e07a64;
+    --destructive-wash-foreground: #1a1816;
+    --warning: #d79921;
+    --warning-foreground: #1a1816;
+    --warning-border: #d79921;
+    --info: #3f5878;
+    --info-foreground: #eef0f4;
+    --success: #3d3c0e;
+    --success-foreground: #d5d66c;
+    --chart-1: #d4896a;
+    --chart-2: #b8bb26;
+    --chart-3: #7a96b6;
+    --chart-4: #fabd2f;
+    --chart-5: #e07a64;
+    --sidebar: #201d1b;
+    --sidebar-foreground: #e8e2dc;
+    --sidebar-primary: #d4896a;
+    --sidebar-primary-foreground: #1a1816;
+    --sidebar-accent: #3a3533;
+    --sidebar-accent-foreground: #e8e2dc;
+    --sidebar-border: #3a3533;
+    --sidebar-ring: #d4896a;
+    --alpha-5: #e8e2dcf2;
+    --alpha-10: #e8e2dce6;
+    --alpha-20: #e8e2dccc;
+    --alpha-30: #e8e2dcb3;
+    --alpha-40: #e8e2dc99;
+    --alpha-50: #e8e2dc80;
+    --alpha-60: #e8e2dc66;
+    --alpha-70: #e8e2dc4d;
+    --alpha-80: #e8e2dc33;
+    --alpha-90: #e8e2dc1a;
+    --alpha-95: #e8e2dc0d;
 
     /* ── Gruvbox green (dark) ── */
     --color-green-50: #2a2a0a;

--- a/src/styles/design-primitives.css
+++ b/src/styles/design-primitives.css
@@ -1,0 +1,144 @@
+/**
+ * Design primitives — the raw ramps exported from Figma (`primitives.json`).
+ *
+ * These are the bottom layer: literal values with no mode awareness. Semantic
+ * tokens in notebook-tokens.css reference them, and product code should reach
+ * for the semantic names (bg-background, text-muted-foreground, …) rather than
+ * a ramp step. Utilities like `bg-storm-700` exist for the cases where a design
+ * genuinely calls out a primitive.
+ *
+ * Brand ramps that share a name with a Tailwind palette (blue/yellow/red) are
+ * prefixed `brand-` so importing this file does not silently repaint every
+ * `text-red-500` in the app. Tailwind's own palette stays intact; cream-theme.css
+ * still overrides `--color-green-*` and friends per color theme.
+ */
+
+@theme {
+  /* ── storm — the neutral spine (backgrounds, text, borders) ── */
+  --color-storm-50: #fafafa;
+  --color-storm-100: #f3f5f8;
+  --color-storm-150: #e9eef4;
+  --color-storm-200: #e1e8f0;
+  --color-storm-250: #d7dfe9;
+  --color-storm-300: #ccd5e1;
+  --color-storm-400: #93a3bb;
+  --color-storm-500: #62748e;
+  --color-storm-600: #475569;
+  --color-storm-700: #37414f;
+  --color-storm-750: #2d3542;
+  --color-storm-800: #222934;
+  --color-storm-825: #1f252e;
+  --color-storm-850: #1c2027;
+  --color-storm-900: #141820;
+  --color-storm-950: #070707;
+
+  /* ── primary green — light-mode brand accent ── */
+  --color-primary-green-50: #e6faed;
+  --color-primary-green-100: #d6f5e3;
+  --color-primary-green-150: #c4f0d6;
+  --color-primary-green-200: #b2efc7;
+  --color-primary-green-300: #9fe7b5;
+  --color-primary-green-400: #8de7ac;
+  --color-primary-green-500: #72e198;
+  --color-primary-green-600: #5adb86;
+  --color-primary-green-700: #08ca4a;
+  --color-primary-green-750: #07b843;
+  --color-primary-green-800: #069a3b;
+  --color-primary-green-850: #068f35;
+  --color-primary-green-900: #046f29;
+  --color-primary-green-925: #03551f;
+  --color-primary-green-950: #023e18;
+
+  /* ── primary green (dark) — dark-mode brand accent ── */
+  --color-primary-green-dark-50: #f0f5ee;
+  --color-primary-green-dark-100: #e5f1e2;
+  --color-primary-green-dark-150: #daeed4;
+  --color-primary-green-dark-200: #ceedc4;
+  --color-primary-green-dark-300: #c1edb3;
+  --color-primary-green-dark-400: #b3efa1;
+  --color-primary-green-dark-500: #a5f28d;
+  --color-primary-green-dark-600: #96f778;
+  --color-primary-green-dark-700: #76f050;
+  --color-primary-green-dark-750: #58e92b;
+  --color-primary-green-dark-800: #44cd1a;
+  --color-primary-green-dark-850: #39a118;
+  --color-primary-green-dark-900: #2c7715;
+  --color-primary-green-dark-925: #1f4f10;
+  --color-primary-green-dark-950: #112909;
+
+  /* ── success green — status, not brand ── */
+  --color-success-green-50: #eaf6e9;
+  --color-success-green-100: #d8efd5;
+  --color-success-green-150: #c7e8c1;
+  --color-success-green-200: #bfe4bb;
+  --color-success-green-300: #a0d79a;
+  --color-success-green-400: #85cb7f;
+  --color-success-green-500: #75c56c;
+  --color-success-green-600: #5ab950;
+  --color-success-green-700: #31a824;
+  --color-success-green-750: #2d9921;
+  --color-success-green-800: #27851d;
+  --color-success-green-850: #23771a;
+  --color-success-green-900: #1b5c14;
+  --color-success-green-925: #184f11;
+  --color-success-green-950: #15470f;
+
+  /* ── brand blue — info, focus ring, links ── */
+  --color-brand-blue-50: #f0f6ff;
+  --color-brand-blue-100: #dde9fe;
+  --color-brand-blue-150: #b9d1fd;
+  --color-brand-blue-200: #78a3ff;
+  --color-brand-blue-300: #4b84ff;
+  --color-brand-blue-400: #3575ff;
+  --color-brand-blue-500: #1d6cf7;
+  --color-brand-blue-600: #1a61de;
+  --color-brand-blue-700: #1756c6;
+  --color-brand-blue-750: #1651b9;
+  --color-brand-blue-800: #114194;
+  --color-brand-blue-850: #0d316f;
+  --color-brand-blue-900: #0a2656;
+  --color-brand-blue-925: #001b56;
+  --color-brand-blue-950: #001b56;
+
+  /* ── brand yellow — warning ── */
+  --color-brand-yellow-50: #fff8e6;
+  --color-brand-yellow-100: #ffeed4;
+  --color-brand-yellow-150: #ffeab2;
+  --color-brand-yellow-200: #ffdf8c;
+  --color-brand-yellow-300: #ffce66;
+  --color-brand-yellow-400: #ffd158;
+  --color-brand-yellow-500: #ffc838;
+  --color-brand-yellow-600: #ffbf20;
+  --color-brand-yellow-700: #ffba06;
+  --color-brand-yellow-750: #e8a905;
+  --color-brand-yellow-800: #dba008;
+  --color-brand-yellow-850: #b58404;
+  --color-brand-yellow-900: #a27d03;
+  --color-brand-yellow-925: #8c6603;
+  --color-brand-yellow-950: #6b4e03;
+
+  /* ── brand red — destructive ── */
+  --color-brand-red-50: #fae6e6;
+  --color-brand-red-100: #f4c9c9;
+  --color-brand-red-150: #f0b0b0;
+  --color-brand-red-200: #e9a3a3;
+  --color-brand-red-300: #e98a8a;
+  --color-brand-red-400: #e66f6f;
+  --color-brand-red-500: #e05554;
+  --color-brand-red-600: #d93f3f;
+  --color-brand-red-700: #d00100;
+  --color-brand-red-750: #bd0100;
+  --color-brand-red-800: #a80000;
+  --color-brand-red-850: #940100;
+  --color-brand-red-900: #820000;
+  --color-brand-red-925: #720100;
+  --color-brand-red-950: #570000;
+
+  /* ── logo — fixed marks, not mode-derived (see --logo-* for the mode pair) ── */
+  --color-logo-mark: #31a824;
+  --color-logo-wordmark: #06262d;
+
+  /* ── translucent scrims, one per surface polarity ── */
+  --color-alpha-light-5: #5f6e9f1a;
+  --color-alpha-dark-5: #dee2eb1a;
+}

--- a/src/styles/notebook-base.css
+++ b/src/styles/notebook-base.css
@@ -1,29 +1,8 @@
 @import "./notebook-tokens.css";
 
-/* Fallback: apply dark theme when system prefers dark and no explicit light class */
-@media (prefers-color-scheme: dark) {
-  :root:not(.light) {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --destructive-foreground: oklch(0.985 0 0);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-  }
-}
+/* Mode selection — explicit .dark / [data-theme] signals plus the
+   prefers-color-scheme fallback — lives in notebook-tokens.css so every host
+   resolves modes from one place. */
 
 body {
   font-family:

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -1,4 +1,30 @@
-@custom-variant dark (&:is(.dark *));
+/**
+ * Semantic design tokens — the authoritative token set for every nteract
+ * surface (desktop shell, cloud viewer, Elements, sift, design-sync).
+ *
+ * Structure, bottom to top:
+ *   1. design-primitives.css — raw Figma ramps (storm, primary-green, …).
+ *   2. The `--mode-light-*` / `--mode-dark-*` banks below — the only place a
+ *      literal color value for a mode lives.
+ *   3. The three mode selectors, which do nothing but point the semantic names
+ *      at one bank or the other. Adding a token means one value in each bank
+ *      and one `var()` line per selector; it never means retyping a hex.
+ *   4. `@theme inline`, which exposes the semantic names as Tailwind utilities
+ *      (bg-background, text-muted-foreground, border-input, …).
+ *
+ * Product code should use the semantic utilities. Reach into a primitive ramp
+ * only when a design explicitly calls out a ramp step.
+ *
+ * Dark mode is dual-keyed on `.dark` and `[data-theme="dark"]` to match the
+ * isolated-renderer/host-bridge convention (isolated-renderer/styles.css,
+ * frame.html): consumers may signal dark via the class (app shell) or the
+ * attribute (iframe/demo hosts). The `prefers-color-scheme` block covers hosts
+ * that set no explicit signal at all; an explicit light signal opts out.
+ */
+
+@import "./design-primitives.css";
+
+@custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
 @theme inline {
   --color-background: var(--background);
@@ -20,67 +46,388 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-ring-offset: var(--ring-offset);
+
+  /* Status intents. `warning`/`info`/`success` are surface washes paired with a
+     legible `-foreground`, so `bg-warning text-warning-foreground` reads in
+     both modes without per-mode opacity juggling. */
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-border: var(--warning-border);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+
+  /* Destructive has two shapes. `destructive` is the solid intent used by
+     `text-destructive` and the button's destructive variant; `destructive-wash`
+     is the tinted surface the design system pairs with solid red text. */
+  --color-destructive-wash: var(--destructive-wash);
+  --color-destructive-wash-foreground: var(--destructive-wash-foreground);
+
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  /* Mode-aware logo pair. The fixed brand marks stay on
+     --color-logo-mark/--color-logo-wordmark in design-primitives.css. */
+  --color-logo: var(--logo-mark);
+  --color-logo-text: var(--logo-wordmark);
+
+  /* Scrim ramp. Numbers follow Figma: a lower number is *more* opaque. */
+  --color-alpha-5: var(--alpha-5);
+  --color-alpha-10: var(--alpha-10);
+  --color-alpha-20: var(--alpha-20);
+  --color-alpha-30: var(--alpha-30);
+  --color-alpha-40: var(--alpha-40);
+  --color-alpha-50: var(--alpha-50);
+  --color-alpha-60: var(--alpha-60);
+  --color-alpha-70: var(--alpha-70);
+  --color-alpha-80: var(--alpha-80);
+  --color-alpha-90: var(--alpha-90);
+  --color-alpha-95: var(--alpha-95);
+
   --color-uv: #de5fe9;
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
-  --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
+  /* Radii are literal token values, not deltas off --radius: the Figma scale is
+     non-linear (2, 6, 8, 10, 14, 18, 22, 26), so arithmetic can't express it. */
+  --radius-xs: 2px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-xl: 14px;
+  --radius-2xl: 18px;
+  --radius-3xl: 22px;
+  --radius-4xl: 26px;
 }
 
+/* ────────────────────────────────────────────────────────────────────────────
+   Mode banks — the single home for every literal per-mode color value.
+   ──────────────────────────────────────────────────────────────────────────── */
+
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  /* ── light ── */
+  --mode-light-background: #f3f5f8; /* storm-100 */
+  --mode-light-foreground: #141820; /* storm-900 */
+  --mode-light-card: #fafafa; /* storm-50 */
+  --mode-light-card-foreground: #141820;
+  --mode-light-popover: #fafafa;
+  --mode-light-popover-foreground: #141820;
+  --mode-light-primary: #08ca4a; /* primary-green-700 */
+  --mode-light-primary-foreground: #141820;
+  --mode-light-secondary: #262626;
+  --mode-light-secondary-foreground: #f5f5f5;
+  --mode-light-muted: #fafafa;
+  --mode-light-muted-foreground: #2d3542; /* storm-750 */
+  --mode-light-accent: #e9eef4; /* storm-150 */
+  --mode-light-accent-foreground: #2d3542;
+  --mode-light-border: #e1e8f0; /* storm-200 */
+  --mode-light-input: #ccd5e1; /* storm-300 */
+  --mode-light-ring: #1d4ed8;
+  --mode-light-ring-offset: #f3f5f8;
+  --mode-light-destructive: #d00100; /* brand-red-700 */
+  --mode-light-destructive-foreground: #fae6e6; /* brand-red-50 */
+  --mode-light-destructive-wash: #fae6e6;
+  --mode-light-destructive-wash-foreground: #d00100;
+  --mode-light-warning: #ffeed4; /* brand-yellow-100 */
+  --mode-light-warning-foreground: #6b4e03; /* brand-yellow-950 */
+  --mode-light-warning-border: #ffba06; /* brand-yellow-700 */
+  --mode-light-info: #dde9fe; /* brand-blue-100 */
+  --mode-light-info-foreground: #1a61de; /* brand-blue-600 */
+  --mode-light-success: #d8efd5; /* success-green-100 */
+  --mode-light-success-foreground: #15470f; /* success-green-950 */
+  --mode-light-chart-1: #ea580c;
+  --mode-light-chart-2: #0d9488;
+  --mode-light-chart-3: #164e63;
+  --mode-light-chart-4: #fbbf24;
+  --mode-light-chart-5: #e11d48;
+  --mode-light-sidebar: #f3f5f8;
+  --mode-light-sidebar-foreground: #070707; /* storm-950 */
+  --mode-light-sidebar-primary: #070707;
+  --mode-light-sidebar-primary-foreground: #fafafa;
+  --mode-light-sidebar-accent: #ccd5e1;
+  --mode-light-sidebar-accent-foreground: #37414f; /* storm-700 */
+  --mode-light-sidebar-border: #ccd5e1;
+  --mode-light-sidebar-ring: #1a61de;
+  --mode-light-logo-mark: #31a824; /* success-green-700 */
+  --mode-light-logo-wordmark: #06262d;
+  --mode-light-alpha-5: #10121af2;
+  --mode-light-alpha-10: #10121ae6;
+  --mode-light-alpha-20: #10121acc;
+  --mode-light-alpha-30: #10121ab3;
+  --mode-light-alpha-40: #10121a99;
+  --mode-light-alpha-50: #10121a80;
+  --mode-light-alpha-60: #10121a66;
+  --mode-light-alpha-70: #10121a4d;
+  --mode-light-alpha-80: #10121a33;
+  --mode-light-alpha-90: #10121a1a;
+  --mode-light-alpha-95: #10121a0d;
+
+  /* ── dark ── */
+  --mode-dark-background: #141820; /* storm-900 */
+  --mode-dark-foreground: #fafafa; /* storm-50 */
+  --mode-dark-card: #1c2027; /* storm-850 */
+  --mode-dark-card-foreground: #fafafa;
+  --mode-dark-popover: #1c2027;
+  --mode-dark-popover-foreground: #fafafa;
+  --mode-dark-primary: #96f778; /* primary-green-dark-600 */
+  --mode-dark-primary-foreground: #141820;
+  --mode-dark-secondary: #fafafa;
+  --mode-dark-secondary-foreground: #262626;
+  --mode-dark-muted: #1c2027;
+  --mode-dark-muted-foreground: #ccd5e1; /* storm-300 */
+  --mode-dark-accent: #070707; /* storm-950 */
+  --mode-dark-accent-foreground: #ccd5e1;
+  --mode-dark-border: #37414f; /* storm-700 */
+  --mode-dark-input: #475569; /* storm-600 */
+  --mode-dark-ring: #76f050; /* primary-green-dark-700 */
+  --mode-dark-ring-offset: #141820;
+  --mode-dark-destructive: #d00100; /* brand-red-700 */
+  --mode-dark-destructive-foreground: #fae6e6; /* brand-red-50 */
+  --mode-dark-destructive-wash: #d00100;
+  --mode-dark-destructive-wash-foreground: #fae6e6;
+  --mode-dark-warning: #ffba06; /* brand-yellow-700 */
+  --mode-dark-warning-foreground: #171717;
+  --mode-dark-warning-border: #ffba06;
+  --mode-dark-info: #1756c6; /* brand-blue-700 */
+  --mode-dark-info-foreground: #f0f6ff; /* brand-blue-50 */
+  --mode-dark-success: #1b5c14; /* success-green-900 */
+  --mode-dark-success-foreground: #eaf6e9; /* success-green-50 */
+  --mode-dark-chart-1: #c2410c;
+  --mode-dark-chart-2: #10b981;
+  --mode-dark-chart-3: #0891b2;
+  --mode-dark-chart-4: #f59e0b;
+  --mode-dark-chart-5: #f43f5e;
+  --mode-dark-sidebar: #141820;
+  --mode-dark-sidebar-foreground: #fafafa;
+  --mode-dark-sidebar-primary: #1a61de; /* brand-blue-600 */
+  --mode-dark-sidebar-primary-foreground: #fafafa;
+  --mode-dark-sidebar-accent: #222934; /* storm-800 */
+  --mode-dark-sidebar-accent-foreground: #ccd5e1;
+  --mode-dark-sidebar-border: #222934;
+  --mode-dark-sidebar-ring: #96f778;
+  --mode-dark-logo-mark: #96f778;
+  --mode-dark-logo-wordmark: #fafafa;
+  --mode-dark-alpha-5: #fbfbfbf2;
+  --mode-dark-alpha-10: #fbfbfbe6;
+  --mode-dark-alpha-20: #fbfbfbcc;
+  --mode-dark-alpha-30: #fbfbfbb3;
+  --mode-dark-alpha-40: #fbfbfb99;
+  --mode-dark-alpha-50: #fbfbfb80;
+  --mode-dark-alpha-60: #fbfbfb66;
+  --mode-dark-alpha-70: #fbfbfb4d;
+  --mode-dark-alpha-80: #fbfbfb33;
+  --mode-dark-alpha-90: #fbfbfb1a;
+  --mode-dark-alpha-95: #fbfbfb0d;
+}
+
+/* ── Light: the default, and whatever explicitly opts into light ── */
+:root,
+.light,
+[data-theme="light"] {
+  color-scheme: light;
+
+  --background: var(--mode-light-background);
+  --foreground: var(--mode-light-foreground);
+  --card: var(--mode-light-card);
+  --card-foreground: var(--mode-light-card-foreground);
+  --popover: var(--mode-light-popover);
+  --popover-foreground: var(--mode-light-popover-foreground);
+  --primary: var(--mode-light-primary);
+  --primary-foreground: var(--mode-light-primary-foreground);
+  --secondary: var(--mode-light-secondary);
+  --secondary-foreground: var(--mode-light-secondary-foreground);
+  --muted: var(--mode-light-muted);
+  --muted-foreground: var(--mode-light-muted-foreground);
+  --accent: var(--mode-light-accent);
+  --accent-foreground: var(--mode-light-accent-foreground);
+  --border: var(--mode-light-border);
+  --input: var(--mode-light-input);
+  --ring: var(--mode-light-ring);
+  --ring-offset: var(--mode-light-ring-offset);
+  --destructive: var(--mode-light-destructive);
+  --destructive-foreground: var(--mode-light-destructive-foreground);
+  --destructive-wash: var(--mode-light-destructive-wash);
+  --destructive-wash-foreground: var(--mode-light-destructive-wash-foreground);
+  --warning: var(--mode-light-warning);
+  --warning-foreground: var(--mode-light-warning-foreground);
+  --warning-border: var(--mode-light-warning-border);
+  --info: var(--mode-light-info);
+  --info-foreground: var(--mode-light-info-foreground);
+  --success: var(--mode-light-success);
+  --success-foreground: var(--mode-light-success-foreground);
+  --chart-1: var(--mode-light-chart-1);
+  --chart-2: var(--mode-light-chart-2);
+  --chart-3: var(--mode-light-chart-3);
+  --chart-4: var(--mode-light-chart-4);
+  --chart-5: var(--mode-light-chart-5);
+  --sidebar: var(--mode-light-sidebar);
+  --sidebar-foreground: var(--mode-light-sidebar-foreground);
+  --sidebar-primary: var(--mode-light-sidebar-primary);
+  --sidebar-primary-foreground: var(--mode-light-sidebar-primary-foreground);
+  --sidebar-accent: var(--mode-light-sidebar-accent);
+  --sidebar-accent-foreground: var(--mode-light-sidebar-accent-foreground);
+  --sidebar-border: var(--mode-light-sidebar-border);
+  --sidebar-ring: var(--mode-light-sidebar-ring);
+  --logo-mark: var(--mode-light-logo-mark);
+  --logo-wordmark: var(--mode-light-logo-wordmark);
+  --alpha-5: var(--mode-light-alpha-5);
+  --alpha-10: var(--mode-light-alpha-10);
+  --alpha-20: var(--mode-light-alpha-20);
+  --alpha-30: var(--mode-light-alpha-30);
+  --alpha-40: var(--mode-light-alpha-40);
+  --alpha-50: var(--mode-light-alpha-50);
+  --alpha-60: var(--mode-light-alpha-60);
+  --alpha-70: var(--mode-light-alpha-70);
+  --alpha-80: var(--mode-light-alpha-80);
+  --alpha-90: var(--mode-light-alpha-90);
+  --alpha-95: var(--mode-light-alpha-95);
+
   --radius: 0.625rem;
   --output-ui-font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --output-mono-font: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   --output-document-font: var(--output-ui-font);
 }
 
-/* Dual-keyed to match the isolated-renderer/host-bridge convention
-   (isolated-renderer/styles.css, frame.html): consumers may signal dark via
-   the .dark class (app shell) or data-theme="dark" (iframe/demo hosts). */
+/* ── Dark: explicit signal ── */
 .dark,
 [data-theme="dark"] {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  color-scheme: dark;
+
+  --background: var(--mode-dark-background);
+  --foreground: var(--mode-dark-foreground);
+  --card: var(--mode-dark-card);
+  --card-foreground: var(--mode-dark-card-foreground);
+  --popover: var(--mode-dark-popover);
+  --popover-foreground: var(--mode-dark-popover-foreground);
+  --primary: var(--mode-dark-primary);
+  --primary-foreground: var(--mode-dark-primary-foreground);
+  --secondary: var(--mode-dark-secondary);
+  --secondary-foreground: var(--mode-dark-secondary-foreground);
+  --muted: var(--mode-dark-muted);
+  --muted-foreground: var(--mode-dark-muted-foreground);
+  --accent: var(--mode-dark-accent);
+  --accent-foreground: var(--mode-dark-accent-foreground);
+  --border: var(--mode-dark-border);
+  --input: var(--mode-dark-input);
+  --ring: var(--mode-dark-ring);
+  --ring-offset: var(--mode-dark-ring-offset);
+  --destructive: var(--mode-dark-destructive);
+  --destructive-foreground: var(--mode-dark-destructive-foreground);
+  --destructive-wash: var(--mode-dark-destructive-wash);
+  --destructive-wash-foreground: var(--mode-dark-destructive-wash-foreground);
+  --warning: var(--mode-dark-warning);
+  --warning-foreground: var(--mode-dark-warning-foreground);
+  --warning-border: var(--mode-dark-warning-border);
+  --info: var(--mode-dark-info);
+  --info-foreground: var(--mode-dark-info-foreground);
+  --success: var(--mode-dark-success);
+  --success-foreground: var(--mode-dark-success-foreground);
+  --chart-1: var(--mode-dark-chart-1);
+  --chart-2: var(--mode-dark-chart-2);
+  --chart-3: var(--mode-dark-chart-3);
+  --chart-4: var(--mode-dark-chart-4);
+  --chart-5: var(--mode-dark-chart-5);
+  --sidebar: var(--mode-dark-sidebar);
+  --sidebar-foreground: var(--mode-dark-sidebar-foreground);
+  --sidebar-primary: var(--mode-dark-sidebar-primary);
+  --sidebar-primary-foreground: var(--mode-dark-sidebar-primary-foreground);
+  --sidebar-accent: var(--mode-dark-sidebar-accent);
+  --sidebar-accent-foreground: var(--mode-dark-sidebar-accent-foreground);
+  --sidebar-border: var(--mode-dark-sidebar-border);
+  --sidebar-ring: var(--mode-dark-sidebar-ring);
+  --logo-mark: var(--mode-dark-logo-mark);
+  --logo-wordmark: var(--mode-dark-logo-wordmark);
+  --alpha-5: var(--mode-dark-alpha-5);
+  --alpha-10: var(--mode-dark-alpha-10);
+  --alpha-20: var(--mode-dark-alpha-20);
+  --alpha-30: var(--mode-dark-alpha-30);
+  --alpha-40: var(--mode-dark-alpha-40);
+  --alpha-50: var(--mode-dark-alpha-50);
+  --alpha-60: var(--mode-dark-alpha-60);
+  --alpha-70: var(--mode-dark-alpha-70);
+  --alpha-80: var(--mode-dark-alpha-80);
+  --alpha-90: var(--mode-dark-alpha-90);
+  --alpha-95: var(--mode-dark-alpha-95);
+}
+
+/* ── Dark: system preference, for hosts that set no explicit signal ──
+   The `:not(...)` list is deliberately one selector, not chained `:not()`s:
+   a list takes the specificity of its most specific argument, so this stays at
+   (0,2,0) and cream-theme.css's `[data-color-theme="cream"]:not(.light)` can
+   still override it on source order. Chaining would make it (0,3,0) and no
+   color theme could opt out of the system-dark fallback. */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light, [data-theme="light"]) {
+    color-scheme: dark;
+
+    --background: var(--mode-dark-background);
+    --foreground: var(--mode-dark-foreground);
+    --card: var(--mode-dark-card);
+    --card-foreground: var(--mode-dark-card-foreground);
+    --popover: var(--mode-dark-popover);
+    --popover-foreground: var(--mode-dark-popover-foreground);
+    --primary: var(--mode-dark-primary);
+    --primary-foreground: var(--mode-dark-primary-foreground);
+    --secondary: var(--mode-dark-secondary);
+    --secondary-foreground: var(--mode-dark-secondary-foreground);
+    --muted: var(--mode-dark-muted);
+    --muted-foreground: var(--mode-dark-muted-foreground);
+    --accent: var(--mode-dark-accent);
+    --accent-foreground: var(--mode-dark-accent-foreground);
+    --border: var(--mode-dark-border);
+    --input: var(--mode-dark-input);
+    --ring: var(--mode-dark-ring);
+    --ring-offset: var(--mode-dark-ring-offset);
+    --destructive: var(--mode-dark-destructive);
+    --destructive-foreground: var(--mode-dark-destructive-foreground);
+    --destructive-wash: var(--mode-dark-destructive-wash);
+    --destructive-wash-foreground: var(--mode-dark-destructive-wash-foreground);
+    --warning: var(--mode-dark-warning);
+    --warning-foreground: var(--mode-dark-warning-foreground);
+    --warning-border: var(--mode-dark-warning-border);
+    --info: var(--mode-dark-info);
+    --info-foreground: var(--mode-dark-info-foreground);
+    --success: var(--mode-dark-success);
+    --success-foreground: var(--mode-dark-success-foreground);
+    --chart-1: var(--mode-dark-chart-1);
+    --chart-2: var(--mode-dark-chart-2);
+    --chart-3: var(--mode-dark-chart-3);
+    --chart-4: var(--mode-dark-chart-4);
+    --chart-5: var(--mode-dark-chart-5);
+    --sidebar: var(--mode-dark-sidebar);
+    --sidebar-foreground: var(--mode-dark-sidebar-foreground);
+    --sidebar-primary: var(--mode-dark-sidebar-primary);
+    --sidebar-primary-foreground: var(--mode-dark-sidebar-primary-foreground);
+    --sidebar-accent: var(--mode-dark-sidebar-accent);
+    --sidebar-accent-foreground: var(--mode-dark-sidebar-accent-foreground);
+    --sidebar-border: var(--mode-dark-sidebar-border);
+    --sidebar-ring: var(--mode-dark-sidebar-ring);
+    --logo-mark: var(--mode-dark-logo-mark);
+    --logo-wordmark: var(--mode-dark-logo-wordmark);
+    --alpha-5: var(--mode-dark-alpha-5);
+    --alpha-10: var(--mode-dark-alpha-10);
+    --alpha-20: var(--mode-dark-alpha-20);
+    --alpha-30: var(--mode-dark-alpha-30);
+    --alpha-40: var(--mode-dark-alpha-40);
+    --alpha-50: var(--mode-dark-alpha-50);
+    --alpha-60: var(--mode-dark-alpha-60);
+    --alpha-70: var(--mode-dark-alpha-70);
+    --alpha-80: var(--mode-dark-alpha-80);
+    --alpha-90: var(--mode-dark-alpha-90);
+    --alpha-95: var(--mode-dark-alpha-95);
+  }
 }
 
 @keyframes queue-breathe {


### PR DESCRIPTION
Rebuilds notebook colors from Figma primitives (design-primitives.css) instead of the placeholder shadcn grayscale defaults. notebook-tokens.css now has one light/dark bank per token, plus new semantic tokens: warning, info, success, destructive-wash, chart-1..5, sidebar-*, alpha-5..95.

Also synced the token copies in isolated-renderer/styles.css, viewer-theme-bootstrap.ts, and oidc-callback-standalone.ts (previously stuck on the old grayscale), and added cream-theme overrides for the new tokens (best-guess values, not yet from Figma — flagged inline).
