### PR TITLE
feat(notebook): redesign workstations panel layout and simplify pairing steps

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -456,7 +456,7 @@ async function assertOwnerBlockedWorkstationStates({
   const offlineDefault = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
     expectedLabel: "Review compute",
-    expectedPanelText: "No heartbeat from this workstation recently.",
+    expectedPanelText: "Offline workstation",
     expectedTitleIncludes: ["Open workstations panel"],
     registry: {
       default_workstation_id: workstationId,

--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -377,6 +377,7 @@ describe("cloud workstations client", () => {
           id: "path",
           label: "Use installed CLI in this shell",
           command: CLOUD_WORKSTATION_PATH_EXPORT_COMMAND,
+          optional: true,
         },
         {
           id: "connect",
@@ -387,6 +388,7 @@ describe("cloud workstations client", () => {
           id: "run",
           label: "Linux user systemd service",
           command: cloudWorkstationServiceInstallCommand(),
+          recommended: true,
         },
         {
           id: "foreground-run",

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
@@ -158,6 +158,8 @@ describe("useCloudWorkstationManager pairing", () => {
       "runt workstation run",
     ]);
     expect(pairing?.commands[0]?.optional).toBe(true);
+    expect(pairing?.commands[2]?.optional).toBe(true);
+    expect(pairing?.commands[4]?.recommended).toBe(true);
     expect(pairing?.commands[5]?.optional).toBe(true);
   });
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -31,6 +31,7 @@ import {
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
   NotebookWorkstationsPanel,
+  NotebookWorkstationsPanelAction,
   KernelLaunchErrorBanner,
   projectNotebookCommandRuntimeStatusFromRuntimeState,
   shouldShowKernelLaunchErrorBanner,
@@ -1581,6 +1582,14 @@ export function NotebookViewer({
             pairing={workstationPairing}
             onStartPairing={onStartPairing}
             onCancelPairing={onCancelPairing}
+          />
+        ) : undefined
+      }
+      workstationsPanelAction={
+        shouldShowCloudWorkstationsPanel ? (
+          <NotebookWorkstationsPanelAction
+            pairing={workstationPairing}
+            onStartPairing={onStartPairing}
           />
         ) : undefined
       }

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -29,6 +29,8 @@ export interface CloudWorkstationPairingCommand {
   label: string;
   command: string;
   optional?: boolean;
+  /** Not the only way to satisfy this step, but the one most hosts should use. */
+  recommended?: boolean;
 }
 
 interface CloudWorkstationsResponse {
@@ -241,6 +243,9 @@ export function cloudWorkstationPairingCommands(
       id: "path",
       label: "Use installed CLI in this shell",
       command: CLOUD_WORKSTATION_PATH_EXPORT_COMMAND,
+      // Only needed in the same shell you ran the installer in — a fresh
+      // terminal already has `runt` on PATH.
+      optional: true,
     },
     {
       id: "connect",
@@ -251,6 +256,7 @@ export function cloudWorkstationPairingCommands(
       id: "run",
       label: "Linux user systemd service",
       command: cloudWorkstationServiceInstallCommand(),
+      recommended: true,
     },
     {
       id: "foreground-run",

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -37,6 +37,8 @@ export interface NotebookRailProps {
   packagesPanel: ReactNode;
   commentsPanel?: ReactNode;
   workstationsPanel?: ReactNode;
+  /** Rendered inline with the Workstations panel title. */
+  workstationsPanelAction?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
@@ -61,6 +63,7 @@ export function NotebookRail({
   packagesPanel,
   commentsPanel,
   workstationsPanel,
+  workstationsPanelAction,
   onActivePanelChange,
   onCollapsedChange,
   onSelectOutlineItem,
@@ -90,8 +93,8 @@ export function NotebookRail({
       activePanelId={activePanelId}
       collapsed={collapsed}
       items={railButtons}
-      panelEyebrow="Notebook"
       panelTitle={title}
+      panelAction={activePanelId === "workstations" ? workstationsPanelAction : undefined}
       panelClassName={NOTEBOOK_RAIL_PANEL_CLASS_NAME}
       className={className}
       dataTestId="notebook-rail"

--- a/src/components/notebook/NotebookDocumentRail.tsx
+++ b/src/components/notebook/NotebookDocumentRail.tsx
@@ -14,6 +14,7 @@ export interface NotebookDocumentRailProps {
   packagesPanel: ReactNode;
   commentsPanel?: ReactNode;
   workstationsPanel?: ReactNode;
+  workstationsPanelAction?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
@@ -32,6 +33,7 @@ export function NotebookDocumentRail({
   packagesPanel,
   commentsPanel,
   workstationsPanel,
+  workstationsPanelAction,
   onActivePanelChange,
   onCollapsedChange,
   onSelectOutlineItem,
@@ -50,6 +52,7 @@ export function NotebookDocumentRail({
       packagesPanel={packagesPanel}
       commentsPanel={commentsPanel}
       workstationsPanel={workstationsPanel}
+      workstationsPanelAction={workstationsPanelAction}
       onActivePanelChange={onActivePanelChange}
       onCollapsedChange={onCollapsedChange}
       onSelectOutlineItem={onSelectOutlineItem}

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   Check,
   ChevronDown,
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
   projectNotebookWorkstationPanel,
   type NotebookShellCapabilities,
@@ -27,7 +28,6 @@ import {
   type NotebookRegisteredWorkstationFactProjection,
   type NotebookRegisteredWorkstationProjection,
   type NotebookWorkstationFactProjection,
-  type NotebookWorkstationPanelTone,
   type NotebookWorkstationSelectionProjection,
 } from "./capabilities";
 import { cn } from "@/lib/utils";
@@ -47,6 +47,8 @@ export interface NotebookWorkstationPairingCommandView {
   label: string;
   command: string;
   optional?: boolean;
+  /** Not the only way to satisfy this step, but the one most hosts should use. */
+  recommended?: boolean;
 }
 
 export interface NotebookWorkstationsPanelProps {
@@ -74,110 +76,27 @@ export function NotebookWorkstationsPanel({
   onCancelPairing,
   statusMessage = null,
 }: NotebookWorkstationsPanelProps) {
+  const [selectedWorkstationId, setSelectedWorkstationId] = useState<string | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const projection = projectNotebookWorkstationPanel(capabilities);
-  const status = workstationStatusTone(projection.tone);
   const showRegistrationPrompt = selection?.state === "needs_registration";
   const registeredWorkstations = selection?.registeredWorkstations ?? [];
-  const compactDetachedTarget =
-    projection.targetId === "workstation:none" && registeredWorkstations.length > 0;
-  const compactRecoverableTarget =
-    !compactDetachedTarget &&
-    Boolean(
-      projection.targetId &&
-      projection.targetId !== "workstation:none" &&
-      registeredWorkstations.some(
-        (workstation) =>
-          workstation.id === projection.targetId &&
-          !workstation.isAttached &&
-          workstation.canAttach,
-      ),
-    );
-  const compactTargetFacts = compactDetachedTarget || compactRecoverableTarget;
-  const activeRegisteredWorkstationId =
-    registeredWorkstations.find((workstation) => workstation.isAttached)?.id ??
-    (!selection && projection.targetId && projection.targetId !== "workstation:none"
-      ? projection.targetId
-      : null);
-  const hasVisibleRegisteredWorkstations = registeredWorkstations.some((workstation) =>
-    shouldShowRegisteredWorkstation(workstation, activeRegisteredWorkstationId),
-  );
+  const hasVisibleRegisteredWorkstations = registeredWorkstations.length > 0;
+  const selectedWorkstation =
+    registeredWorkstations.find((workstation) => workstation.id === selectedWorkstationId) ?? null;
+  // Per-workstation messages belong to the details section, never above the list.
   const visibleStatusMessage =
     statusMessage &&
     !registeredWorkstations.some((workstation) => workstation.statusMessage === statusMessage)
       ? statusMessage
       : null;
-  const visibleTargetId =
-    projection.targetId &&
-    !compactRecoverableTarget &&
-    projection.targetKind !== "local_daemon" &&
-    projection.targetId !== "workstation:none"
-      ? `id ${projection.targetId}`
-      : null;
 
   return (
-    <div className={cn("space-y-3 text-sm", className)} data-testid="notebook-workstations-panel">
-      <section
-        className={cn("space-y-2 border-b border-border/70", compactTargetFacts ? "pb-2" : "pb-3")}
-        aria-label="Active workstation target"
-      >
-        <div className="flex min-w-0 items-start gap-3">
-          <status.icon
-            className={cn("mt-0.5 size-4 shrink-0", status.iconClassName)}
-            aria-hidden="true"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-              <h3 className="truncate text-sm font-semibold">{projection.title}</h3>
-              <span className={cn("shrink-0 text-xs font-medium", status.textClassName)}>
-                {projection.statusLabel}
-              </span>
-            </div>
-            {projection.detail ? (
-              <p className="mt-1 text-xs leading-5 text-muted-foreground">{projection.detail}</p>
-            ) : null}
-            {visibleTargetId ? (
-              <div className="mt-1 truncate font-mono text-[10.5px] tracking-normal text-muted-foreground">
-                {visibleTargetId}
-              </div>
-            ) : null}
-          </div>
-        </div>
-
-        {compactTargetFacts ? null : (
-          <div className="flex min-w-0 flex-wrap gap-x-3 gap-y-1.5 text-xs">
-            {projection.facts.map((fact) => (
-              <WorkstationFact
-                key={fact.kind}
-                fact={fact}
-                icon={workstationFactIcon(fact, projection.source)}
-              />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {visibleStatusMessage ? (
-        <section className="text-xs leading-5 text-muted-foreground" aria-live="polite">
-          {visibleStatusMessage}
-        </section>
-      ) : null}
-
-      {hasVisibleRegisteredWorkstations ? (
-        <section className="space-y-1.5" aria-label="Registered workstations">
-          {registeredWorkstations.map((workstation) =>
-            shouldShowRegisteredWorkstation(workstation, activeRegisteredWorkstationId) ? (
-              <RegisteredWorkstationRow
-                key={workstation.id}
-                busy={busyWorkstationId === workstation.id}
-                workstation={workstation}
-                onAttachWorkstation={onAttachWorkstation}
-                onSetDefaultWorkstation={onSetDefaultWorkstation}
-              />
-            ) : null,
-          )}
-        </section>
-      ) : null}
-
+    <div
+      className={cn("flex min-h-full flex-col gap-3 text-sm", className)}
+      data-testid="notebook-workstations-panel"
+    >
+      {/* Pairing opens directly under the rail header so the flow reads top-down. */}
       {pairing ? (
         <WorkstationPairingCard
           pairing={pairing}
@@ -185,6 +104,88 @@ export function NotebookWorkstationsPanel({
           onRestart={onStartPairing}
         />
       ) : null}
+
+      {hasVisibleRegisteredWorkstations ? (
+        <section
+          aria-label="Registered workstations"
+          className={cn("-mx-3 flex-1", pairing ? undefined : "-mt-3")}
+        >
+          <ul className="divide-y divide-border/70 border-b border-border/70">
+            {registeredWorkstations.map((workstation) => (
+              <RegisteredWorkstationRow
+                key={workstation.id}
+                busy={busyWorkstationId === workstation.id}
+                selected={workstation.id === selectedWorkstationId}
+                workstation={workstation}
+                onAttachWorkstation={onAttachWorkstation}
+                onSelect={() => {
+                  setSelectedWorkstationId(workstation.id);
+                  setDetailsOpen(true);
+                }}
+              />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {visibleStatusMessage ? (
+        <section className="text-xs leading-5 text-muted-foreground" aria-live="polite">
+          {visibleStatusMessage}
+        </section>
+      ) : null}
+
+      <section
+        aria-label="Workstation details"
+        className={hasVisibleRegisteredWorkstations ? "mt-auto" : undefined}
+      >
+        <PanelSection title="Workstation details" open={detailsOpen} onOpenChange={setDetailsOpen}>
+          {selectedWorkstation ? (
+            <div className="space-y-2">
+              <div className="min-w-0">
+                <h4 className="truncate text-sm font-semibold text-foreground">
+                  {selectedWorkstation.displayName}
+                </h4>
+                <div className="truncate font-mono text-[10.5px] tracking-normal text-muted-foreground">
+                  {selectedWorkstation.idLabel}
+                </div>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  {selectedWorkstation.isAttached ? "Running" : selectedWorkstation.statusLabel}
+                </p>
+              </div>
+              <div className="grid min-w-0 gap-1.5">
+                {registeredWorkstationDetailFacts(selectedWorkstation).map((fact) => (
+                  <RegisteredWorkstationFact key={fact.kind} fact={fact} />
+                ))}
+              </div>
+              {onSetDefaultWorkstation && !selectedWorkstation.isDefault ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={busyWorkstationId === selectedWorkstation.id}
+                  onClick={() => onSetDefaultWorkstation(selectedWorkstation.id)}
+                >
+                  Set default
+                </Button>
+              ) : null}
+            </div>
+          ) : hasVisibleRegisteredWorkstations ? (
+            <p className="text-xs leading-5 text-muted-foreground">
+              Select a workstation above to see its details.
+            </p>
+          ) : (
+            <div className="flex min-w-0 flex-wrap gap-x-3 gap-y-1.5 text-xs">
+              {projection.facts.map((fact) => (
+                <WorkstationFact
+                  key={fact.kind}
+                  fact={fact}
+                  icon={workstationFactIcon(fact, projection.source)}
+                />
+              ))}
+            </div>
+          )}
+        </PanelSection>
+      </section>
 
       {showRegistrationPrompt && !pairing ? (
         <section
@@ -199,38 +200,76 @@ export function NotebookWorkstationsPanel({
           <p className="leading-5 text-muted-foreground">
             Connect a machine you own to run this notebook&rsquo;s compute there.
           </p>
-          {onStartPairing ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="mt-1"
-              onClick={onStartPairing}
-              data-testid="workstation-add-button"
-            >
-              <Plus className="size-3.5" aria-hidden="true" />
-              Add workstation
-            </Button>
-          ) : null}
-        </section>
-      ) : null}
-
-      {!showRegistrationPrompt && !pairing && onStartPairing ? (
-        <section aria-label="Workstation setup">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="text-xs text-muted-foreground"
-            onClick={onStartPairing}
-            data-testid="workstation-add-button"
-          >
-            <Plus className="size-3.5" aria-hidden="true" />
-            Add workstation
-          </Button>
         </section>
       ) : null}
     </div>
+  );
+}
+
+export interface NotebookWorkstationsPanelActionProps {
+  /** Hidden while pairing is in flight; the panel already shows that card. */
+  pairing?: NotebookWorkstationPairingView | null;
+  onStartPairing?: () => void;
+}
+
+/** Add workstation control for the rail header, inline with the panel title. */
+export function NotebookWorkstationsPanelAction({
+  pairing = null,
+  onStartPairing,
+}: NotebookWorkstationsPanelActionProps) {
+  if (!onStartPairing || pairing) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="-my-1 h-7 px-2 text-xs text-muted-foreground"
+      onClick={onStartPairing}
+      data-testid="workstation-add-button"
+    >
+      <Plus className="size-3.5" aria-hidden="true" />
+      Add workstation
+    </Button>
+  );
+}
+
+function PanelSection({
+  title,
+  defaultOpen = true,
+  open,
+  onOpenChange,
+  bleed = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Let content span the full panel width instead of aligning to the title gutter. */
+  bleed?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Collapsible
+      defaultOpen={open === undefined ? defaultOpen : undefined}
+      open={open}
+      onOpenChange={onOpenChange}
+      className="-mx-3 border-t border-border/70"
+    >
+      <CollapsibleTrigger className="group flex w-full items-center justify-between gap-2 px-4 py-2 text-sm font-semibold text-foreground">
+        {title}
+        <ChevronDown
+          className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90"
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn("border-t border-border/70 pt-2", bleed ? undefined : "px-4 pb-2")}
+      >
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -363,6 +402,32 @@ function pairingCommandHelpText(
   return "Keep the command running until the workstation appears in the panel.";
 }
 
+// Each optional step is hidden for a different reason; say why instead of a
+// generic "run these if they apply" blurb once more than one is folded away.
+function additionalSetupHelpText(
+  additionalCommands: readonly NotebookWorkstationPairingCommandView[],
+): string {
+  const ids = new Set(additionalCommands.map((command) => command.id));
+  const notes: string[] = [];
+  if (ids.has("debian-prep")) {
+    notes.push("Fresh Debian/Ubuntu hosts may need curl and tmux before the install command.");
+  }
+  if (ids.has("path")) {
+    notes.push(
+      "Only needed in the same terminal you ran the install command in — a new terminal already has it on PATH.",
+    );
+  }
+  if (ids.has("foreground-run")) {
+    notes.push(
+      "Use the foreground fallback in tmux for macOS, non-systemd hosts, or manual testing.",
+    );
+  }
+  if (notes.length > 0) {
+    return notes.join(" ");
+  }
+  return "Run optional setup commands only when they match the host you are attaching.";
+}
+
 export function PairingCommandList({
   commands,
 }: {
@@ -373,13 +438,11 @@ export function PairingCommandList({
   const additionalCommands =
     requiredCommands.length > 0 ? commands.filter((command) => command.optional === true) : [];
   const hasAdditionalCommands = additionalCommands.length > 0;
-  const additionalPanelId = useId();
   const [additionalOpen, setAdditionalOpen] = useState(false);
   const bulkCommandText = primaryCommands.map((command) => command.command).join("\n");
   const hasLinuxServiceBundle = commands.some((command) =>
     command.command.includes("workstation service"),
   );
-  const hasForegroundFallback = commands.some((command) => command.id === "foreground-run");
   const copyLabel = hasLinuxServiceBundle
     ? "Linux workstation setup commands"
     : "workstation setup commands";
@@ -423,44 +486,38 @@ export function PairingCommandList({
         ))}
       </ol>
       {hasAdditionalCommands ? (
-        <div className="pt-0.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="-ml-1 h-7 px-1.5 text-[11px] text-muted-foreground"
-            aria-expanded={additionalOpen}
-            aria-controls={additionalPanelId}
-            aria-label={
-              additionalOpen ? "Hide additional setup options" : "Show additional setup options"
-            }
-            onClick={() => setAdditionalOpen((open) => !open)}
-          >
-            <ChevronDown
-              className={cn("size-3.5 transition-transform", additionalOpen && "rotate-180")}
-              aria-hidden="true"
-            />
-            Additional setup options
-          </Button>
-          {additionalOpen ? (
-            <div
-              id={additionalPanelId}
-              className="mt-1.5 space-y-2 rounded-md border border-border/60 bg-muted/[0.03] p-2"
-              data-testid="workstation-pairing-additional-commands"
+        <Collapsible open={additionalOpen} onOpenChange={setAdditionalOpen} className="pt-0.5">
+          <CollapsibleTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="-ml-1 h-7 px-1.5 text-[11px] text-muted-foreground"
+              aria-label={
+                additionalOpen ? "Hide additional setup options" : "Show additional setup options"
+              }
             >
-              <ul className="space-y-1.5">
-                {additionalCommands.map((command) => (
-                  <PairingCommandItem key={command.id} command={command} />
-                ))}
-              </ul>
-              <p className="leading-5 text-muted-foreground">
-                {hasLinuxServiceBundle && hasForegroundFallback
-                  ? "Fresh Debian/Ubuntu hosts may need curl and tmux before the install command. Use the foreground fallback in tmux for macOS, non-systemd hosts, or manual testing."
-                  : "Run optional setup commands only when they match the host you are attaching."}
-              </p>
-            </div>
-          ) : null}
-        </div>
+              <ChevronDown
+                className={cn("size-3.5 transition-transform", additionalOpen && "rotate-180")}
+                aria-hidden="true"
+              />
+              Additional setup options
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent
+            className="mt-1.5 space-y-2 rounded-md border border-border/60 bg-muted/[0.03] p-2"
+            data-testid="workstation-pairing-additional-commands"
+          >
+            <ul className="space-y-1.5">
+              {additionalCommands.map((command) => (
+                <PairingCommandItem key={command.id} command={command} />
+              ))}
+            </ul>
+            <p className="leading-5 text-muted-foreground">
+              {additionalSetupHelpText(additionalCommands)}
+            </p>
+          </CollapsibleContent>
+        </Collapsible>
       ) : null}
     </div>
   );
@@ -482,6 +539,8 @@ function PairingCommandItem({
         <span className="truncate">{command.label}</span>
         {command.optional ? (
           <span className="shrink-0 text-muted-foreground">(optional)</span>
+        ) : command.recommended ? (
+          <span className="shrink-0 text-muted-foreground">(recommended)</span>
         ) : null}
       </div>
       <PairingCommand command={command.command} label={command.label} />
@@ -550,90 +609,86 @@ export function PairingCountdown({ expiresAt }: { expiresAt: string }) {
   );
 }
 
-function shouldShowRegisteredWorkstation(
-  workstation: NotebookRegisteredWorkstationProjection,
-  activeRegisteredWorkstationId: string | null,
-): boolean {
-  return !workstation.isAttached && workstation.id !== activeRegisteredWorkstationId;
-}
-
 function RegisteredWorkstationRow({
   busy,
+  selected,
   workstation,
   onAttachWorkstation,
-  onSetDefaultWorkstation,
+  onSelect,
 }: {
   busy: boolean;
+  selected: boolean;
   workstation: NotebookRegisteredWorkstationProjection;
   onAttachWorkstation?: (workstationId: string) => void;
-  onSetDefaultWorkstation?: (workstationId: string) => void;
+  onSelect: () => void;
 }) {
   const status = registeredWorkstationStatusTone(workstation);
   const Icon = status.icon;
+  const statusLabel = workstation.isAttached
+    ? "Running"
+    : busy
+      ? "Starting"
+      : workstation.statusLabel;
+
   return (
-    <div
+    <li
       className={cn(
-        "rounded-md px-2.5 py-2 transition-colors",
-        workstation.isAttached ? "bg-primary/[0.06]" : "hover:bg-muted/[0.06]",
+        "relative flex min-w-0 items-start gap-2 px-4 py-2.5 transition-colors hover:bg-muted/[0.06]",
+        workstation.isAttached && "bg-primary/[0.06]",
+        selected &&
+          "bg-accent before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-primary",
       )}
       data-testid="registered-workstation"
+      data-selected={selected ? "true" : "false"}
     >
-      <div className="flex min-w-0 items-start gap-2.5">
+      <button
+        type="button"
+        aria-pressed={selected}
+        className="flex min-w-0 flex-1 items-start gap-2.5 text-left"
+        onClick={onSelect}
+      >
         <Icon className={cn("mt-0.5 size-4 shrink-0", status.iconClassName)} aria-hidden="true" />
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-            <h4 className="truncate text-sm font-medium">{workstation.displayName}</h4>
-            {workstation.isAttached ? (
-              <span className="text-xs font-medium text-primary">Running</span>
-            ) : null}
-            {workstation.isDefault ? (
-              <span className="text-xs font-medium text-muted-foreground">Default</span>
-            ) : null}
-            <span className={cn("text-xs font-medium", status.textClassName)}>
-              {workstation.statusLabel}
-            </span>
-          </div>
-          <div className="mt-1.5 grid min-w-0 gap-1 text-xs">
-            {workstation.facts.map((fact) => (
-              <RegisteredWorkstationFact key={fact.kind} fact={fact} />
-            ))}
-          </div>
-          {workstation.statusMessage ? (
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">
-              {workstation.statusMessage}
-            </p>
-          ) : null}
-          <div className="mt-1 truncate font-mono text-[10.5px] tracking-normal text-muted-foreground">
-            {workstation.idLabel}
-          </div>
-        </div>
-      </div>
-      <div className="mt-2 flex flex-wrap justify-end gap-2">
-        {onSetDefaultWorkstation && !workstation.isDefault ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            disabled={busy}
-            onClick={() => onSetDefaultWorkstation(workstation.id)}
-          >
-            Set default
-          </Button>
-        ) : null}
-        {onAttachWorkstation ? (
-          <Button
-            type="button"
-            variant={workstation.isAttached ? "secondary" : "outline"}
-            size="sm"
-            disabled={busy || workstation.isAttached || !workstation.canAttach}
-            onClick={() => onAttachWorkstation(workstation.id)}
-          >
-            {workstation.isAttached ? "Running" : busy ? "Starting" : "Start"}
-          </Button>
-        ) : null}
-      </div>
-    </div>
+        <span className="min-w-0 flex-1">
+          <h4 className="truncate text-sm font-medium">{workstation.displayName}</h4>
+          <span className={cn("mt-0.5 block text-xs font-medium", status.textClassName)}>
+            {statusLabel}
+          </span>
+        </span>
+      </button>
+      {onAttachWorkstation ? (
+        <Button
+          type="button"
+          variant={workstation.isAttached ? "secondary" : "outline"}
+          size="sm"
+          className="shrink-0"
+          disabled={busy || workstation.isAttached || !workstation.canAttach}
+          title={registeredWorkstationStartTitle(workstation, busy)}
+          onClick={() => onAttachWorkstation(workstation.id)}
+        >
+          {workstation.isAttached ? "Running" : busy ? "Starting" : "Start"}
+        </Button>
+      ) : null}
+    </li>
   );
+}
+
+// Start is gated on the projection's canAttach; say why instead of going dead.
+function registeredWorkstationStartTitle(
+  workstation: NotebookRegisteredWorkstationProjection,
+  busy: boolean,
+): string {
+  if (workstation.isAttached)
+    return "This workstation is already running compute for this notebook";
+  if (busy) return "Starting compute on this workstation";
+  if (workstation.canAttach) return `Start compute on ${workstation.displayName}`;
+  if (workstation.status === "connecting") return "This workstation is still connecting";
+  if (workstation.status !== "online") {
+    return "This workstation is not online. Run the workstation agent on that machine first.";
+  }
+  if (!workstation.workingDirectoryLabel) {
+    return "This workstation has not reported a working directory yet";
+  }
+  return "This workstation has no available environment yet";
 }
 
 function WorkstationFact({
@@ -673,20 +728,69 @@ function WorkstationFact({
   );
 }
 
+// The projection carries provider, agent build, and heartbeat facts the panel
+// can show alongside the resource facts without another data source.
+function registeredWorkstationDetailFacts(
+  workstation: NotebookRegisteredWorkstationProjection,
+): readonly NotebookRegisteredWorkstationFactProjection[] {
+  const extras: NotebookRegisteredWorkstationFactProjection[] = [];
+  const push = (
+    kind: string,
+    label: string,
+    value: string | null,
+    detail: string | null = null,
+    tone: NotebookRegisteredWorkstationFactProjection["tone"] = "neutral",
+  ) => {
+    if (!value) return;
+    extras.push({
+      detail,
+      kind: kind as NotebookRegisteredWorkstationFactProjection["kind"],
+      label,
+      tone,
+      value,
+    });
+  };
+
+  push("provider", "Provider", workstation.providerLabel);
+  push(
+    "build",
+    "Agent build",
+    workstation.installedBuild,
+    workstation.isOutdated && workstation.latestBuild
+      ? `Update to ${workstation.latestBuild}`
+      : null,
+    workstation.isOutdated ? "attention" : "neutral",
+  );
+  push("channel", "Channel", workstation.channel);
+  push("last_seen", "Last seen", workstationLastSeenLabel(workstation));
+
+  return [...workstation.facts, ...extras];
+}
+
+function workstationLastSeenLabel(
+  workstation: NotebookRegisteredWorkstationProjection,
+): string | null {
+  if (workstation.status === "online") return "Active now";
+  if (workstation.status === "connecting") return "Connecting…";
+  if (!workstation.updatedAt) return null;
+  const seenMs = Date.parse(workstation.updatedAt);
+  if (!Number.isFinite(seenMs)) return null;
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(seenMs),
+  );
+}
+
 function RegisteredWorkstationFact({
   fact,
 }: {
   fact: NotebookRegisteredWorkstationFactProjection;
 }) {
   return (
-    <span
-      className="grid min-w-0 grid-cols-[2.25rem_minmax(0,1fr)] items-baseline gap-x-1 gap-y-0.5 text-muted-foreground"
-      data-tone={fact.tone}
-    >
-      <span className="text-[11px]">{fact.label}</span>
+    <span className="grid min-w-0" data-tone={fact.tone}>
+      <span className="text-[11px] leading-4 text-muted-foreground">{fact.label}</span>
       <span
         className={cn(
-          "min-w-0 font-medium",
+          "min-w-0 text-xs leading-5 font-medium",
           fact.kind === "accelerator" ? "break-words" : "truncate",
           fact.tone === "attention" ? "text-[var(--sev-warn)]" : "text-foreground",
         )}
@@ -694,39 +798,10 @@ function RegisteredWorkstationFact({
         {fact.value}
       </span>
       {fact.detail ? (
-        <span className="col-start-2 min-w-0 text-[11px] leading-4 text-muted-foreground">
-          {fact.detail}
-        </span>
+        <span className="min-w-0 text-[11px] leading-4 text-muted-foreground">{fact.detail}</span>
       ) : null}
     </span>
   );
-}
-
-function workstationStatusTone(tone: NotebookWorkstationPanelTone): {
-  icon: LucideIcon;
-  iconClassName: string;
-  textClassName: string;
-} {
-  if (tone === "ready") {
-    return {
-      icon: CircleCheck,
-      iconClassName: "text-emerald-700 dark:text-emerald-300",
-      textClassName: "text-emerald-700 dark:text-emerald-300",
-    };
-  }
-  if (tone === "available") {
-    return {
-      icon: Server,
-      iconClassName: "text-sky-700 dark:text-sky-300",
-      textClassName: "text-sky-700 dark:text-sky-300",
-    };
-  }
-
-  return {
-    icon: CircleAlert,
-    iconClassName: "text-muted-foreground",
-    textClassName: "text-muted-foreground",
-  };
 }
 
 function registeredWorkstationStatusTone(workstation: NotebookRegisteredWorkstationProjection): {

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -5,7 +5,15 @@ import {
   projectNotebookWorkstationSelection,
   readOnlyNotebookShellCapabilities,
 } from "../capabilities";
-import { NotebookWorkstationsPanel } from "../NotebookWorkstationsPanel";
+import {
+  NotebookWorkstationsPanel,
+  NotebookWorkstationsPanelAction,
+} from "../NotebookWorkstationsPanel";
+
+// "Workstation details" is collapsed by default, so facts need an expand click.
+function expandWorkstationDetails() {
+  fireEvent.click(screen.getByRole("button", { name: "Workstation details" }));
+}
 
 const localReadyCapabilities: NotebookShellCapabilities = {
   ...readOnlyNotebookShellCapabilities,
@@ -80,6 +88,7 @@ const cloudPairingCommands = [
     id: "path",
     label: "Use installed CLI in this shell",
     command: 'export PATH="$HOME/.local/bin:$PATH"',
+    optional: true,
   },
   {
     id: "connect",
@@ -90,6 +99,7 @@ const cloudPairingCommands = [
     id: "run",
     label: "Linux user systemd service",
     command: "runt workstation service install --start",
+    recommended: true,
   },
   {
     id: "foreground-run",
@@ -102,10 +112,9 @@ const cloudPairingCommands = [
 describe("NotebookWorkstationsPanel", () => {
   it("renders a local executable runtime as a workstation target", () => {
     render(<NotebookWorkstationsPanel capabilities={localReadyCapabilities} />);
+    expandWorkstationDetails();
 
     expect(screen.queryByText("local-daemon")).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "This machine" })).toBeVisible();
-    expect(screen.getByText("Ready")).toBeVisible();
     expect(screen.queryByText("The local daemon is available for this notebook.")).toBeNull();
     expect(screen.getByText("Local daemon")).toBeVisible();
     expect(screen.getByText("Notebook runtime")).toBeVisible();
@@ -154,15 +163,9 @@ describe("NotebookWorkstationsPanel", () => {
     };
 
     render(<NotebookWorkstationsPanel capabilities={capabilities} />);
+    expandWorkstationDetails();
 
     expect(screen.queryByText("workstation:none")).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "No compute session" })).toBeVisible();
-    expect(screen.getByText("Offline")).toBeVisible();
-    expect(
-      screen.getByText(
-        "Start compute from a user-owned workstation to run cells in this notebook.",
-      ),
-    ).toBeVisible();
     expect(screen.getByText("Cloud room")).toBeVisible();
     expect(screen.queryByText("Kyle")).not.toBeInTheDocument();
     expect(screen.getByText("Not running")).toBeVisible();
@@ -233,7 +236,7 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.queryByTestId("workstation-registration-empty")).not.toBeInTheDocument();
   });
 
-  it("renders registered workstation targets with default and attach actions", () => {
+  it("lists registered workstations as icon, name, and status only", () => {
     const attached: string[] = [];
     const defaults: string[] = [];
     const selection = projectNotebookWorkstationSelection({
@@ -270,21 +273,126 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    expect(screen.getByText("id ws-lab2")).toBeVisible();
-    expect(screen.getByText("Lab2")).toBeVisible();
-    expect(screen.getByText("Default")).toBeVisible();
-    expect(screen.getByText("Env")).toBeVisible();
-    expect(screen.getByText("/home/ubuntu/project")).toBeVisible();
-    const attachButtons = screen.getAllByRole("button", { name: "Start" });
-    fireEvent.click(attachButtons[0]!);
-    expect(attached).toEqual(["ws-lab2"]);
+    expect(screen.getByRole("heading", { name: "Lab2" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Offline workstation" })).toBeVisible();
+    const rows = screen.getAllByTestId("registered-workstation");
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]!).getByText("Online")).toBeVisible();
+    expect(within(rows[1]!).getByText("Offline")).toBeVisible();
 
-    expect(screen.getByText("Offline workstation")).toBeVisible();
-    expect(screen.getByText("No heartbeat from this workstation recently.")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Set default" })).toBeEnabled();
-    fireEvent.click(screen.getByRole("button", { name: "Set default" }));
+    // Rows carry the status plus a right-aligned Start; no facts, ids, or defaults.
+    expect(screen.queryByText("id ws-lab2")).not.toBeInTheDocument();
+    expect(screen.queryByText("Env")).not.toBeInTheDocument();
+    expect(screen.queryByText("/home/ubuntu/project")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No heartbeat from this workstation recently."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Set default" })).not.toBeInTheDocument();
+    expect(defaults).toEqual([]);
+
+    expect(within(rows[1]!).getByRole("button", { name: "Start" })).toBeDisabled();
+    fireEvent.click(within(rows[0]!).getByRole("button", { name: "Start" }));
+    expect(attached).toEqual(["ws-lab2"]);
+  });
+
+  it("opens details for the workstation picked from the list", () => {
+    const defaults: string[] = [];
+    const selection = projectNotebookWorkstationSelection({
+      canRegisterWorkstation: true,
+      canSelectWorkstation: true,
+      canSetDefaultWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          id: "ws-lab2",
+          displayName: "Lab2",
+          defaultEnvironmentLabel: "Current Python",
+          environmentPolicy: "current_python",
+          provider: "runtime_peer",
+          status: "online",
+          workingDirectory: "/home/ubuntu/project",
+        },
+        {
+          id: "ws-offline",
+          displayName: "Offline workstation",
+          provider: "runtime_peer",
+          status: "offline",
+          statusMessage: "No heartbeat from this workstation recently.",
+        },
+      ],
+    });
+
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={readOnlyNotebookShellCapabilities}
+        selection={selection}
+        onAttachWorkstation={() => {}}
+        onSetDefaultWorkstation={(workstationId) => defaults.push(workstationId)}
+      />,
+    );
+
+    const details = () => screen.getByRole("region", { name: "Workstation details" });
+    const rows = () => screen.getAllByTestId("registered-workstation");
+
+    // Expanded with nothing selected: details guide the reader to the list instead of showing facts.
+    expect(rows().map((row) => row.dataset.selected)).toEqual(["false", "false"]);
+    expandWorkstationDetails();
+    expect(
+      within(details()).getByText("Select a workstation above to see its details."),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /Lab2/ }));
+    expect(rows().map((row) => row.dataset.selected)).toEqual(["true", "false"]);
+    expect(within(details()).getByText("id ws-lab2")).toBeVisible();
+    expect(within(details()).getByText("/home/ubuntu/project")).toBeVisible();
+    expect(
+      within(details()).queryByText("Select a workstation above to see its details."),
+    ).not.toBeInTheDocument();
+
+    // Picking another workstation swaps the details and the selected row.
+    fireEvent.click(screen.getByRole("button", { name: /Offline workstation/ }));
+    expect(rows().map((row) => row.dataset.selected)).toEqual(["false", "true"]);
+    expect(within(details()).getByText("id ws-offline")).toBeVisible();
+    fireEvent.click(within(details()).getByRole("button", { name: "Set default" }));
     expect(defaults).toEqual(["ws-offline"]);
-    expect(attachButtons[1]).toBeDisabled();
+  });
+
+  it("shows provider, agent build, and heartbeat facts in the details section", () => {
+    const selection = projectNotebookWorkstationSelection({
+      canSelectWorkstation: true,
+      registeredWorkstations: [
+        {
+          id: "ws-lab2",
+          displayName: "Lab2",
+          provider: "runtime_peer",
+          providerLabel: "Workstation agent",
+          installedBuild: "2026.7.1",
+          latestBuild: "2026.7.9",
+          isOutdated: true,
+          channel: "nightly",
+          status: "offline",
+          updatedAt: "2026-07-20T18:30:00.000Z",
+        },
+      ],
+    });
+
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={readOnlyNotebookShellCapabilities}
+        selection={selection}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Lab2/ }));
+    const details = within(screen.getByRole("region", { name: "Workstation details" }));
+    expect(details.getByText("Provider")).toBeVisible();
+    expect(details.getByText("Workstation agent")).toBeVisible();
+    expect(details.getByText("Agent build")).toBeVisible();
+    expect(details.getByText("2026.7.1")).toBeVisible();
+    expect(details.getByText("Update to 2026.7.9")).toBeVisible();
+    expect(details.getByText("Channel")).toBeVisible();
+    expect(details.getByText("nightly")).toBeVisible();
+    expect(details.getByText("Last seen")).toBeVisible();
   });
 
   it("renders accelerator capability, attention diagnostics, known-none, unknown, and offline facts", () => {
@@ -353,46 +461,43 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    const readyRow = screen
-      .getByRole("heading", { name: "Usable GPU" })
-      .closest('[data-testid="registered-workstation"]');
-    const attentionRow = screen
-      .getByRole("heading", { name: "GPU attention" })
-      .closest('[data-testid="registered-workstation"]');
-    const knownNoneRow = screen
-      .getByRole("heading", { name: "CPU workstation" })
-      .closest('[data-testid="registered-workstation"]');
-    const legacyRow = screen
-      .getByRole("heading", { name: "Older agent" })
-      .closest('[data-testid="registered-workstation"]');
-    const offlineRow = screen
-      .getByRole("heading", { name: "Offline GPU" })
-      .closest('[data-testid="registered-workstation"]');
+    // Facts live in the details section for whichever workstation the list selects.
+    const details = () => screen.getByRole("region", { name: "Workstation details" });
+    const selectRow = (name: string) => {
+      const row = screen
+        .getByRole("heading", { name })
+        .closest('[data-testid="registered-workstation"]');
+      expect(row).not.toBeNull();
+      fireEvent.click(within(row!).getByRole("button"));
+      return within(details());
+    };
 
-    expect(readyRow).not.toBeNull();
     expect(
-      within(readyRow!).getByText("1× NVIDIA A100 · 80 GiB").closest("[data-tone]"),
+      selectRow("Usable GPU").getByText("1× NVIDIA A100 · 80 GiB").closest("[data-tone]"),
     ).toHaveAttribute("data-tone", "positive");
-    expect(attentionRow).not.toBeNull();
+
+    const attention = selectRow("GPU attention");
     expect(
-      within(attentionRow!).getByText("NVIDIA driver is not visible to the workstation service."),
+      attention.getByText("NVIDIA driver is not visible to the workstation service."),
     ).toBeVisible();
-    expect(
-      within(attentionRow!).getByText("1× NVIDIA A100 · 80 GiB").closest("[data-tone]"),
-    ).toHaveAttribute("data-tone", "attention");
-    expect(knownNoneRow).not.toBeNull();
-    expect(within(knownNoneRow!).queryByText("GPU")).not.toBeInTheDocument();
-    expect(legacyRow).not.toBeNull();
-    expect(within(legacyRow!).queryByText("GPU")).not.toBeInTheDocument();
+    expect(attention.getByText("1× NVIDIA A100 · 80 GiB").closest("[data-tone]")).toHaveAttribute(
+      "data-tone",
+      "attention",
+    );
+
+    expect(selectRow("CPU workstation").queryByText("GPU")).not.toBeInTheDocument();
+    expect(selectRow("Older agent").queryByText("GPU")).not.toBeInTheDocument();
     expect(screen.queryByText("No GPU")).not.toBeInTheDocument();
-    expect(offlineRow).not.toBeNull();
-    expect(
-      within(offlineRow!).getByText("1× NVIDIA A100 · 80 GiB").closest("[data-tone]"),
-    ).toHaveAttribute("data-tone", "neutral");
-    expect(within(offlineRow!).queryByText(/available/i)).not.toBeInTheDocument();
+
+    const offline = selectRow("Offline GPU");
+    expect(offline.getByText("1× NVIDIA A100 · 80 GiB").closest("[data-tone]")).toHaveAttribute(
+      "data-tone",
+      "neutral",
+    );
+    expect(offline.queryByText(/available/i)).not.toBeInTheDocument();
   });
 
-  it("keeps the detached cloud target compact when registered workstations are listed", () => {
+  it("shows only the registered list when the cloud room has no compute session", () => {
     const capabilities: NotebookShellCapabilities = {
       ...readOnlyNotebookShellCapabilities,
       access: {
@@ -450,21 +555,29 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "No compute session" })).toBeVisible();
+    expect(screen.queryByText("No compute session")).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Start compute from a user-owned workstation to run cells in this notebook.",
       ),
-    ).toBeVisible();
-    expect(screen.queryByText("Cloud room")).not.toBeInTheDocument();
-    expect(screen.queryByText("Not runnable")).not.toBeInTheDocument();
-    expect(screen.getByText("Lab2")).toBeVisible();
-    expect(screen.getByText("Current Python")).toBeVisible();
-    expect(screen.getByText("id ws-lab2")).toBeVisible();
-    expect(screen.getAllByText("No heartbeat from this workstation recently.")).toHaveLength(1);
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Lab2" })).toBeVisible();
+    // A per-workstation message never renders above the list.
+    expect(
+      screen.queryByText("No heartbeat from this workstation recently."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Lab2/ }));
+    const details = within(screen.getByRole("region", { name: "Workstation details" }));
+    expect(details.getByText("Current Python")).toBeVisible();
+    expect(details.getByText("id ws-lab2")).toBeVisible();
+    // The raw per-workstation message never renders; status is conveyed by the label.
+    expect(
+      screen.queryByText("No heartbeat from this workstation recently."),
+    ).not.toBeInTheDocument();
   });
 
-  it("does not duplicate the attached workstation in the registered list", () => {
+  it("lists the attached workstation alongside the other registered ones", () => {
     const capabilities: NotebookShellCapabilities = {
       ...readOnlyNotebookShellCapabilities,
       canExecute: true,
@@ -541,14 +654,18 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Lab2" })).toBeVisible();
-    expect(screen.getAllByText("Workstation")).toHaveLength(1);
-    expect(screen.getAllByText("Current Python")).toHaveLength(1);
-    expect(screen.getByText("id ws-lab2")).toBeVisible();
-    expect(screen.getAllByTestId("registered-workstation")).toHaveLength(1);
+    // The attached workstation appears once, in the list — not restated as a target section.
+    expect(screen.getAllByRole("heading", { name: "Lab2" })).toHaveLength(1);
+    expect(screen.getAllByTestId("registered-workstation")).toHaveLength(2);
+    expect(screen.queryByRole("region", { name: "Active workstation target" })).toBeNull();
     expect(screen.getByRole("heading", { name: "GPU host" })).toBeVisible();
-    expect(screen.getByText("CUDA Python")).toBeVisible();
-    expect(screen.getByText("id ws-gpu")).toBeVisible();
+
+    const details = () => within(screen.getByRole("region", { name: "Workstation details" }));
+    fireEvent.click(screen.getByRole("button", { name: /Lab2/ }));
+    expect(details().getByText("id ws-lab2")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /GPU host/ }));
+    expect(details().getByText("CUDA Python")).toBeVisible();
+    expect(details().getByText("id ws-gpu")).toBeVisible();
   });
 
   it("keeps an online registered workstation actionable when a matching attachment is stale", () => {
@@ -620,30 +737,27 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Previous compute session" })).toBeVisible();
+    expect(screen.queryByText("Previous compute session")).not.toBeInTheDocument();
     expect(screen.getAllByRole("heading", { name: "Lab2" })).toHaveLength(1);
-    expect(screen.getByText("Needs attention")).toBeVisible();
-    expect(
-      screen.getByText(
-        "Compute from Lab2 is no longer connected to this notebook. Start compute again from an available workstation.",
-      ),
-    ).toBeVisible();
     expect(screen.queryByText(/runtime peer disconnected/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Runtime peer")).not.toBeInTheDocument();
-    expect(screen.getAllByText("Current Python")).toHaveLength(1);
-    expect(screen.getAllByText("/home/ubuntu/project")).toHaveLength(1);
-    expect(screen.getAllByText("id ws-lab2")).toHaveLength(1);
-    expect(screen.getByTestId("registered-workstation")).toBeVisible();
-    expect(screen.getByText("Online")).toBeVisible();
-    expect(screen.getByText("Default")).toBeVisible();
+    const row = within(screen.getByTestId("registered-workstation"));
+    expect(row.getByText("Online")).toBeVisible();
     expect(screen.queryByText("Running")).not.toBeInTheDocument();
-    const attachButton = screen.getByRole("button", { name: "Start" });
+
+    const attachButton = row.getByRole("button", { name: "Start" });
     expect(attachButton).toBeEnabled();
     fireEvent.click(attachButton);
     expect(attached).toEqual(["ws-lab2"]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Lab2/ }));
+    const details = within(screen.getByRole("region", { name: "Workstation details" }));
+    expect(details.getAllByText("Current Python")).toHaveLength(1);
+    expect(details.getAllByText("/home/ubuntu/project")).toHaveLength(1);
+    expect(details.getAllByText("id ws-lab2")).toHaveLength(1);
   });
 
-  it("explains stale cloud attachments to viewers without implementation terms", () => {
+  it("never leaks implementation terms from a stale cloud attachment", () => {
     const capabilities: NotebookShellCapabilities = {
       ...readOnlyNotebookShellCapabilities,
       access: {
@@ -672,12 +786,6 @@ describe("NotebookWorkstationsPanel", () => {
 
     render(<NotebookWorkstationsPanel capabilities={capabilities} />);
 
-    expect(screen.getByRole("heading", { name: "Previous compute session" })).toBeVisible();
-    expect(
-      screen.getByText(
-        "Compute from Lab2 is no longer connected to this notebook. The owner can start compute again from an available workstation.",
-      ),
-    ).toBeVisible();
     expect(screen.queryByText(/runtime peer disconnected/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/grace window/i)).not.toBeInTheDocument();
   });
@@ -705,7 +813,8 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Remote devbox" })).toBeVisible();
+    expandWorkstationDetails();
+
     expect(screen.getByText("Default env")).toBeVisible();
     expect(screen.getByText("Current Python")).toBeVisible();
     expect(screen.getByText("Resources")).toBeVisible();
@@ -717,18 +826,69 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.queryByText("RAM")).not.toBeInTheDocument();
   });
 
-  it("offers Add workstation and starts pairing", () => {
+  it("offers Add workstation from the rail header and starts pairing", () => {
     const started: number[] = [];
-    render(
+    const { rerender } = render(
+      <NotebookWorkstationsPanelAction onStartPairing={() => started.push(1)} />,
+    );
+
+    fireEvent.click(screen.getByTestId("workstation-add-button"));
+    expect(started).toHaveLength(1);
+
+    // The panel body never renders its own copy of the control.
+    rerender(
       <NotebookWorkstationsPanel
         capabilities={localReadyCapabilities}
         onStartPairing={() => started.push(1)}
       />,
     );
+    expect(screen.queryByTestId("workstation-add-button")).not.toBeInTheDocument();
+  });
 
-    const addButton = screen.getByTestId("workstation-add-button");
-    fireEvent.click(addButton);
-    expect(started).toHaveLength(1);
+  it("puts the pairing section above the registered workstation list", () => {
+    const selection = projectNotebookWorkstationSelection({
+      canSelectWorkstation: true,
+      registeredWorkstations: [
+        { id: "ws-lab2", displayName: "Lab2", provider: "runtime_peer", status: "online" },
+      ],
+    });
+
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={localReadyCapabilities}
+        selection={selection}
+        pairing={{
+          code: "ABCD-EFGH-JKMN",
+          connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+          expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
+          status: "pending",
+          workstationName: null,
+          error: null,
+        }}
+      />,
+    );
+
+    const card = screen.getByTestId("workstation-pairing-card");
+    const list = screen.getByRole("region", { name: "Registered workstations" });
+    expect(card.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("hides the header Add workstation control while pairing is in flight", () => {
+    render(
+      <NotebookWorkstationsPanelAction
+        pairing={{
+          code: "ABCD-EFGH-JKMN",
+          connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+          expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
+          status: "pending",
+          workstationName: null,
+          error: null,
+        }}
+        onStartPairing={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("workstation-add-button")).not.toBeInTheDocument();
   });
 
   it("renders the pending pairing card with the connect command and countdown", () => {
@@ -749,30 +909,43 @@ describe("NotebookWorkstationsPanel", () => {
 
     expect(screen.getByTestId("workstation-pairing-command-list")).toBeVisible();
     expect(screen.getByText("Install nteract headless")).toBeVisible();
-    expect(screen.getByText("Use installed CLI in this shell")).toBeVisible();
     expect(screen.getByText("Pair this workstation")).toBeVisible();
     expect(screen.getByText("Linux user systemd service")).toBeVisible();
+    // Only the steps required to connect show up front; PATH export and
+    // platform alternatives are conditional and live under "Additional".
+    expect(screen.queryByText("Use installed CLI in this shell")).toBeNull();
     expect(screen.queryByText("Fresh Debian/Ubuntu only")).toBeNull();
     expect(screen.queryByText("macOS/non-systemd fallback")).toBeNull();
     const commands = screen.getAllByTestId("workstation-pairing-command");
     expect(commands.map((command) => command.textContent)).toEqual([
       "curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless",
-      'export PATH="$HOME/.local/bin:$PATH"',
       "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
       "runt workstation service install --start",
     ]);
+    expect(screen.getByText("(recommended)")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Show additional setup options" }));
     const additionalCommands = within(
       screen.getByTestId("workstation-pairing-additional-commands"),
     );
     expect(additionalCommands.getByText("Fresh Debian/Ubuntu only")).toBeVisible();
+    expect(additionalCommands.getByText("Use installed CLI in this shell")).toBeVisible();
     expect(additionalCommands.getByText("macOS/non-systemd fallback")).toBeVisible();
-    expect(additionalCommands.getAllByText("(optional)")).toHaveLength(2);
+    expect(additionalCommands.getAllByText("(optional)")).toHaveLength(3);
     expect(
       additionalCommands
         .getAllByTestId("workstation-pairing-command")
         .map((command) => command.textContent),
-    ).toEqual(["sudo apt update && sudo apt install -y curl tmux", "runt workstation run"]);
+    ).toEqual([
+      "sudo apt update && sudo apt install -y curl tmux",
+      'export PATH="$HOME/.local/bin:$PATH"',
+      "runt workstation run",
+    ]);
+    // Each folded-away step explains why it's conditional, not a generic blurb.
+    expect(
+      additionalCommands.getByText(/Fresh Debian\/Ubuntu hosts may need curl and tmux/),
+    ).toBeVisible();
+    expect(additionalCommands.getByText(/a new terminal already has it on PATH/)).toBeVisible();
+    expect(additionalCommands.getByText(/foreground fallback in tmux/)).toBeVisible();
     expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
       /Waiting for the machine to connect/,
     );
@@ -792,7 +965,6 @@ describe("NotebookWorkstationsPanel", () => {
     expect(writeText).toHaveBeenCalledWith(
       [
         "curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless",
-        'export PATH="$HOME/.local/bin:$PATH"',
         "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
         "runt workstation service install --start",
       ].join("\n"),

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -262,10 +262,12 @@ export {
 } from "./NotebookPackageSummaryPanel";
 export {
   NotebookWorkstationsPanel,
+  NotebookWorkstationsPanelAction,
   PairingCommandList,
   PairingCountdown,
   type NotebookWorkstationPairingCommandView,
   type NotebookWorkstationPairingView,
+  type NotebookWorkstationsPanelActionProps,
   type NotebookWorkstationsPanelProps,
 } from "./NotebookWorkstationsPanel";
 export { NotebookDocumentRail, type NotebookDocumentRailProps } from "./NotebookDocumentRail";

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -23,6 +23,8 @@ export interface RailProps<PanelId extends string = string> {
   onActivePanelChange: (panelId: PanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   panelEyebrow?: string;
+  /** Rendered inline with the panel title, right-aligned. */
+  panelAction?: ReactNode;
   panelClassName?: string;
   className?: string;
   dataTestId?: string;
@@ -36,6 +38,7 @@ export function Rail<PanelId extends string = string>({
   items,
   panelTitle,
   panelEyebrow,
+  panelAction,
   panelClassName,
   children,
   onActivePanelChange,
@@ -95,6 +98,7 @@ export function Rail<PanelId extends string = string>({
                 data-slot={panelTitleRowSlot}
               >
                 <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
+                {panelAction}
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Reworks the workstations panel into a selectable list (icon, name, status) with a separate collapsible "Workstation details" section below, instead of one dense always-expanded target section.
- Moves "Add workstation" into the rail header, next to the panel title.
- Cuts the "Connect a machine" card down to the two steps actually required to connect (install, pair). PATH export and platform-specific persistence commands move into "Additional setup options."
OLD:

<img width="856" height="1462" alt="image" src="https://github.com/user-attachments/assets/86adfc6f-d691-47a9-8186-37676ec62941" />
NEW:

<img width="379" height="643" alt="image" src="https://github.com/user-attachments/assets/33d7af68-2a31-4995-bc56-7a9705b3c0ee" />
<img width="396" height="642" alt="image" src="https://github.com/user-attachments/assets/9836515f-e519-4ea1-9f2e-ada615d7fcd1" />
<img width="369" height="639" alt="image" src="https://github.com/user-attachments/assets/e11a5715-ea7c-4794-9c76-f599df0d4c04" />
