### PR TITLE
fix(ui): stop clipping the avatar presence badge

### DIFF
--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -15,7 +15,7 @@ function Avatar({
       data-slot="avatar"
       data-size={size}
       className={cn(
-        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
         className,
       )}
       {...props}
@@ -27,7 +27,7 @@ function AvatarImage({ className, ...props }: React.ComponentProps<typeof Avatar
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full rounded-full", className)}
       {...props}
     />
   );


### PR DESCRIPTION
`Avatar`'s root had `overflow-hidden` to circle-crop photos, which clipped the absolutely-positioned `AvatarBadge` into a wedge and ate its ring. Moved the crop onto `AvatarImage` via `rounded-full`.

![before and after](https://anaconda.com/api/projects/cc5a1842-3bf9-46f9-a8f0-1eae36f85ad4/files/2026-07-28T15-05-50_compare.png)

CI green; photo avatars still crop circular.