### PR TITLE
fix(cloud): make Share a real Radix popover

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -399,10 +399,23 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sharingSourceText, /aria-label=\{`Remove \$\{row\.label\}`\}/);
   const sharePanelCss = cssText.match(/\.cloud-share-panel \{(?<body>[\s\S]*?)\n\}/)?.groups?.body;
   assert.ok(sharePanelCss);
-  assert.match(sharePanelCss, /position: fixed;/);
-  assert.match(sharePanelCss, /right: max\(0\.75rem, env\(safe-area-inset-right\)\);/);
   assert.match(sharePanelCss, /width: min\(30rem, calc\(100vw - 1\.5rem\)\);/);
-  assert.doesNotMatch(sharePanelCss, /position: absolute;/);
+  assert.doesNotMatch(sharePanelCss, /position: fixed;/);
+  assert.match(
+    sharingSourceText,
+    /import \{ Popover, PopoverContent, PopoverTrigger \} from "@\/components\/ui\/popover";/,
+  );
+  assert.match(sharingSourceText, /<Popover open=\{open\} onOpenChange=\{setOpen\}>/);
+  assert.match(
+    sharingSourceText,
+    /<PopoverTrigger className="cloud-share-trigger" title="Share notebook">/,
+  );
+  assert.match(
+    sharingSourceText,
+    /<PopoverContent className="cloud-share-panel" align="end" sideOffset=\{8\}>/,
+  );
+  assert.doesNotMatch(sharingSourceText, /<details/);
+  assert.doesNotMatch(sharingSourceText, /<summary/);
   assert.match(
     presenceSourceText,
     /function CloudPresenceStatus[\s\S]*const presence = useSyncExternalStore\(store\.subscribe, store\.getSnapshot, store\.getSnapshot\);[\s\S]*const presenceDisplay = cloudViewerPresenceDisplay\(presence\);/,

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -557,7 +557,7 @@ body {
     display: none;
   }
 
-  .cloud-share-menu > summary,
+  .cloud-share-trigger,
   .cloud-sign-in-button {
     max-width: min(10rem, 28vw);
     padding-inline: 0.375rem;
@@ -584,14 +584,14 @@ body {
     gap: 0.125rem 0.375rem;
   }
 
-  .cloud-share-menu > summary,
+  .cloud-share-trigger,
   .cloud-sign-in-button {
     width: 2.25rem;
     max-width: 2.25rem;
     padding-inline: 0;
   }
 
-  .cloud-share-menu > summary span,
+  .cloud-share-trigger span,
   .cloud-sign-in-button span {
     display: none;
   }
@@ -2229,11 +2229,7 @@ body {
   }
 }
 
-.cloud-share-menu {
-  position: relative;
-}
-
-.cloud-share-menu > summary,
+.cloud-share-trigger,
 .cloud-sign-in-button {
   display: inline-flex;
   align-items: center;
@@ -2251,28 +2247,24 @@ body {
   list-style: none;
 }
 
-.cloud-share-menu > summary::-webkit-details-marker {
-  display: none;
-}
-
-.cloud-share-menu > summary:hover {
+.cloud-share-trigger:hover {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
 }
 
-.cloud-share-menu > summary:focus-visible {
+.cloud-share-trigger:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
 }
 
-.cloud-share-menu svg,
+.cloud-share-trigger svg,
 .cloud-sign-in-button svg {
   width: 1rem;
   height: 1rem;
   flex: 0 0 auto;
 }
 
-.cloud-share-menu > summary span,
+.cloud-share-trigger span,
 .cloud-sign-in-button span {
   min-width: 0;
   overflow: hidden;
@@ -2332,11 +2324,6 @@ body {
 }
 
 .cloud-share-panel {
-  position: fixed;
-  top: 4.75rem;
-  right: max(0.75rem, env(safe-area-inset-right));
-  left: auto;
-  z-index: 30;
   display: grid;
   gap: 0;
   width: min(30rem, calc(100vw - 1.5rem));
@@ -2632,13 +2619,7 @@ body {
 }
 
 @media (max-width: 640px) {
-  .cloud-share-panel {
-    right: max(0.75rem, env(safe-area-inset-right));
-    left: auto;
-    width: auto;
-  }
-
-  .cloud-share-menu > summary,
+  .cloud-share-trigger,
   .cloud-sign-in-button {
     max-width: min(10rem, 36vw);
   }

--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { Check, Globe2, Link2, Mail, ServerCog, Share2, Trash2, UserRound, X } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { appendEndpointPathSegment, cloudResponseError } from "./cloud-response";
 import {
@@ -329,16 +330,12 @@ export function CloudSharingControls({
   };
 
   return (
-    <details
-      className="cloud-share-menu"
-      open={open}
-      onToggle={(event) => setOpen(event.currentTarget.open)}
-    >
-      <summary title="Share notebook">
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger className="cloud-share-trigger" title="Share notebook">
         <Share2 aria-hidden="true" />
         <span>Share</span>
-      </summary>
-      <div className="cloud-share-panel">
+      </PopoverTrigger>
+      <PopoverContent className="cloud-share-panel" align="end" sideOffset={8}>
         <header>
           <div>
             <h2>Share notebook</h2>
@@ -553,8 +550,8 @@ export function CloudSharingControls({
             {message}
           </div>
         ) : null}
-      </div>
-    </details>
+      </PopoverContent>
+    </Popover>
   );
 }
 


### PR DESCRIPTION
## Summary
- Swap the Share button's native `<details>`/`<summary>` for the shared `Popover` primitive (`@/components/ui/popover`) in `apps/notebook-cloud/viewer/sharing-controls.tsx`, so it reliably closes on outside click.
- Update `apps/notebook-cloud/viewer/index.css`: rename `.cloud-share-menu > summary` selectors to `.cloud-share-trigger`, drop the fixed-position hack on `.cloud-share-panel` now that Radix Popper handles placement.
- Update `apps/notebook-cloud/test/viewer-render-props.test.ts` to assert the new Popover-based markup instead of the old `<details>` structure.

## Test plan
- [x] `pnpm --dir apps/notebook-cloud typecheck` passes
- [x] `pnpm --dir apps/notebook-cloud test` passes (same pre-existing unrelated failures as main)
- [x] Verified live in a local dev room: clicking Share opens the popover correctly positioned with all sharing controls, clicking outside closes it

![Share popover opening and closing on outside click](https://anaconda.com/api/projects/cc5a1842-3bf9-46f9-a8f0-1eae36f85ad4/files/2026-07-28T15-25-29_share-popover-fix.gif)