### PR TITLE
chore(rail): drop the unused panel eyebrow

### DIFF
--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -22,7 +22,6 @@ export interface RailProps<PanelId extends string = string> {
   children: ReactNode;
   onActivePanelChange: (panelId: PanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
-  panelEyebrow?: string;
   /** Rendered inline with the panel title, right-aligned. */
   panelAction?: ReactNode;
   panelClassName?: string;
@@ -37,7 +36,6 @@ export function Rail<PanelId extends string = string>({
   collapsed,
   items,
   panelTitle,
-  panelEyebrow,
   panelAction,
   panelClassName,
   children,
@@ -86,13 +84,6 @@ export function Rail<PanelId extends string = string>({
         >
           <div className="border-b px-4 py-3">
             <div className="flex flex-col gap-1.5">
-              {panelEyebrow && (
-                <div className="min-w-0">
-                  <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
-                    {panelEyebrow}
-                  </p>
-                </div>
-              )}
               <div
                 className="flex min-w-0 flex-wrap items-center justify-between gap-2"
                 data-slot={panelTitleRowSlot}

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -22,7 +22,6 @@ describe("Rail", () => {
         activePanelId="packages"
         collapsed={false}
         items={items}
-        panelEyebrow="Notebook"
         panelTitle="Packages"
         panelClassName="w-64"
         dataTestId="example-rail"
@@ -36,7 +35,6 @@ describe("Rail", () => {
     );
 
     expect(screen.getByTestId("example-rail")).toHaveAttribute("data-collapsed", "false");
-    expect(screen.getByText("Notebook")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
     expect(screen.queryByText("uv · 2 packages")).not.toBeInTheDocument();
     expect(screen.getByTestId("panel-content")).toHaveTextContent("Dependencies");


### PR DESCRIPTION
Follow-up to #4094. That PR moved the panel action inline with the title and stopped passing `panelEyebrow`, which left the prop with no caller.

`NotebookRail` is the only component that renders `Rail`, and it no longer passes the prop, so the only thing exercising it was its own test in `Rail.test.tsx`. Removes the prop, the render block, and that assertion.

The eyebrow markup was the sole reason the title row sat inside a `flex flex-col gap-1.5` wrapper. The wrapper stays: it now has a single child, and collapsing it would change DOM structure for no visible gain.

`Rail` is app-internal to `nteract-desktop` rather than exported from a published package, so this is not an API change for consumers.

## Not included

The workstations redesign also left the panel-level `tone` unrendered, and I had initially flagged it as dead alongside this. It is not. `NotebookWorkstationPanelTone` is defined and computed in `packages/runtimed/src/notebook-workstation-panel.ts`, has its own coverage in `packages/runtimed/tests/notebook-workstation-panel.test.ts`, and is exported from that package's public index. It is a published projection field whose in-repo renderer went away, not dead code, so removing it would delete tested behavior from a package other consumers can depend on. Left alone deliberately.
