### PR TITLE
ci(smoke): cap the MCP client SDK below 2.0

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -487,7 +487,9 @@ jobs:
 
       - name: Install MCP client SDK
         shell: pwsh
-        run: pip install "mcp>=1.0"
+        # Capped below 2.0: it renames result fields to snake_case
+        # (`isError` -> `is_error`), which scripts/smoke-mcp.py still reads.
+        run: pip install "mcp>=1.0,<2"
 
       - name: Run daemon and smoke (single step)
         # Variant 1: keep the daemon and the smoke script inside one step,
@@ -695,7 +697,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install MCP client SDK
-        run: pip install "mcp>=1.0"
+        # Capped below 2.0: it renames result fields to snake_case
+        # (`isError` -> `is_error`), which scripts/smoke-mcp.py still reads.
+        run: pip install "mcp>=1.0,<2"
 
       - name: Run daemon and smoke
         timeout-minutes: 15


### PR DESCRIPTION
## Summary

Post-merge `Smoke` runs on `main` started failing on **both Linux and Windows** today. The cause is an unpinned third-party dependency, not any of the merged changes.

- `mcp` 2.0.0 was published to PyPI on 2026-07-28 at 13:45 UTC and renames protocol result fields to snake_case — `CallToolResult.isError` is now `is_error`.
- Both smoke jobs installed `pip install "mcp>=1.0"`, so they resolved to 2.0.0 and `scripts/smoke-mcp.py` died on the very first tool call:

```
AttributeError: 'CallToolResult' object has no attribute 'isError'. Did you mean: 'is_error'?
```

This caps the range below 2.0 to restore signal now. Migrating `scripts/smoke-mcp.py` to the 2.x field names (7 call sites) is a deliberate follow-up rather than part of this unbreak.

## Evidence this was the dependency, not the merged PRs

- Runs [30405090434](https://github.com/nteract/nteract/actions/runs/30405090434) (#4097) and [30403466220](https://github.com/nteract/nteract/actions/runs/30403466220) (#4096) fail with the *identical* traceback on *both* platforms, at `smoke-mcp.py:307` in `create_notebook_checked` — before any product surface is exercised. Neither PR touches Python or the daemon.
- Last green Smoke was 2026-07-22; the first red run is the first push to `main` after mcp 2.0.0 landed.
- Smoke only triggers on `push` to `main`, so the PR checks were legitimately green — the break only surfaced post-merge.

## Test plan

- [x] `mcp>=1.0,<2` resolves to **1.29.0** in a clean venv (published 4 minutes before 2.0.0)
- [x] On 1.29.0 every SDK symbol the script uses is intact: `CallToolResult.isError`, content-block `.text` extraction, and `ClientSession.initialize` / `call_tool` / `list_tools`
- [x] `scripts/smoke-mcp.py` imports cleanly against the pinned SDK
- [x] Workflow YAML still parses; both `windows-smoke` and `linux-smoke` carry the cap (`windows-app-launch-smoke` does not install the SDK)
- [x] `cargo xtask lint --fix` passes with no changes
- [ ] Re-dispatch `Smoke` on `main` after merge to confirm green

## Note

This fixes Smoke for *future* pushes to `main`. The runs already in flight for #4093 and #4094 are executing `main`'s unpinned code and will fail the same way.

## Follow-up

`mcp-connect-harness.py` also references `isError`, but it reads raw JSON-RPC dicts rather than importing the SDK, so it is unaffected. Worth migrating `smoke-mcp.py` to 2.x and pinning `>=2,<3` — an unbounded major-version range is what let a third-party release turn `main` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)