### PR TITLE
fix(ui): stop dialogs animating in from the top left

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
Dialogs animated in from the top-left corner instead of scaling up in place. The cause is a Tailwind v3→v4 migration leftover: v4 compiles `translate-x-[-50%] translate-y-[-50%]` to the **`translate`** property, while `tw-animate-css`'s `enter`/`exit` keyframes animate **`transform`** — separate properties that compose rather than override, so the v3-era `slide-in-from-left-1/2` / `slide-in-from-top-[48%]` compensation (which only existed to cancel out the centering transform) now double-applies it. Removing those four classes leaves just the fade + 95% zoom, and upstream shadcn's v4 registry dropped exactly the same four, which independently confirms the diagnosis.

https://anaconda.com/api/projects/cc5a1842-3bf9-46f9-a8f0-1eae36f85ad4/files/2026-07-28T20-17-56_dialog-comparison.mp4

![before/after](https://anaconda.com/api/projects/cc5a1842-3bf9-46f9-a8f0-1eae36f85ad4/files/2026-07-28T20-18-17_dialog-comparison.gif)

Recorded by mounting the real `DialogContent` twice in one page — pre-fix code from `HEAD^` on the left, the committed fix on the right — with the animation slowed from 150ms to 1.2s so the motion path is visible; measured first-frame offset goes from `-75px` (off-canvas) to `+72px` (centered). Settled position is unchanged, so no dialog shifts once open. `cargo xtask lint --fix` and the full suite (2789 tests) pass locally.