### PR TITLE
fix(sift): re-arm the streaming guard and free unmounted stores

### DIFF
--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -619,6 +619,30 @@ describe("SiftTable", () => {
     expect(container.innerHTML).not.toMatch(/FIRST/);
   });
 
+  it("frees a store whose first chunk fetch fails, without waiting for unmount", async () => {
+    vi.useRealTimers();
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({ ok: false as const, status: 500, statusText: "boom" }),
+    );
+
+    render(
+      <SiftTable
+        source={{
+          kind: "arrow-stream-manifest",
+          manifest: {
+            chunks: [{ url: "http://127.0.0.1:9000/blob/chunk-0" }],
+            complete: true,
+          },
+        }}
+      />,
+    );
+
+    // The engine never took ownership, so nothing else will release it.
+    await waitFor(() => {
+      expect(predicateModule.free).toHaveBeenCalledWith(9);
+    });
+  });
+
   it("frees the WASM store on unmount after a manifest load", async () => {
     vi.useRealTimers();
     vi.stubGlobal("fetch", () =>

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -184,6 +184,15 @@ describe("SiftTable", () => {
     expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({ totalCount: 2 });
   });
 
+  it("settles table data as complete on initial mount", async () => {
+    const { container } = render(<SiftTable data={makeTableData([[1, "Alice", 95]])} />);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(container.querySelector(".sift-status-indicator")?.className).toContain(
+      "sift-status-ready",
+    );
+  });
+
   it("renders container for url prop without loading flash", async () => {
     // Mock fetch to never resolve (simulating slow load)
     vi.stubGlobal("fetch", () => new Promise(() => {}));
@@ -522,7 +531,7 @@ describe("SiftTable", () => {
       },
     });
 
-    const { rerender } = render(<SiftTable source={growing(1)} />);
+    const { container, rerender } = render(<SiftTable source={growing(1)} />);
     await waitFor(() => {
       expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
     });
@@ -532,6 +541,9 @@ describe("SiftTable", () => {
     await waitFor(() => {
       expect(predicateModule.free).toHaveBeenCalled();
     });
+    expect(container.querySelector(".sift-status-indicator")?.className).toContain(
+      "sift-status-ready",
+    );
 
     // Returning to a manifest that looks like an extension must not append to
     // the freed handle. It has to build a new store.

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -453,7 +453,11 @@ export function SiftTable({
 
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
-        engineRef.current.replaceData(tableData);
+        // A reused engine keeps whatever streaming state the previous
+        // manifest settled on, so an open stream re-arms the guard here.
+        engineRef.current.replaceData(tableData, {
+          streaming: manifest.complete === false,
+        });
         disposePendingStore = null;
         return;
       }

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -416,7 +416,7 @@ export function SiftTable({
     storeRef.current = null;
 
     if (engineRef.current) {
-      engineRef.current.replaceData(dataSource);
+      engineRef.current.replaceData(dataSource, { streaming: false });
       emitLoadMilestone(startedAt, {
         source: "table-data",
         phase: "engine-data-replaced",
@@ -433,6 +433,7 @@ export function SiftTable({
       onChange: stableOnChange,
       footerControl: getFooterControlElement(),
     });
+    engineRef.current.setStreamingDone();
     emitLoadMilestone(startedAt, {
       source: "table-data",
       phase: "engine-mounted",

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -679,6 +679,12 @@ export function SiftTable({
         })();
 
     run.catch((err) => {
+      // A store that failed before mounting has no owner: the engine never
+      // took it and `replaceData` will never free it. Release it here instead
+      // of holding the handle until the next effect run or unmount. Mounted
+      // stores have already cleared this, so the append path is unaffected.
+      disposePendingStore?.();
+      disposePendingStore = null;
       if (!cancelled) {
         const message = err instanceof Error ? err.message : String(err);
         setError(message);

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -168,6 +168,26 @@ describe("createTable", () => {
       local.destroy();
       root.remove();
     });
+
+    it("preserves the requested guard when a new column shape rebuilds the engine", () => {
+      const { engine: local, root } = mount();
+      const columns = makeColumns().slice(0, 2);
+
+      local.replaceData(
+        makeTableDataWithColumns(
+          [
+            [1, "Alice"],
+            [2, "Bob"],
+          ],
+          columns,
+        ),
+        { streaming: false },
+      );
+      expect(statusClass(root)).toContain("sift-status-ready");
+
+      local.destroy();
+      root.remove();
+    });
   });
 
   afterEach(() => {

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -119,6 +119,57 @@ describe("createTable", () => {
     engine = createTable(container, data);
   });
 
+  describe("streaming guard across data swaps", () => {
+    function statusClass(root: HTMLElement): string {
+      const el = root.querySelector(".sift-status-indicator");
+      return el?.className ?? "";
+    }
+
+    function mount(): { engine: TableEngine; root: HTMLDivElement } {
+      const root = document.createElement("div");
+      document.body.appendChild(root);
+      return { engine: createTable(root, makeTableData(makeRows(4))), root };
+    }
+
+    it("re-arms when an open stream replaces a finished one", () => {
+      const { engine: local, root } = mount();
+
+      local.setStreamingDone();
+      expect(statusClass(root)).toContain("sift-status-ready");
+
+      // A reused engine must not carry the finished state into a new stream:
+      // casts are gated on this flag and a schema mismatch would crash WASM.
+      local.replaceData(makeTableData(makeRows(4)), { streaming: true });
+      expect(statusClass(root)).toContain("sift-status-streaming");
+      expect(statusClass(root)).not.toContain("sift-status-ready");
+
+      local.destroy();
+      root.remove();
+    });
+
+    it("leaves the guard alone when the caller says nothing", () => {
+      const { engine: local, root } = mount();
+
+      local.setStreamingDone();
+      local.replaceData(makeTableData(makeRows(4)));
+      expect(statusClass(root)).toContain("sift-status-ready");
+
+      local.destroy();
+      root.remove();
+    });
+
+    it("settles a still-open engine when the replacement is complete", () => {
+      const { engine: local, root } = mount();
+
+      expect(statusClass(root)).toContain("sift-status-streaming");
+      local.replaceData(makeTableData(makeRows(4)), { streaming: false });
+      expect(statusClass(root)).toContain("sift-status-ready");
+
+      local.destroy();
+      root.remove();
+    });
+  });
+
   afterEach(() => {
     engine.destroy();
     container.remove();

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -135,6 +135,15 @@ export type ReplaceDataOptions = {
   resetSort?: boolean;
   /** Drop filters even when filtered columns survive in the new data. */
   resetFilters?: boolean;
+  /**
+   * Whether the replacement data is still arriving.
+   *
+   * The engine outlives the data it renders, and the streaming guard gates
+   * casts that would crash WASM on a schema mismatch. A caller swapping in an
+   * open stream must say so, or the guard stays open from whatever the previous
+   * data settled on. Omit to leave the current state alone.
+   */
+  streaming?: boolean;
 };
 
 export type TableEngine = {
@@ -2038,6 +2047,26 @@ export function createTable(
     scheduleRender();
   }
 
+  /// Move the streaming guard in either direction as data is swapped.
+  ///
+  /// Completion routes through `setStreamingDone` so its notify and progress-bar
+  /// teardown still run exactly once.
+  function setStreamingState(next: boolean) {
+    if (streaming === next) return;
+    if (!next) {
+      setStreamingDone();
+      return;
+    }
+    streaming = true;
+    statusIndicator.classList.remove("sift-status-ready");
+    statusIndicator.classList.add("sift-status-streaming");
+    statusIndicator.textContent = "●";
+    statusIndicator.title = "Loading data…";
+    updateRowCountDisplay();
+    // The progress bar is detached from the DOM when a stream completes, so a
+    // re-armed stream shows the indicator without it.
+  }
+
   function setStreamingDone() {
     if (!streaming) return;
     streaming = false;
@@ -2127,6 +2156,9 @@ export function createTable(
   }
 
   function replaceData(newData: TableData, replaceOptions?: ReplaceDataOptions) {
+    if (replaceOptions?.streaming !== undefined) {
+      setStreamingState(replaceOptions.streaming);
+    }
     const preserved = preserveStateFor(newData.columns, replaceOptions);
 
     if (!sameColumnShape(newData.columns)) {

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -2156,14 +2156,15 @@ export function createTable(
   }
 
   function replaceData(newData: TableData, replaceOptions?: ReplaceDataOptions) {
-    if (replaceOptions?.streaming !== undefined) {
-      setStreamingState(replaceOptions.streaming);
-    }
+    const replacementStreaming = replaceOptions?.streaming ?? streaming;
     const preserved = preserveStateFor(newData.columns, replaceOptions);
 
     if (!sameColumnShape(newData.columns)) {
       destroy();
       const replacement = createTable(container, newData, options);
+      if (!replacementStreaming) {
+        replacement.setStreamingDone();
+      }
       Object.assign(api, replacement);
       if (preserved.sort) {
         replacement.setSort(preserved.sort.column, preserved.sort.direction);
@@ -2175,6 +2176,10 @@ export function createTable(
         if (newIndex !== -1) replacement.setFilter(newIndex, preservedFilter.filter);
       }
       return;
+    }
+
+    if (replaceOptions?.streaming !== undefined) {
+      setStreamingState(replaceOptions.streaming);
     }
 
     const oldData = data;


### PR DESCRIPTION
Two manifest-lifecycle defects found while reviewing #4093 and deliberately left out of it as pre-existing. Both predate append-only store reuse.

## The streaming guard was a one-way latch

`setStreamingDone` cleared `streaming` and nothing set it back. `replaceData` never touched it. The engine outlives the data it renders, so a manifest that finished left the flag cleared for whatever loaded next.

The flag is not decoration. Casts and undo-casts are gated on it:

```ts
case "cast":
  if (streaming) break; // Cast blocked during streaming — schema mismatch would crash WASM
```

A cleared flag therefore **permits** the cast the guard exists to prevent. Load a complete manifest, then load an open one into the same engine, and casting a column mid-stream reaches the path that comment warns about. I originally described this as blocking casts, which is backwards; the risk is the inverse and worse.

`ReplaceDataOptions` gains `streaming`, and `setStreamingState` moves the flag in either direction. Completion still routes through `setStreamingDone` so its notify and progress-bar teardown run exactly once. Omitting the option leaves the flag alone, including when a changed column shape rebuilds the engine. The manifest loader re-arms the guard for an open manifest; static `TableData` explicitly settles it on mount and replacement.

One asymmetry worth naming: the progress bar is detached from the DOM once a stream completes, so a re-armed stream shows the status indicator without it. Restoring the bar would mean rebuilding a removed node, which is more than this fix needs.

## A store that failed before mounting leaked its handle

`disposePendingStore` was only invoked from effect cleanup, which runs on the next effect pass or at unmount. A store whose first chunk fetch failed held its WASM handle for as long as the component stayed mounted with an unchanged manifest.

The error path now releases it. Such a store has no owner: the engine never took it, so `replaceData` will never free it either. Mounted stores clear the disposer at mount, so the append path is unaffected.

## Verification

190 Sift tests pass. Targeted lifecycle coverage includes:

| Test | Guards |
| --- | --- |
| re-arms when an open stream replaces a finished one | the cast hazard |
| settles a still-open engine when the replacement is complete | the other direction |
| leaves the guard alone when the caller says nothing | existing callers |
| preserves the requested guard when a new column shape rebuilds the engine | engine replacement |
| settles table data as complete on initial mount | static initial data |
| rebuilds rather than appending after another source takes over the engine | open-manifest to static-data transition |
| frees a store whose first chunk fetch fails | the leak |

The existing-caller test passes on `main` too, by design: it exists to catch a future change to the default rather than to prove today's bug.

Assertions go through the rendered status indicator rather than the `onChange` state, because `onChange` does not settle synchronously under the suite's fake timers.

Additional local gates:

- `pnpm --dir packages/sift build:lib`
- `cargo xtask lint --fix`
