### PR TITLE
fix(notice): collapsible errors, icon size, gallery

### DIFF
--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -590,11 +590,11 @@ function NoticeIcon({ tone }: { tone: NotebookNoticeTone }) {
   switch (tone) {
     case "warning":
     case "error":
-      return <AlertTriangle className="size-3.5" />;
+      return <AlertTriangle />;
     case "success":
-      return <ShieldCheck className="size-3.5" />;
+      return <ShieldCheck />;
     default:
-      return <Info className="size-3.5" />;
+      return <Info />;
   }
 }
 

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -258,7 +258,7 @@ function RuntimeBanners() {
         >
           <NotebookNotice
             tone="warning"
-            icon={<AlertTriangle className="size-4" aria-hidden="true" />}
+            icon={<AlertTriangle aria-hidden="true" />}
             title="Document attention needed."
             actions={<NotebookNoticeAction onClick={noop}>Review</NotebookNoticeAction>}
           >

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -11,7 +11,11 @@ import {
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   cloudConnectionErrorAcceptsAccessDiagnostic,
 } from "../viewer/connection-diagnostics";
-import { CloudNotebookNotices, cloudNotebookHasNotices } from "../viewer/notices";
+import {
+  CloudNotebookNotices,
+  cloudNotebookHasNotices,
+  splitNoticeMessage,
+} from "../viewer/notices";
 
 globalThis.React = React;
 
@@ -445,6 +449,79 @@ test("connection notice sanitizer redacts http(s) URLs down to host and path", (
   assert.match(html, /https:\/\/cdn\.example\/assets\/runtimed_wasm_bg\.wasm/);
   assert.doesNotMatch(html, /SECRET/);
   assert.doesNotMatch(html, /token=/);
+});
+
+test("short single-line notice copy stays entirely on the bar", () => {
+  assert.deepEqual(splitNoticeMessage("Live room needs attention."), {
+    summary: "Live room needs attention.",
+    details: null,
+  });
+});
+
+test("multiline notice copy keeps a lead line on the bar and the rest in details", () => {
+  const { summary, details } = splitNoticeMessage(
+    "Failed to prepare environment\nTraceback (most recent call last):\n  ModuleNotFoundError",
+  );
+
+  assert.equal(summary, "Failed to prepare environment");
+  assert.match(details ?? "", /ModuleNotFoundError$/);
+});
+
+test("a long single-line message is clipped on a word boundary with the full text in details", () => {
+  const long = `cloud room rejected frame: ${"solver-conflict ".repeat(20)}`;
+  const { summary, details } = splitNoticeMessage(long);
+
+  assert.ok(summary.length < long.trim().length);
+  assert.ok(summary.endsWith("…"));
+  assert.doesNotMatch(summary, /solver-con…$/);
+  assert.equal(details, long.trim());
+});
+
+test("a long connection error collapses behind a disclosure instead of growing the bar", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: `cloud room rejected frame: ${"detail-token ".repeat(30)}`,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onRetryConnection: () => {},
+    }),
+  );
+
+  assert.match(html, /Live room needs attention/);
+  assert.match(html, /<details/);
+  assert.match(html, /Show error details/);
+  // The bar carries a clipped lead line; the full string lives only in the
+  // disclosure, so the header can never grow unbounded.
+  const bar = html.slice(0, html.indexOf("<details"));
+  assert.match(bar, /cloud room rejected frame/);
+  assert.match(bar, /…/);
+  const barTokens = bar.match(/detail-token/g)?.length ?? 0;
+  const detailTokens = html.slice(html.indexOf("<details")).match(/detail-token/g)?.length ?? 0;
+  assert.equal(detailTokens, 30);
+  assert.ok(barTokens < detailTokens);
+});
+
+test("a long load error routes its raw text through the details disclosure", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      status: {
+        kind: "error",
+        message: "Notebook load failed\nEndpoint not found at /tmp/runtimed.sock",
+      },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Unable to load notebook/);
+  assert.match(html, /Notebook load failed/);
+  assert.match(html, /Show error details/);
+  assert.match(html, /Endpoint not found at/);
 });
 
 test("cloud notebook notices keep dev diagnostics inside the shared stack", () => {

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -11,11 +11,7 @@ import {
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   cloudConnectionErrorAcceptsAccessDiagnostic,
 } from "../viewer/connection-diagnostics";
-import {
-  CloudNotebookNotices,
-  cloudNotebookHasNotices,
-  splitNoticeMessage,
-} from "../viewer/notices";
+import { CloudNotebookNotices, cloudNotebookHasNotices } from "../viewer/notices";
 
 globalThis.React = React;
 
@@ -449,79 +445,6 @@ test("connection notice sanitizer redacts http(s) URLs down to host and path", (
   assert.match(html, /https:\/\/cdn\.example\/assets\/runtimed_wasm_bg\.wasm/);
   assert.doesNotMatch(html, /SECRET/);
   assert.doesNotMatch(html, /token=/);
-});
-
-test("short single-line notice copy stays entirely on the bar", () => {
-  assert.deepEqual(splitNoticeMessage("Live room needs attention."), {
-    summary: "Live room needs attention.",
-    details: null,
-  });
-});
-
-test("multiline notice copy keeps a lead line on the bar and the rest in details", () => {
-  const { summary, details } = splitNoticeMessage(
-    "Failed to prepare environment\nTraceback (most recent call last):\n  ModuleNotFoundError",
-  );
-
-  assert.equal(summary, "Failed to prepare environment");
-  assert.match(details ?? "", /ModuleNotFoundError$/);
-});
-
-test("a long single-line message is clipped on a word boundary with the full text in details", () => {
-  const long = `cloud room rejected frame: ${"solver-conflict ".repeat(20)}`;
-  const { summary, details } = splitNoticeMessage(long);
-
-  assert.ok(summary.length < long.trim().length);
-  assert.ok(summary.endsWith("…"));
-  assert.doesNotMatch(summary, /solver-con…$/);
-  assert.equal(details, long.trim());
-});
-
-test("a long connection error collapses behind a disclosure instead of growing the bar", () => {
-  const html = renderToStaticMarkup(
-    React.createElement(CloudNotebookNotices, {
-      authState: authState("anonymous"),
-      authRenewal: { kind: "idle", message: null },
-      connectionError: `cloud room rejected frame: ${"detail-token ".repeat(30)}`,
-      status: { kind: "ready", message: "Ready" },
-      onResetAuth: () => {},
-      onRetryConnection: () => {},
-    }),
-  );
-
-  assert.match(html, /Live room needs attention/);
-  assert.match(html, /<details/);
-  assert.match(html, /Show error details/);
-  // The bar carries a clipped lead line; the full string lives only in the
-  // disclosure, so the header can never grow unbounded.
-  const bar = html.slice(0, html.indexOf("<details"));
-  assert.match(bar, /cloud room rejected frame/);
-  assert.match(bar, /…/);
-  const barTokens = bar.match(/detail-token/g)?.length ?? 0;
-  const detailTokens = html.slice(html.indexOf("<details")).match(/detail-token/g)?.length ?? 0;
-  assert.equal(detailTokens, 30);
-  assert.ok(barTokens < detailTokens);
-});
-
-test("a long load error routes its raw text through the details disclosure", () => {
-  const html = renderToStaticMarkup(
-    React.createElement(CloudNotebookNotices, {
-      authState: authState("oidc"),
-      authRenewal: { kind: "idle", message: null },
-      connectionError: null,
-      hasAppSession: true,
-      status: {
-        kind: "error",
-        message: "Notebook load failed\nEndpoint not found at /tmp/runtimed.sock",
-      },
-      onResetAuth: () => {},
-    }),
-  );
-
-  assert.match(html, /Unable to load notebook/);
-  assert.match(html, /Notebook load failed/);
-  assert.match(html, /Show error details/);
-  assert.match(html, /Endpoint not found at/);
 });
 
 test("cloud notebook notices keep dev diagnostics inside the shared stack", () => {

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -617,14 +617,9 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   const noticesCss = cssText.match(/\.cloud-notebook-notices \{(?<body>[\s\S]*?)\n\}/)?.groups
     ?.body;
   assert.ok(noticesCss);
-  // Notices size to content above a collapsed floor with no cap and no scroll
-  // surface of their own: long error text lives behind the details disclosure,
-  // whose <pre> owns the only scrolling.
-  assert.match(noticesCss, /flex: 0 0 auto;/);
-  assert.match(noticesCss, /min-height: var\(--cloud-notice-height\);/);
-  assert.doesNotMatch(noticesCss, /max-height:/);
-  assert.doesNotMatch(noticesCss, /\n {2}height: var\(--cloud-notice-height\);/);
-  assert.doesNotMatch(noticesCss, /overflow/);
+  assert.match(noticesCss, /flex: 0 0 var\(--cloud-notice-height\);/);
+  assert.match(noticesCss, /height: var\(--cloud-notice-height\);/);
+  assert.match(noticesCss, /overflow-y: auto;/);
   assert.match(noticesCss, /animation: cloud-notice-enter/);
   assert.doesNotMatch(noticesCss, /position: absolute;/);
   assert.match(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -609,27 +609,6 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
   assert.match(sourceText, /cloud-notebook-shell--command-toolbar/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
-  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-height: 3rem;/);
-  assert.match(
-    cssText,
-    /\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-height: 3rem;/,
-  );
-  const noticesCss = cssText.match(/\.cloud-notebook-notices \{(?<body>[\s\S]*?)\n\}/)?.groups
-    ?.body;
-  assert.ok(noticesCss);
-  assert.match(noticesCss, /flex: 0 0 var\(--cloud-notice-height\);/);
-  assert.match(noticesCss, /height: var\(--cloud-notice-height\);/);
-  assert.match(noticesCss, /overflow-y: auto;/);
-  assert.match(noticesCss, /animation: cloud-notice-enter/);
-  assert.doesNotMatch(noticesCss, /position: absolute;/);
-  assert.match(
-    cssText,
-    /\.cloud-notebook-notices \[data-slot="notebook-notice"\] \{[\s\S]*min-height: var\(--cloud-notice-height\);/,
-  );
-  assert.match(
-    cssText,
-    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-notebook-shell \{[\s\S]*--cloud-notice-height: 3rem;[\s\S]*\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-height: 3rem;/,
-  );
   assert.match(
     cssText,
     /@media \(max-width: 900px\) \{[\s\S]*\.cloud-room-toolbar \{[\s\S]*flex-wrap: nowrap;/,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -610,7 +610,6 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(sourceText, /cloud-notebook-shell--command-toolbar/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-height: 3rem;/);
-  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-max-height: 50vh;/);
   assert.match(
     cssText,
     /\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-height: 3rem;/,
@@ -618,13 +617,14 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   const noticesCss = cssText.match(/\.cloud-notebook-notices \{(?<body>[\s\S]*?)\n\}/)?.groups
     ?.body;
   assert.ok(noticesCss);
-  // Notices size to content between a collapsed floor and a viewport-relative
-  // cap, so an expanded traceback is readable instead of clipped to one row.
+  // Notices size to content above a collapsed floor with no cap and no scroll
+  // surface of their own: long error text lives behind the details disclosure,
+  // whose <pre> owns the only scrolling.
   assert.match(noticesCss, /flex: 0 0 auto;/);
   assert.match(noticesCss, /min-height: var\(--cloud-notice-height\);/);
-  assert.match(noticesCss, /max-height: var\(--cloud-notice-max-height\);/);
+  assert.doesNotMatch(noticesCss, /max-height:/);
   assert.doesNotMatch(noticesCss, /\n {2}height: var\(--cloud-notice-height\);/);
-  assert.match(noticesCss, /overflow-y: auto;/);
+  assert.doesNotMatch(noticesCss, /overflow/);
   assert.match(noticesCss, /animation: cloud-notice-enter/);
   assert.doesNotMatch(noticesCss, /position: absolute;/);
   assert.match(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -610,6 +610,7 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(sourceText, /cloud-notebook-shell--command-toolbar/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-height: 3rem;/);
+  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-max-height: 50vh;/);
   assert.match(
     cssText,
     /\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-height: 3rem;/,
@@ -617,8 +618,12 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   const noticesCss = cssText.match(/\.cloud-notebook-notices \{(?<body>[\s\S]*?)\n\}/)?.groups
     ?.body;
   assert.ok(noticesCss);
-  assert.match(noticesCss, /flex: 0 0 var\(--cloud-notice-height\);/);
-  assert.match(noticesCss, /height: var\(--cloud-notice-height\);/);
+  // Notices size to content between a collapsed floor and a viewport-relative
+  // cap, so an expanded traceback is readable instead of clipped to one row.
+  assert.match(noticesCss, /flex: 0 0 auto;/);
+  assert.match(noticesCss, /min-height: var\(--cloud-notice-height\);/);
+  assert.match(noticesCss, /max-height: var\(--cloud-notice-max-height\);/);
+  assert.doesNotMatch(noticesCss, /\n {2}height: var\(--cloud-notice-height\);/);
   assert.match(noticesCss, /overflow-y: auto;/);
   assert.match(noticesCss, /animation: cloud-notice-enter/);
   assert.doesNotMatch(noticesCss, /position: absolute;/);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -168,7 +168,6 @@ body {
 
 .cloud-notebook-shell {
   --cloud-notice-height: 3rem;
-  --cloud-notice-max-height: 50vh;
 
   display: flex;
   position: relative;
@@ -200,20 +199,18 @@ body {
 /* Notices grow with their content instead of being pinned to a single row:
    an expanded traceback needs the space, and clamping it clipped the text into
    the notebook body. `--cloud-notice-height` stays the collapsed floor so a
-   one-line bar keeps its familiar height; the max keeps a long detail block
-   from swallowing the notebook, scrolling inside the region instead. */
+   one-line bar keeps its familiar height. No cap and no scrolling here — long
+   error text lives behind a disclosure whose own <pre> scrolls, so the region
+   never becomes a second scroll surface competing with the notebook. */
 .cloud-notebook-notices {
   display: grid;
   flex: 0 0 auto;
   min-height: var(--cloud-notice-height);
-  max-height: var(--cloud-notice-max-height);
   z-index: 18;
   gap: 0;
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
   box-shadow: 0 4px 10px color-mix(in srgb, #000 4%, transparent);
   animation: cloud-notice-enter 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -196,34 +196,23 @@ body {
   overflow: hidden;
 }
 
+/* Region chrome only — do not restyle [data-slot="notebook-notice"] /
+   notebook-notice-stack; shared NotebookNotice owns tone, border-b, padding,
+   and stack gap. Size to content so multi-notice stacks and disclosures are
+   not clipped; `--cloud-notice-height` is a one-line floor so a bare bar
+   keeps a stable height. Region border-bottom keeps a separator under the
+   notices block when it meets the stage. */
 .cloud-notebook-notices {
   display: grid;
-  flex: 0 0 var(--cloud-notice-height);
-  height: var(--cloud-notice-height);
+  flex: 0 0 auto;
   min-height: var(--cloud-notice-height);
   z-index: 18;
   gap: 0;
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
   box-shadow: 0 4px 10px color-mix(in srgb, #000 4%, transparent);
   animation: cloud-notice-enter 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-
-.cloud-notebook-notices [data-slot="notebook-notice-stack"] {
-  min-height: 100%;
-  gap: 0;
-}
-
-.cloud-notebook-notices [data-slot="notebook-notice"] {
-  min-height: var(--cloud-notice-height);
-  align-items: center;
-  border: 0;
-  border-radius: 0;
-  padding: 0.5rem clamp(0.5rem, 2vw, 1rem) 0.5rem clamp(0.75rem, 4vw, 2rem);
-  background: color-mix(in srgb, currentColor 6%, var(--background));
 }
 
 @keyframes cloud-notice-enter {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -196,21 +196,18 @@ body {
   overflow: hidden;
 }
 
-/* Notices grow with their content instead of being pinned to a single row:
-   an expanded traceback needs the space, and clamping it clipped the text into
-   the notebook body. `--cloud-notice-height` stays the collapsed floor so a
-   one-line bar keeps its familiar height. No cap and no scrolling here — long
-   error text lives behind a disclosure whose own <pre> scrolls, so the region
-   never becomes a second scroll surface competing with the notebook. */
 .cloud-notebook-notices {
   display: grid;
-  flex: 0 0 auto;
+  flex: 0 0 var(--cloud-notice-height);
+  height: var(--cloud-notice-height);
   min-height: var(--cloud-notice-height);
   z-index: 18;
   gap: 0;
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   box-shadow: 0 4px 10px color-mix(in srgb, #000 4%, transparent);
   animation: cloud-notice-enter 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
@@ -220,12 +217,9 @@ body {
   gap: 0;
 }
 
-/* `justify-content` (not `align-items`) because the notice is a column: it
-   vertically centers a bare one-line bar inside the collapsed floor, and goes
-   inert once an expanded detail row pushes the notice past that floor. */
 .cloud-notebook-notices [data-slot="notebook-notice"] {
   min-height: var(--cloud-notice-height);
-  justify-content: center;
+  align-items: center;
   border: 0;
   border-radius: 0;
   padding: 0.5rem clamp(0.5rem, 2vw, 1rem) 0.5rem clamp(0.75rem, 4vw, 2rem);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -168,6 +168,7 @@ body {
 
 .cloud-notebook-shell {
   --cloud-notice-height: 3rem;
+  --cloud-notice-max-height: 50vh;
 
   display: flex;
   position: relative;
@@ -196,11 +197,16 @@ body {
   overflow: hidden;
 }
 
+/* Notices grow with their content instead of being pinned to a single row:
+   an expanded traceback needs the space, and clamping it clipped the text into
+   the notebook body. `--cloud-notice-height` stays the collapsed floor so a
+   one-line bar keeps its familiar height; the max keeps a long detail block
+   from swallowing the notebook, scrolling inside the region instead. */
 .cloud-notebook-notices {
   display: grid;
-  flex: 0 0 var(--cloud-notice-height);
-  height: var(--cloud-notice-height);
+  flex: 0 0 auto;
   min-height: var(--cloud-notice-height);
+  max-height: var(--cloud-notice-max-height);
   z-index: 18;
   gap: 0;
   border-bottom: 1px solid var(--border);
@@ -217,9 +223,12 @@ body {
   gap: 0;
 }
 
+/* `justify-content` (not `align-items`) because the notice is a column: it
+   vertically centers a bare one-line bar inside the collapsed floor, and goes
+   inert once an expanded detail row pushes the notice past that floor. */
 .cloud-notebook-notices [data-slot="notebook-notice"] {
   min-height: var(--cloud-notice-height);
-  align-items: center;
+  justify-content: center;
   border: 0;
   border-radius: 0;
   padding: 0.5rem clamp(0.5rem, 2vw, 1rem) 0.5rem clamp(0.75rem, 4vw, 2rem);

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -2081,11 +2081,7 @@ function cloudAccessRequestNotice(
 
   if (projection.kind === "error") {
     return (
-      <NotebookNotice
-        tone={projection.tone}
-        icon={<AlertCircle className="h-4 w-4" />}
-        title={projection.title}
-      >
+      <NotebookNotice tone={projection.tone} icon={<AlertCircle />} title={projection.title}>
         {projection.message}
       </NotebookNotice>
     );
@@ -2095,7 +2091,7 @@ function cloudAccessRequestNotice(
     return (
       <NotebookNotice
         tone={projection.tone}
-        icon={<Loader2 className="h-4 w-4 animate-spin" />}
+        icon={<Loader2 className="animate-spin" />}
         title={projection.title}
       >
         {projection.message}
@@ -2105,11 +2101,7 @@ function cloudAccessRequestNotice(
 
   if (projection.kind === "approved") {
     return (
-      <NotebookNotice
-        tone={projection.tone}
-        icon={<Check className="h-4 w-4" />}
-        title={projection.title}
-      >
+      <NotebookNotice tone={projection.tone} icon={<Check />} title={projection.title}>
         {projection.message}
       </NotebookNotice>
     );
@@ -2117,11 +2109,7 @@ function cloudAccessRequestNotice(
 
   if (projection.kind === "denied") {
     return (
-      <NotebookNotice
-        tone={projection.tone}
-        icon={<X className="h-4 w-4" />}
-        title={projection.title}
-      >
+      <NotebookNotice tone={projection.tone} icon={<X />} title={projection.title}>
         {projection.message}
       </NotebookNotice>
     );
@@ -2129,22 +2117,14 @@ function cloudAccessRequestNotice(
 
   if (projection.kind === "dismissed") {
     return (
-      <NotebookNotice
-        tone={projection.tone}
-        icon={<Info className="h-4 w-4" />}
-        title={projection.title}
-      >
+      <NotebookNotice tone={projection.tone} icon={<Info />} title={projection.title}>
         {projection.message}
       </NotebookNotice>
     );
   }
 
   return (
-    <NotebookNotice
-      tone={projection.tone}
-      icon={<AlertCircle className="h-4 w-4" />}
-      title={projection.title}
-    >
+    <NotebookNotice tone={projection.tone} icon={<AlertCircle />} title={projection.title}>
       {projection.message}
     </NotebookNotice>
   );

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -3,7 +3,6 @@ import { AlertCircle, Cloud, CloudOff, ImageOff, Loader2, LogIn, RotateCcw } fro
 import {
   NotebookNotice,
   NotebookNoticeAction,
-  NotebookNoticeDetails,
   NotebookNoticeStack,
 } from "@/components/notebook/NotebookNotice";
 import { prototypeAuthSummary, type CloudPrototypeAuthState } from "./collaborator-auth";
@@ -238,7 +237,6 @@ export function CloudNotebookNotices({
     !(connectionNotice && status.kind === "loading") &&
     !signInRequired &&
     !isStatusDerivedFromConnectionError(status, connectionError);
-  const statusMessage = splitNoticeMessage(status.message);
   const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
     authState,
     hasAppSession,
@@ -364,13 +362,6 @@ export function CloudNotebookNotices({
               onSignInAgain={onSignInAgain}
             />
           }
-          details={
-            connectionNotice.details ? (
-              <NotebookNoticeDetails label="Show error details">
-                {connectionNotice.details}
-              </NotebookNoticeDetails>
-            ) : undefined
-          }
         >
           {connectionNotice.message}
         </NotebookNotice>
@@ -410,15 +401,8 @@ export function CloudNotebookNotices({
             )
           }
           title={status.kind === "error" ? "Unable to load notebook." : "Loading notebook."}
-          details={
-            statusMessage.details ? (
-              <NotebookNoticeDetails label="Show error details">
-                {statusMessage.details}
-              </NotebookNoticeDetails>
-            ) : undefined
-          }
         >
-          {statusMessage.summary}
+          {status.message}
         </NotebookNotice>
       ) : null}
     </NotebookNoticeStack>
@@ -563,44 +547,12 @@ function isStatusDerivedFromConnectionError(
   );
 }
 
-/**
- * Longest machine-derived message kept inline on the notice bar. Past this a
- * lead line stays on the bar and the whole string moves behind a disclosure,
- * matching the kernel-launch banner: the notices region grows with content, so
- * an unbounded wall of stderr would otherwise shove the notebook down the page.
- */
-const NOTICE_INLINE_MESSAGE_MAX = 160;
-
-/**
- * Split a free-form error string into the line that goes on the bar and the
- * full text for the disclosure. Human-authored notice copy is short and skips
- * this entirely; only daemon/transport/asset strings can run long or multiline.
- */
-export function splitNoticeMessage(message: string): {
-  summary: string;
-  details: string | null;
-} {
-  const full = message.trim();
-  const firstLine = (full.split("\n", 1)[0] ?? "").trim();
-  if (firstLine === full && full.length <= NOTICE_INLINE_MESSAGE_MAX) {
-    return { summary: full, details: null };
-  }
-  if (firstLine.length <= NOTICE_INLINE_MESSAGE_MAX) {
-    return { summary: firstLine, details: full };
-  }
-  const clipped = firstLine.slice(0, NOTICE_INLINE_MESSAGE_MAX);
-  const lastSpace = clipped.lastIndexOf(" ");
-  const summary = lastSpace > NOTICE_INLINE_MESSAGE_MAX / 2 ? clipped.slice(0, lastSpace) : clipped;
-  return { summary: `${summary.trimEnd()}…`, details: full };
-}
-
 function cloudConnectionNoticeDisplay(
   error: string,
   hasReadableSnapshot: boolean,
 ): {
   title: string;
   message: string;
-  details?: string | null;
   tone: "warning" | "success";
 } | null {
   if (isTransportReconnectError(error)) {
@@ -651,11 +603,9 @@ function cloudConnectionNoticeDisplay(
   }
 
   if (isRuntimedWasmAssetFailure(error)) {
-    const { summary, details } = splitNoticeMessage(sanitizeCloudConnectionError(error));
     return {
       title: "Notebook engine failed to load.",
-      message: summary,
-      details,
+      message: sanitizeCloudConnectionError(error),
       tone: "warning",
     };
   }
@@ -675,11 +625,9 @@ function cloudConnectionNoticeDisplay(
     };
   }
 
-  const { summary, details } = splitNoticeMessage(sanitizeCloudConnectionError(error));
   return {
     title: "Live room needs attention.",
-    message: summary,
-    details,
+    message: sanitizeCloudConnectionError(error),
     tone: "warning",
   };
 }

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, Cloud, CloudOff, ImageOff, Loader2, LogIn, RotateCcw } fro
 import {
   NotebookNotice,
   NotebookNoticeAction,
+  NotebookNoticeDetails,
   NotebookNoticeStack,
 } from "@/components/notebook/NotebookNotice";
 import { prototypeAuthSummary, type CloudPrototypeAuthState } from "./collaborator-auth";
@@ -237,6 +238,7 @@ export function CloudNotebookNotices({
     !(connectionNotice && status.kind === "loading") &&
     !signInRequired &&
     !isStatusDerivedFromConnectionError(status, connectionError);
+  const statusMessage = splitNoticeMessage(status.message);
   const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
     authState,
     hasAppSession,
@@ -362,6 +364,13 @@ export function CloudNotebookNotices({
               onSignInAgain={onSignInAgain}
             />
           }
+          details={
+            connectionNotice.details ? (
+              <NotebookNoticeDetails label="Show error details">
+                {connectionNotice.details}
+              </NotebookNoticeDetails>
+            ) : undefined
+          }
         >
           {connectionNotice.message}
         </NotebookNotice>
@@ -401,8 +410,15 @@ export function CloudNotebookNotices({
             )
           }
           title={status.kind === "error" ? "Unable to load notebook." : "Loading notebook."}
+          details={
+            statusMessage.details ? (
+              <NotebookNoticeDetails label="Show error details">
+                {statusMessage.details}
+              </NotebookNoticeDetails>
+            ) : undefined
+          }
         >
-          {status.message}
+          {statusMessage.summary}
         </NotebookNotice>
       ) : null}
     </NotebookNoticeStack>
@@ -547,12 +563,44 @@ function isStatusDerivedFromConnectionError(
   );
 }
 
+/**
+ * Longest machine-derived message kept inline on the notice bar. Past this a
+ * lead line stays on the bar and the whole string moves behind a disclosure,
+ * matching the kernel-launch banner: the notices region grows with content, so
+ * an unbounded wall of stderr would otherwise shove the notebook down the page.
+ */
+const NOTICE_INLINE_MESSAGE_MAX = 160;
+
+/**
+ * Split a free-form error string into the line that goes on the bar and the
+ * full text for the disclosure. Human-authored notice copy is short and skips
+ * this entirely; only daemon/transport/asset strings can run long or multiline.
+ */
+export function splitNoticeMessage(message: string): {
+  summary: string;
+  details: string | null;
+} {
+  const full = message.trim();
+  const firstLine = (full.split("\n", 1)[0] ?? "").trim();
+  if (firstLine === full && full.length <= NOTICE_INLINE_MESSAGE_MAX) {
+    return { summary: full, details: null };
+  }
+  if (firstLine.length <= NOTICE_INLINE_MESSAGE_MAX) {
+    return { summary: firstLine, details: full };
+  }
+  const clipped = firstLine.slice(0, NOTICE_INLINE_MESSAGE_MAX);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const summary = lastSpace > NOTICE_INLINE_MESSAGE_MAX / 2 ? clipped.slice(0, lastSpace) : clipped;
+  return { summary: `${summary.trimEnd()}…`, details: full };
+}
+
 function cloudConnectionNoticeDisplay(
   error: string,
   hasReadableSnapshot: boolean,
 ): {
   title: string;
   message: string;
+  details?: string | null;
   tone: "warning" | "success";
 } | null {
   if (isTransportReconnectError(error)) {
@@ -603,9 +651,11 @@ function cloudConnectionNoticeDisplay(
   }
 
   if (isRuntimedWasmAssetFailure(error)) {
+    const { summary, details } = splitNoticeMessage(sanitizeCloudConnectionError(error));
     return {
       title: "Notebook engine failed to load.",
-      message: sanitizeCloudConnectionError(error),
+      message: summary,
+      details,
       tone: "warning",
     };
   }
@@ -625,9 +675,11 @@ function cloudConnectionNoticeDisplay(
     };
   }
 
+  const { summary, details } = splitNoticeMessage(sanitizeCloudConnectionError(error));
   return {
     title: "Live room needs attention.",
-    message: sanitizeCloudConnectionError(error),
+    message: summary,
+    details,
     tone: "warning",
   };
 }

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -264,7 +264,7 @@ export function CloudNotebookNotices({
       {shouldShowAnonymousViewerAuthNotice ? (
         <NotebookNotice
           tone="info"
-          icon={<LogIn className="h-4 w-4" />}
+          icon={<LogIn />}
           title="Viewing anonymously."
           actions={
             onSignInAgain ? (
@@ -280,7 +280,7 @@ export function CloudNotebookNotices({
       {shouldShowSignInRequiredNotice ? (
         <NotebookNotice
           tone="warning"
-          icon={<LogIn className="h-4 w-4" />}
+          icon={<LogIn />}
           title="Sign in required."
           actions={
             onSignInAgain ? (
@@ -295,7 +295,7 @@ export function CloudNotebookNotices({
       {shouldShowAuthNotice ? (
         <NotebookNotice
           tone="error"
-          icon={<AlertCircle className="h-4 w-4" />}
+          icon={<AlertCircle />}
           title="Auth needs attention."
           actions={<AuthNoticeAction onResetAuth={onResetAuth} onSignInAgain={onSignInAgain} />}
         >
@@ -307,11 +307,7 @@ export function CloudNotebookNotices({
         <NotebookNotice
           tone={authRenewal.kind === "failed" ? "error" : "info"}
           icon={
-            authRenewal.kind === "failed" ? (
-              <AlertCircle className="h-4 w-4" />
-            ) : (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            )
+            authRenewal.kind === "failed" ? <AlertCircle /> : <Loader2 className="animate-spin" />
           }
           title={authRenewal.kind === "failed" ? "Sign-in refresh failed." : "Refreshing sign-in."}
           actions={
@@ -325,17 +321,13 @@ export function CloudNotebookNotices({
       ) : null}
 
       {sustainedReconnecting ? (
-        <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
+        <NotebookNotice tone="info" icon={<CloudOff />} title="Reconnecting.">
           Your edits are kept locally and will sync when the connection returns.
         </NotebookNotice>
       ) : null}
 
       {syncHealStalled && !sustainedReconnecting ? (
-        <NotebookNotice
-          tone="info"
-          icon={<CloudOff className="h-4 w-4" />}
-          title="Sync is stalled."
-        >
+        <NotebookNotice tone="info" icon={<CloudOff />} title="Sync is stalled.">
           Your edits are kept locally. This clears as soon as the room catches up.
         </NotebookNotice>
       ) : null}
@@ -343,7 +335,7 @@ export function CloudNotebookNotices({
       {offlineMergeNotice ? (
         <NotebookNotice
           tone="info"
-          icon={<Cloud className="h-4 w-4" />}
+          icon={<Cloud />}
           title={offlineMergeNoticeTitle(offlineMergeNotice)}
         >
           {offlineMergeRemovedCellsLine(offlineMergeNotice.removedEditedCellCount)}
@@ -353,7 +345,7 @@ export function CloudNotebookNotices({
       {connectionNotice ? (
         <NotebookNotice
           tone={connectionNotice.tone}
-          icon={<CloudOff className="h-4 w-4" />}
+          icon={<CloudOff />}
           title={connectionNotice.title}
           actions={
             <ConnectionNoticeAction
@@ -370,14 +362,11 @@ export function CloudNotebookNotices({
       {rendererAssetError ? (
         <NotebookNotice
           tone="warning"
-          icon={<ImageOff className="h-4 w-4" />}
+          icon={<ImageOff />}
           title="Output renderer unavailable."
           actions={
             onRetryRendererAssets ? (
-              <NotebookNoticeAction
-                onClick={onRetryRendererAssets}
-                icon={<RotateCcw className="h-3 w-3" />}
-              >
+              <NotebookNoticeAction onClick={onRetryRendererAssets} icon={<RotateCcw />}>
                 Retry
               </NotebookNoticeAction>
             ) : null
@@ -393,13 +382,7 @@ export function CloudNotebookNotices({
       {shouldShowStatusNotice ? (
         <NotebookNotice
           tone={status.kind === "error" ? "error" : "info"}
-          icon={
-            status.kind === "error" ? (
-              <AlertCircle className="h-4 w-4" />
-            ) : (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            )
-          }
+          icon={status.kind === "error" ? <AlertCircle /> : <Loader2 className="animate-spin" />}
           title={status.kind === "error" ? "Unable to load notebook." : "Loading notebook."}
         >
           {status.message}
@@ -437,7 +420,7 @@ function AuthNoticeAction({
   }
 
   return (
-    <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw className="h-3 w-3" />}>
+    <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw />}>
       Clear stale sign-in
     </NotebookNoticeAction>
   );
@@ -455,7 +438,7 @@ function SignInNoticeAction({
       onClick={() => {
         void onSignInAgain();
       }}
-      icon={<LogIn className="h-3 w-3" />}
+      icon={<LogIn />}
     >
       {children}
     </NotebookNoticeAction>
@@ -476,7 +459,7 @@ function ConnectionNoticeAction({
     // a signed-in session without fixing anything. retryLiveConnection is
     // the documented re-entry and genuinely re-imports.
     return (
-      <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw className="h-3 w-3" />}>
+      <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw />}>
         Retry
       </NotebookNoticeAction>
     );
@@ -492,7 +475,7 @@ function ConnectionNoticeAction({
 
   if (onRetryConnection) {
     return (
-      <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw className="h-3 w-3" />}>
+      <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw />}>
         Retry
       </NotebookNoticeAction>
     );

--- a/apps/notebook/gallery/App.tsx
+++ b/apps/notebook/gallery/App.tsx
@@ -4,6 +4,7 @@ import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { PrivacySection } from "../settings/sections/Privacy";
+import { NotebookNoticesGallery } from "./NotebookNoticesGallery";
 
 /**
  * Standalone component gallery.
@@ -28,6 +29,17 @@ export default function App() {
             app.
           </p>
         </header>
+
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold tracking-tight">Notebook notices</h2>
+            <p className="text-sm text-foreground/80">
+              Every banner/gate that can prevent — or explain the inability to — run cells, using
+              the real shipped components. Review surface for the notice-consolidation work.
+            </p>
+          </div>
+          <NotebookNoticesGallery />
+        </section>
 
         <Section
           title="TelemetryDisclosureCard"

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -78,13 +78,11 @@ function NoComputeNotice({ isOwner }: { isOwner: boolean }) {
   return (
     <NotebookNotice
       tone="info"
-      icon={<Cpu className="h-4 w-4" />}
+      icon={<Cpu />}
       title="No compute attached."
       actions={
         isOwner ? (
-          <NotebookNoticeAction icon={<RotateCw className="h-3 w-3" />}>
-            Start compute
-          </NotebookNoticeAction>
+          <NotebookNoticeAction icon={<RotateCw />}>Start compute</NotebookNoticeAction>
         ) : null
       }
     >
@@ -117,7 +115,7 @@ const viewableScenarios: Scenario[] = [
     label: "Reconnecting",
     note: "Transport dropped past the 3s debounce. Quiet, no CTA — the transport retries forever on its own.",
     render: () => (
-      <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
+      <NotebookNotice tone="info" icon={<CloudOff />} title="Reconnecting.">
         Your edits are kept locally and will sync when the connection returns.
       </NotebookNotice>
     ),
@@ -141,7 +139,7 @@ const viewableScenarios: Scenario[] = [
     render: () => (
       <NotebookNotice
         tone="warning"
-        icon={<CloudOff className="h-4 w-4" />}
+        icon={<CloudOff />}
         title="Live room needs attention."
         details={
           <NotebookNoticeDetails label="Show error details">
@@ -197,11 +195,7 @@ const viewableScenarios: Scenario[] = [
       <NotebookNotice
         tone="error"
         title="Auth needs attention."
-        actions={
-          <NotebookNoticeAction icon={<LogIn className="h-3 w-3" />}>
-            Sign in again
-          </NotebookNoticeAction>
-        }
+        actions={<NotebookNoticeAction icon={<LogIn />}>Sign in again</NotebookNoticeAction>}
       >
         Your sign-in expired. Sign in again to keep editing.
       </NotebookNotice>
@@ -214,7 +208,7 @@ const viewableScenarios: Scenario[] = [
     render: () => (
       <NotebookNotice
         tone="info"
-        icon={<Loader2 className="h-4 w-4 animate-spin" />}
+        icon={<Loader2 className="animate-spin" />}
         title="Refreshing sign-in."
       >
         Reconnecting your account…
@@ -228,13 +222,9 @@ const viewableScenarios: Scenario[] = [
     render: () => (
       <NotebookNotice
         tone="warning"
-        icon={<ImageOff className="h-4 w-4" />}
+        icon={<ImageOff />}
         title="Output renderer unavailable."
-        actions={
-          <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
-            Retry
-          </NotebookNoticeAction>
-        }
+        actions={<NotebookNoticeAction icon={<RotateCcw />}>Retry</NotebookNoticeAction>}
       >
         Rich outputs are paused because their renderer assets failed to load. Code and text stay
         readable; retry to restore outputs.
@@ -248,7 +238,7 @@ const viewableScenarios: Scenario[] = [
     render: () => (
       <NotebookNotice
         tone="info"
-        icon={<Cloud className="h-4 w-4" />}
+        icon={<Cloud />}
         title="Synced your offline edits — 3 updates from collaborators merged."
       >
         A cell you edited offline was removed by a collaborator.
@@ -499,9 +489,7 @@ function ToneReference() {
               title={`${tone[0].toUpperCase()}${tone.slice(1)} tone.`}
               actions={
                 i < 3 ? (
-                  <NotebookNoticeAction icon={<AlertCircle className="h-3 w-3" />}>
-                    Action
-                  </NotebookNoticeAction>
+                  <NotebookNoticeAction icon={<AlertCircle />}>Action</NotebookNoticeAction>
                 ) : null
               }
             >

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -24,7 +24,6 @@ import {
   NotebookNoticeDetails,
   NotebookNoticeStack,
 } from "@/components/notebook/NotebookNotice";
-import { cn } from "@/lib/utils";
 
 /**
  * Notice gallery — every notification/banner/gate that can prevent (or
@@ -320,7 +319,6 @@ export function NotebookNoticesGallery() {
     <div className="space-y-12">
       <ViewableSection />
       <NotViewableSection />
-      <SpacingContrast />
       <ToneReference />
     </div>
   );
@@ -328,16 +326,13 @@ export function NotebookNoticesGallery() {
 
 /**
  * Frame that mimics the real shell: a toolbar row, the notices region, and a
- * body. `padded` toggles the proposed container padding so notices never
- * touch the edges.
+ * body. Notices sit edge-to-edge in the region (matching shipping desktop/cloud).
  */
 function ShellFrame({
   children,
-  padded = true,
   showBody = true,
 }: {
   children: React.ReactNode;
-  padded?: boolean;
   showBody?: boolean;
 }) {
   return (
@@ -349,7 +344,7 @@ function ShellFrame({
         <span className="opacity-50">Start compute</span>
         <span className="ml-auto">Python</span>
       </div>
-      <div className={cn("border-b bg-background", padded ? "px-3 py-2" : "")}>{children}</div>
+      <div className="border-b bg-background">{children}</div>
       {showBody ? (
         <div className="min-h-[96px] bg-background px-6 py-8 text-sm text-muted-foreground">
           <code className="text-foreground/70">print(&apos;hello&apos;)</code>
@@ -427,40 +422,6 @@ function NotViewableSection() {
             </div>
           </div>
         ))}
-      </div>
-    </section>
-  );
-}
-
-function SpacingContrast() {
-  return (
-    <section className="space-y-3">
-      <div className="space-y-1">
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-          Spacing: edge-to-edge vs padded
-        </h2>
-        <p className="text-sm text-foreground/80">
-          Today (desktop) notices sit edge-to-edge with only the atom&apos;s own `px-3`. The
-          proposed container adds breathing room so notices never touch the frame.
-        </p>
-      </div>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        <div className="space-y-2">
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
-            edge-to-edge (today)
-          </span>
-          <ShellFrame padded={false} showBody={false}>
-            <NoComputeNotice isOwner />
-          </ShellFrame>
-        </div>
-        <div className="space-y-2">
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
-            padded (proposed)
-          </span>
-          <ShellFrame padded showBody={false}>
-            <NoComputeNotice isOwner />
-          </ShellFrame>
-        </div>
       </div>
     </section>
   );

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -4,13 +4,13 @@ import {
   Cloud,
   CloudOff,
   Cpu,
+  FileQuestion,
   ImageOff,
   Loader2,
   LogIn,
   RotateCcw,
   RotateCw,
 } from "lucide-react";
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DaemonStatusBanner } from "@/components/notebook/DaemonStatusBanner";
 import {
@@ -31,18 +31,16 @@ import { cn } from "@/lib/utils";
  * shipped components so this doubles as the visual-review artifact for the
  * notice-consolidation work.
  *
- * Scenarios are grouped by the underlying reason a run is blocked:
- *   - runtime/compute not attached (the silent case today)
- *   - connection/transport loss
- *   - kernel launch/crash
- *   - auth / access
- *   - renderer assets
+ * The organizing rule (matching PR #4081): treatment depends on whether the
+ * notebook is still VIEWABLE.
+ *   - Viewable  → inline banner in the notices region; the notebook stays
+ *     readable/editable underneath.
+ *   - Not viewable (signed out, connection/access error) → full-stage
+ *     centered `NotebookAccessGate` that owns the whole canvas.
  *
- * Each scenario is shown inside a `ShellFrame` that mimics the real
- * toolbar → notices-slot → body layout, so edge spacing and how a notice
- * reads in context are both visible. A dedicated "spacing" section
- * contrasts edge-to-edge (today's desktop) against a padded container
- * (the proposed fix).
+ * Every scenario is rendered at once (no click-to-reveal) so the whole
+ * family can be scanned side by side. Icons differ per tone so color is not
+ * the only severity signal.
  */
 
 const LONG_TRACEBACK = `Traceback (most recent call last):
@@ -58,16 +56,15 @@ const DAEMON_SOCK_ERROR =
 interface Scenario {
   id: string;
   label: string;
-  /** Short human note describing the trigger, shown above the frame. */
+  /** Short human note describing the trigger. */
   note: string;
   render: () => React.ReactNode;
 }
 
 /**
  * Proposed NEW notice for the "no compute attached" case — the state in the
- * dev:browser screenshot that currently surfaces NO UI at all. Built here as
- * a mockup on top of the real `NotebookNotice` so the visual treatment can be
- * reviewed before it lands in production (`CloudNotebookNotices`).
+ * dev:browser screenshot that currently surfaces NO UI at all. The notebook
+ * is fully viewable, so this is an inline banner, not a gate.
  */
 function NoComputeNotice({ isOwner }: { isOwner: boolean }) {
   return (
@@ -90,23 +87,27 @@ function NoComputeNotice({ isOwner }: { isOwner: boolean }) {
   );
 }
 
-const scenarios: Scenario[] = [
+/**
+ * VIEWABLE states — the notebook renders underneath, so these are inline
+ * banners in the notices region.
+ */
+const viewableScenarios: Scenario[] = [
   {
     id: "no-compute-owner",
     label: "No compute (owner)",
-    note: "dev:browser / cloud, owner, no runtime peer attached. Today this is SILENT — no banner, no run button, no tooltip. This is the proposed new notice.",
+    note: "dev:browser / cloud, owner, no runtime peer attached. Today this is SILENT — no banner, no run button, no tooltip. Proposed new notice.",
     render: () => <NoComputeNotice isOwner />,
   },
   {
     id: "no-compute-viewer",
     label: "No compute (viewer)",
-    note: "Non-owner with no runtime attached. Cannot attach compute themselves. Proposed new notice.",
+    note: "Non-owner, no runtime attached. Cannot attach compute themselves. Proposed new notice.",
     render: () => <NoComputeNotice isOwner={false} />,
   },
   {
     id: "reconnecting",
     label: "Reconnecting",
-    note: "Transport link dropped past the 3s debounce (useSustainedReconnecting). Quiet, no CTA — the transport retries forever on its own.",
+    note: "Transport dropped past the 3s debounce. Quiet, no CTA — the transport retries forever on its own.",
     render: () => (
       <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
         Your edits are kept locally and will sync when the connection returns.
@@ -114,52 +115,9 @@ const scenarios: Scenario[] = [
     ),
   },
   {
-    id: "live-room-unavailable",
-    label: "Live room unavailable",
-    note: "failed to connect wss://… with no readable snapshot. cloudConnectionNoticeDisplay.",
-    render: () => (
-      <NotebookNotice
-        tone="warning"
-        icon={<CloudOff className="h-4 w-4" />}
-        title="Live room unavailable."
-        actions={
-          <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
-            Retry
-          </NotebookNoticeAction>
-        }
-      >
-        The notebook will load once the account or connection is refreshed.
-      </NotebookNotice>
-    ),
-  },
-  {
-    id: "runtime-unavailable",
-    label: "Runtime unavailable (desktop)",
-    note: "DaemonStatusBanner failed state. Today renders the raw sock-path error uncollapsed.",
-    render: () => (
-      <DaemonStatusBanner
-        status={{
-          status: "failed",
-          error: `Reconnection failed: ${DAEMON_SOCK_ERROR}`,
-          guidance: "Automatic reconnection is paused. Retry reconnects once.",
-        }}
-        onRetry={() => {}}
-        onDismiss={() => {}}
-      />
-    ),
-  },
-  {
-    id: "daemon-starting",
-    label: "Runtime starting (desktop)",
-    note: "DaemonStatusBanner progress state — calm info with spinner.",
-    render: () => (
-      <DaemonStatusBanner status={{ status: "waiting_for_ready", attempt: 2, max_attempts: 5 }} />
-    ),
-  },
-  {
     id: "kernel-launch",
     label: "Kernel failed to start",
-    note: "RuntimeLifecycle::Error with stderr tail. Traceback is COLLAPSED into a scroll box (max-h-32) with Copy + Retry — the pattern we want everywhere.",
+    note: "RuntimeLifecycle::Error with stderr tail. Traceback COLLAPSED into a scroll box with Copy + Retry — the pattern to standardize on.",
     render: () => (
       <KernelLaunchErrorBanner
         errorDetails={LONG_TRACEBACK}
@@ -181,51 +139,36 @@ const scenarios: Scenario[] = [
     ),
   },
   {
-    id: "sign-in-required",
-    label: "Sign in required",
-    note: "CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC (HTTP 401). Blocks the notebook body entirely.",
+    id: "runtime-unavailable",
+    label: "Runtime unavailable (desktop)",
+    note: "DaemonStatusBanner failed state. Today renders the raw sock-path error uncollapsed (a target for the sanitize/collapse fix).",
     render: () => (
-      <NotebookNotice
-        tone="warning"
-        icon={<LogIn className="h-4 w-4" />}
-        title="Sign in required."
-        actions={
-          <NotebookNoticeAction icon={<LogIn className="h-3 w-3" />}>
-            Sign in again
-          </NotebookNoticeAction>
-        }
-      >
-        Sign in again to open the live notebook room.
-      </NotebookNotice>
+      <DaemonStatusBanner
+        status={{
+          status: "failed",
+          error: `Reconnection failed: ${DAEMON_SOCK_ERROR}`,
+          guidance: "Automatic reconnection is paused. Retry reconnects once.",
+        }}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
     ),
   },
   {
-    id: "access-needed",
-    label: "Notebook access needed",
-    note: "CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC (HTTP 403).",
+    id: "daemon-starting",
+    label: "Runtime starting (desktop)",
+    note: "DaemonStatusBanner progress state — calm info with spinner.",
     render: () => (
-      <NotebookNotice
-        tone="warning"
-        icon={<Ban className="h-4 w-4" />}
-        title="Notebook access needed."
-        actions={
-          <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
-            Retry
-          </NotebookNoticeAction>
-        }
-      >
-        Ask the owner to share it, or refresh sign-in if an invite was just accepted.
-      </NotebookNotice>
+      <DaemonStatusBanner status={{ status: "waiting_for_ready", attempt: 2, max_attempts: 5 }} />
     ),
   },
   {
     id: "auth-attention",
     label: "Auth needs attention",
-    note: "authState.mode invalid / oidc_expired. Error tone.",
+    note: "authState.mode invalid / oidc_expired while a readable snapshot exists. Error tone; notebook still visible.",
     render: () => (
       <NotebookNotice
         tone="error"
-        icon={<AlertCircle className="h-4 w-4" />}
         title="Auth needs attention."
         actions={
           <NotebookNoticeAction icon={<LogIn className="h-3 w-3" />}>
@@ -240,7 +183,7 @@ const scenarios: Scenario[] = [
   {
     id: "refreshing-sign-in",
     label: "Refreshing sign-in",
-    note: "authRenewal.kind === refreshing. Transient, spinner, no CTA.",
+    note: "authRenewal.kind === refreshing. Transient, spinner, no CTA. (Explicit spinner icon overrides the tone default.)",
     render: () => (
       <NotebookNotice
         tone="info"
@@ -274,7 +217,7 @@ const scenarios: Scenario[] = [
   {
     id: "offline-merge",
     label: "Synced offline edits",
-    note: "Reconnect completed with locally-authored work pending. Success/info, informational.",
+    note: "Reconnect completed with locally-authored work pending. Informational.",
     render: () => (
       <NotebookNotice
         tone="info"
@@ -287,13 +230,80 @@ const scenarios: Scenario[] = [
   },
 ];
 
+interface GateScenario {
+  id: string;
+  label: string;
+  note: string;
+  tone: "neutral" | "info" | "attention";
+  icon: React.ReactNode;
+  title: string;
+  detail: string;
+  primaryAction?: React.ReactNode;
+}
+
+/**
+ * NOT-VIEWABLE states — the notebook cannot be shown at all, so these take
+ * over the whole stage as a centered `NotebookAccessGate` (the PR #4081
+ * pattern) rather than floating a banner over an empty void.
+ */
+const gateScenarios: GateScenario[] = [
+  {
+    id: "signed-out",
+    label: "Signed out (private)",
+    note: "signedOutNotebookSignInRequired. Private notebook, no session, no readable snapshot.",
+    tone: "info",
+    icon: <LogIn aria-hidden="true" />,
+    title: "Sign in to open this notebook",
+    detail:
+      "This notebook is private. Sign in with your account and we'll bring you straight back here.",
+    primaryAction: <Button size="sm">Sign in with Anaconda</Button>,
+  },
+  {
+    id: "no-access",
+    label: "No access",
+    note: "CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC (HTTP 403). Signed in, but not shared with this account.",
+    tone: "attention",
+    icon: <Ban aria-hidden="true" />,
+    title: "You don't have access",
+    detail: "Ask the owner to share this notebook with your account, then reload.",
+    primaryAction: (
+      <Button size="sm" variant="secondary">
+        Reload
+      </Button>
+    ),
+  },
+  {
+    id: "not-found",
+    label: "Not found",
+    note: "CLOUD_CONNECTION_NOT_FOUND_DIAGNOSTIC (HTTP 404). No such notebook — no action.",
+    tone: "neutral",
+    icon: <FileQuestion aria-hidden="true" />,
+    title: "Notebook not found",
+    detail: "This notebook may have been moved or deleted.",
+  },
+  {
+    id: "load-failed",
+    label: "Load failed (desktop)",
+    note: "Daemon-not-running load failure with nothing to show. Replaces the Tauri triple-treatment with one gate.",
+    tone: "attention",
+    icon: <CloudOff aria-hidden="true" />,
+    title: "Couldn't load this notebook",
+    detail: "The runtime isn't available right now. Reconnect to try again.",
+    primaryAction: (
+      <Button size="sm" variant="secondary">
+        <RotateCcw className="mr-1 size-3" />
+        Reconnect
+      </Button>
+    ),
+  },
+];
+
 export function NotebookNoticesGallery() {
   return (
     <div className="space-y-12">
-      <SingleNoticeExplorer />
-      <StackedExample />
+      <ViewableSection />
+      <NotViewableSection />
       <SpacingContrast />
-      <GateExample />
       <ToneReference />
     </div>
   );
@@ -304,7 +314,15 @@ export function NotebookNoticesGallery() {
  * body. `padded` toggles the proposed container padding so notices never
  * touch the edges.
  */
-function ShellFrame({ children, padded = true }: { children: React.ReactNode; padded?: boolean }) {
+function ShellFrame({
+  children,
+  padded = true,
+  showBody = true,
+}: {
+  children: React.ReactNode;
+  padded?: boolean;
+  showBody?: boolean;
+}) {
   return (
     <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
       <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
@@ -315,86 +333,84 @@ function ShellFrame({ children, padded = true }: { children: React.ReactNode; pa
         <span className="ml-auto">Python</span>
       </div>
       <div className={cn("border-b bg-background", padded ? "px-3 py-2" : "")}>{children}</div>
-      <div className="min-h-[120px] bg-background px-6 py-8 text-sm text-muted-foreground">
-        <code className="text-foreground/70">print(&apos;hello&apos;)</code>
-      </div>
+      {showBody ? (
+        <div className="min-h-[96px] bg-background px-6 py-8 text-sm text-muted-foreground">
+          <code className="text-foreground/70">print(&apos;hello&apos;)</code>
+        </div>
+      ) : null}
     </div>
   );
 }
 
-function SingleNoticeExplorer() {
-  const [selectedId, setSelectedId] = useState(scenarios[0].id);
-  const selected = scenarios.find((s) => s.id === selectedId) ?? scenarios[0];
-
+function ScenarioCard({ scenario }: { scenario: Scenario }) {
   return (
-    <section className="space-y-3">
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-xs font-medium text-foreground">{scenario.label}</span>
+      </div>
+      <p className="text-[11px] leading-4 text-muted-foreground">{scenario.note}</p>
+      <ShellFrame showBody={false}>{scenario.render()}</ShellFrame>
+    </div>
+  );
+}
+
+function ViewableSection() {
+  return (
+    <section className="space-y-4">
       <div className="space-y-1">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-          Blocked-run states
+          Notebook viewable → inline banner
         </h2>
         <p className="text-sm text-foreground/80">
-          Every notice that can prevent (or explain the inability to) run cells, in the shell
-          toolbar → notices → body layout. Pick a scenario.
+          The notebook still renders underneath, so the message is a banner in the notices region.
+          Every state shown at once. Adding a single action never resizes the bar.
         </p>
       </div>
-
-      <div className="flex flex-wrap items-center gap-1 rounded-md border bg-muted/50 p-1">
-        {scenarios.map((s) => (
-          <button
-            key={s.id}
-            type="button"
-            onClick={() => setSelectedId(s.id)}
-            className={cn(
-              "rounded-sm px-2 py-1 text-xs transition-colors",
-              s.id === selectedId
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {s.label}
-          </button>
+      <div className="grid gap-6 lg:grid-cols-2">
+        {viewableScenarios.map((s) => (
+          <ScenarioCard key={s.id} scenario={s} />
         ))}
       </div>
-
-      <p className="text-xs leading-5 text-muted-foreground">{selected.note}</p>
-
-      <ShellFrame>{selected.render()}</ShellFrame>
     </section>
   );
 }
 
-function StackedExample() {
+function NotViewableSection() {
   return (
-    <section className="space-y-3">
+    <section className="space-y-4">
       <div className="space-y-1">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-          Stacked (multiple at once)
+          Notebook not viewable → full-stage gate
         </h2>
         <p className="text-sm text-foreground/80">
-          When several are active, they pile in one `NotebookNoticeStack`. This is what the
-          consolidated single-location model should look like — one region, consistent spacing.
+          Nothing to show underneath (signed out, no access, not found, load failed), so the state
+          owns the whole canvas — the PR #4081 pattern — instead of floating a banner over an empty
+          void.
         </p>
       </div>
-      <ShellFrame>
-        <NotebookNoticeStack>
-          <NoComputeNotice isOwner />
-          <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
-            Your edits are kept locally and will sync when the connection returns.
-          </NotebookNotice>
-          <NotebookNotice
-            tone="warning"
-            icon={<ImageOff className="h-4 w-4" />}
-            title="Output renderer unavailable."
-            actions={
-              <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
-                Retry
-              </NotebookNoticeAction>
-            }
-          >
-            Rich outputs are paused because their renderer assets failed to load.
-          </NotebookNotice>
-        </NotebookNoticeStack>
-      </ShellFrame>
+      <div className="grid gap-6 lg:grid-cols-2">
+        {gateScenarios.map((g) => (
+          <div key={g.id} className="space-y-2">
+            <span className="text-xs font-medium text-foreground">{g.label}</span>
+            <p className="text-[11px] leading-4 text-muted-foreground">{g.note}</p>
+            <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+              <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">Notebook</span>
+                <span className="ml-auto">Python</span>
+              </div>
+              <div className="flex min-h-[220px] flex-col">
+                <NotebookAccessGate
+                  tone={g.tone}
+                  icon={g.icon}
+                  title={g.title}
+                  detail={g.detail}
+                  primaryAction={g.primaryAction}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }
@@ -416,7 +432,7 @@ function SpacingContrast() {
           <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
             edge-to-edge (today)
           </span>
-          <ShellFrame padded={false}>
+          <ShellFrame padded={false} showBody={false}>
             <NoComputeNotice isOwner />
           </ShellFrame>
         </div>
@@ -424,40 +440,9 @@ function SpacingContrast() {
           <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
             padded (proposed)
           </span>
-          <ShellFrame padded>
+          <ShellFrame padded showBody={false}>
             <NoComputeNotice isOwner />
           </ShellFrame>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function GateExample() {
-  return (
-    <section className="space-y-3">
-      <div className="space-y-1">
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-          Full-stage gate
-        </h2>
-        <p className="text-sm text-foreground/80">
-          Hard blockers (signed-out private notebook, not found) replace the body with a centered
-          `NotebookAccessGate` rather than a banner.
-        </p>
-      </div>
-      <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
-        <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">Notebook</span>
-          <span className="ml-auto">Python</span>
-        </div>
-        <div className="min-h-[260px]">
-          <NotebookAccessGate
-            tone="info"
-            icon={<LogIn aria-hidden="true" />}
-            title="Sign in to open this notebook"
-            detail="This notebook is private. Sign in with your account and we'll bring you straight back here."
-            primaryAction={<Button size="sm">Sign in with Anaconda</Button>}
-          />
         </div>
       </div>
     </section>
@@ -473,17 +458,25 @@ function ToneReference() {
           Tone reference
         </h2>
         <p className="text-sm text-foreground/80">
-          The five `NotebookNotice` tones, for quick contrast in light and dark.
+          The five tones with their default per-tone icons — shape distinguishes severity, not just
+          color. The first three carry a single action to show the button treatment and stable bar
+          height.
         </p>
       </div>
-      <ShellFrame>
+      <ShellFrame showBody={false}>
         <NotebookNoticeStack>
-          {tones.map((tone) => (
+          {tones.map((tone, i) => (
             <NotebookNotice
               key={tone}
               tone={tone}
-              icon={<AlertCircle className="h-4 w-4" />}
               title={`${tone[0].toUpperCase()}${tone.slice(1)} tone.`}
+              actions={
+                i < 3 ? (
+                  <NotebookNoticeAction icon={<AlertCircle className="h-3 w-3" />}>
+                    Action
+                  </NotebookNoticeAction>
+                ) : null
+              }
             >
               The quick brown fox jumps over the lazy dog.
             </NotebookNotice>

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -1,0 +1,495 @@
+import {
+  AlertCircle,
+  Ban,
+  Cloud,
+  CloudOff,
+  Cpu,
+  ImageOff,
+  Loader2,
+  LogIn,
+  RotateCcw,
+  RotateCw,
+} from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { DaemonStatusBanner } from "@/components/notebook/DaemonStatusBanner";
+import {
+  ComputeDisconnectedNotice,
+  KernelLaunchErrorBanner,
+} from "@/components/notebook/KernelLaunchErrorBanner";
+import { NotebookAccessGate } from "@/components/notebook/NotebookAccessGate";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  NotebookNoticeStack,
+} from "@/components/notebook/NotebookNotice";
+import { cn } from "@/lib/utils";
+
+/**
+ * Notice gallery — every notification/banner/gate that can prevent (or
+ * explain the inability to) run notebook cells, rendered with the real
+ * shipped components so this doubles as the visual-review artifact for the
+ * notice-consolidation work.
+ *
+ * Scenarios are grouped by the underlying reason a run is blocked:
+ *   - runtime/compute not attached (the silent case today)
+ *   - connection/transport loss
+ *   - kernel launch/crash
+ *   - auth / access
+ *   - renderer assets
+ *
+ * Each scenario is shown inside a `ShellFrame` that mimics the real
+ * toolbar → notices-slot → body layout, so edge spacing and how a notice
+ * reads in context are both visible. A dedicated "spacing" section
+ * contrasts edge-to-edge (today's desktop) against a padded container
+ * (the proposed fix).
+ */
+
+const LONG_TRACEBACK = `Traceback (most recent call last):
+  File "/opt/anaconda3/lib/python3.13/runpy.py", line 189, in _run_module_as_main
+    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
+  File "/opt/anaconda3/lib/python3.13/runpy.py", line 148, in _get_module_details
+    return _get_module_details(pkg_main_name, error)
+ModuleNotFoundError: No module named 'ipykernel_launcher'`;
+
+const DAEMON_SOCK_ERROR =
+  "sync connect (create): Daemon is not running. Endpoint not found at /Users/erikayee/Library/Caches/runt-nightly/worktrees/e0dd4fbd4f3b/runtimed.sock.";
+
+interface Scenario {
+  id: string;
+  label: string;
+  /** Short human note describing the trigger, shown above the frame. */
+  note: string;
+  render: () => React.ReactNode;
+}
+
+/**
+ * Proposed NEW notice for the "no compute attached" case — the state in the
+ * dev:browser screenshot that currently surfaces NO UI at all. Built here as
+ * a mockup on top of the real `NotebookNotice` so the visual treatment can be
+ * reviewed before it lands in production (`CloudNotebookNotices`).
+ */
+function NoComputeNotice({ isOwner }: { isOwner: boolean }) {
+  return (
+    <NotebookNotice
+      tone="info"
+      icon={<Cpu className="h-4 w-4" />}
+      title="No compute attached."
+      actions={
+        isOwner ? (
+          <NotebookNoticeAction icon={<RotateCw className="h-3 w-3" />}>
+            Start compute
+          </NotebookNoticeAction>
+        ) : null
+      }
+    >
+      {isOwner
+        ? "Start compute to run cells in this notebook."
+        : "Only the notebook owner can attach compute to run cells."}
+    </NotebookNotice>
+  );
+}
+
+const scenarios: Scenario[] = [
+  {
+    id: "no-compute-owner",
+    label: "No compute (owner)",
+    note: "dev:browser / cloud, owner, no runtime peer attached. Today this is SILENT — no banner, no run button, no tooltip. This is the proposed new notice.",
+    render: () => <NoComputeNotice isOwner />,
+  },
+  {
+    id: "no-compute-viewer",
+    label: "No compute (viewer)",
+    note: "Non-owner with no runtime attached. Cannot attach compute themselves. Proposed new notice.",
+    render: () => <NoComputeNotice isOwner={false} />,
+  },
+  {
+    id: "reconnecting",
+    label: "Reconnecting",
+    note: "Transport link dropped past the 3s debounce (useSustainedReconnecting). Quiet, no CTA — the transport retries forever on its own.",
+    render: () => (
+      <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
+        Your edits are kept locally and will sync when the connection returns.
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "live-room-unavailable",
+    label: "Live room unavailable",
+    note: "failed to connect wss://… with no readable snapshot. cloudConnectionNoticeDisplay.",
+    render: () => (
+      <NotebookNotice
+        tone="warning"
+        icon={<CloudOff className="h-4 w-4" />}
+        title="Live room unavailable."
+        actions={
+          <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
+            Retry
+          </NotebookNoticeAction>
+        }
+      >
+        The notebook will load once the account or connection is refreshed.
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "runtime-unavailable",
+    label: "Runtime unavailable (desktop)",
+    note: "DaemonStatusBanner failed state. Today renders the raw sock-path error uncollapsed.",
+    render: () => (
+      <DaemonStatusBanner
+        status={{
+          status: "failed",
+          error: `Reconnection failed: ${DAEMON_SOCK_ERROR}`,
+          guidance: "Automatic reconnection is paused. Retry reconnects once.",
+        }}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    ),
+  },
+  {
+    id: "daemon-starting",
+    label: "Runtime starting (desktop)",
+    note: "DaemonStatusBanner progress state — calm info with spinner.",
+    render: () => (
+      <DaemonStatusBanner status={{ status: "waiting_for_ready", attempt: 2, max_attempts: 5 }} />
+    ),
+  },
+  {
+    id: "kernel-launch",
+    label: "Kernel failed to start",
+    note: "RuntimeLifecycle::Error with stderr tail. Traceback is COLLAPSED into a scroll box (max-h-32) with Copy + Retry — the pattern we want everywhere.",
+    render: () => (
+      <KernelLaunchErrorBanner
+        errorDetails={LONG_TRACEBACK}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    ),
+  },
+  {
+    id: "compute-disconnected",
+    label: "Compute disconnected",
+    note: "runtime peer disconnected: … A kernel that was attached dropped. Wake-on-run.",
+    render: () => (
+      <ComputeDisconnectedNotice
+        errorDetails="runtime peer disconnected: workstation went offline"
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    ),
+  },
+  {
+    id: "sign-in-required",
+    label: "Sign in required",
+    note: "CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC (HTTP 401). Blocks the notebook body entirely.",
+    render: () => (
+      <NotebookNotice
+        tone="warning"
+        icon={<LogIn className="h-4 w-4" />}
+        title="Sign in required."
+        actions={
+          <NotebookNoticeAction icon={<LogIn className="h-3 w-3" />}>
+            Sign in again
+          </NotebookNoticeAction>
+        }
+      >
+        Sign in again to open the live notebook room.
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "access-needed",
+    label: "Notebook access needed",
+    note: "CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC (HTTP 403).",
+    render: () => (
+      <NotebookNotice
+        tone="warning"
+        icon={<Ban className="h-4 w-4" />}
+        title="Notebook access needed."
+        actions={
+          <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
+            Retry
+          </NotebookNoticeAction>
+        }
+      >
+        Ask the owner to share it, or refresh sign-in if an invite was just accepted.
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "auth-attention",
+    label: "Auth needs attention",
+    note: "authState.mode invalid / oidc_expired. Error tone.",
+    render: () => (
+      <NotebookNotice
+        tone="error"
+        icon={<AlertCircle className="h-4 w-4" />}
+        title="Auth needs attention."
+        actions={
+          <NotebookNoticeAction icon={<LogIn className="h-3 w-3" />}>
+            Sign in again
+          </NotebookNoticeAction>
+        }
+      >
+        Your sign-in expired. Sign in again to keep editing.
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "refreshing-sign-in",
+    label: "Refreshing sign-in",
+    note: "authRenewal.kind === refreshing. Transient, spinner, no CTA.",
+    render: () => (
+      <NotebookNotice
+        tone="info"
+        icon={<Loader2 className="h-4 w-4 animate-spin" />}
+        title="Refreshing sign-in."
+      >
+        Reconnecting your account…
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "renderer-assets",
+    label: "Output renderer unavailable",
+    note: "Terminal renderer-asset load failure. Code stays readable; rich outputs paused.",
+    render: () => (
+      <NotebookNotice
+        tone="warning"
+        icon={<ImageOff className="h-4 w-4" />}
+        title="Output renderer unavailable."
+        actions={
+          <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
+            Retry
+          </NotebookNoticeAction>
+        }
+      >
+        Rich outputs are paused because their renderer assets failed to load. Code and text stay
+        readable; retry to restore outputs.
+      </NotebookNotice>
+    ),
+  },
+  {
+    id: "offline-merge",
+    label: "Synced offline edits",
+    note: "Reconnect completed with locally-authored work pending. Success/info, informational.",
+    render: () => (
+      <NotebookNotice
+        tone="info"
+        icon={<Cloud className="h-4 w-4" />}
+        title="Synced your offline edits — 3 updates from collaborators merged."
+      >
+        A cell you edited offline was removed by a collaborator.
+      </NotebookNotice>
+    ),
+  },
+];
+
+export function NotebookNoticesGallery() {
+  return (
+    <div className="space-y-12">
+      <SingleNoticeExplorer />
+      <StackedExample />
+      <SpacingContrast />
+      <GateExample />
+      <ToneReference />
+    </div>
+  );
+}
+
+/**
+ * Frame that mimics the real shell: a toolbar row, the notices region, and a
+ * body. `padded` toggles the proposed container padding so notices never
+ * touch the edges.
+ */
+function ShellFrame({ children, padded = true }: { children: React.ReactNode; padded?: boolean }) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+      <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">Notebook</span>
+        <span>Code</span>
+        <span>Markdown</span>
+        <span className="opacity-50">Start compute</span>
+        <span className="ml-auto">Python</span>
+      </div>
+      <div className={cn("border-b bg-background", padded ? "px-3 py-2" : "")}>{children}</div>
+      <div className="min-h-[120px] bg-background px-6 py-8 text-sm text-muted-foreground">
+        <code className="text-foreground/70">print(&apos;hello&apos;)</code>
+      </div>
+    </div>
+  );
+}
+
+function SingleNoticeExplorer() {
+  const [selectedId, setSelectedId] = useState(scenarios[0].id);
+  const selected = scenarios.find((s) => s.id === selectedId) ?? scenarios[0];
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Blocked-run states
+        </h2>
+        <p className="text-sm text-foreground/80">
+          Every notice that can prevent (or explain the inability to) run cells, in the shell
+          toolbar → notices → body layout. Pick a scenario.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1 rounded-md border bg-muted/50 p-1">
+        {scenarios.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            onClick={() => setSelectedId(s.id)}
+            className={cn(
+              "rounded-sm px-2 py-1 text-xs transition-colors",
+              s.id === selectedId
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-xs leading-5 text-muted-foreground">{selected.note}</p>
+
+      <ShellFrame>{selected.render()}</ShellFrame>
+    </section>
+  );
+}
+
+function StackedExample() {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Stacked (multiple at once)
+        </h2>
+        <p className="text-sm text-foreground/80">
+          When several are active, they pile in one `NotebookNoticeStack`. This is what the
+          consolidated single-location model should look like — one region, consistent spacing.
+        </p>
+      </div>
+      <ShellFrame>
+        <NotebookNoticeStack>
+          <NoComputeNotice isOwner />
+          <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
+            Your edits are kept locally and will sync when the connection returns.
+          </NotebookNotice>
+          <NotebookNotice
+            tone="warning"
+            icon={<ImageOff className="h-4 w-4" />}
+            title="Output renderer unavailable."
+            actions={
+              <NotebookNoticeAction icon={<RotateCcw className="h-3 w-3" />}>
+                Retry
+              </NotebookNoticeAction>
+            }
+          >
+            Rich outputs are paused because their renderer assets failed to load.
+          </NotebookNotice>
+        </NotebookNoticeStack>
+      </ShellFrame>
+    </section>
+  );
+}
+
+function SpacingContrast() {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Spacing: edge-to-edge vs padded
+        </h2>
+        <p className="text-sm text-foreground/80">
+          Today (desktop) notices sit edge-to-edge with only the atom&apos;s own `px-3`. The
+          proposed container adds breathing room so notices never touch the frame.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+            edge-to-edge (today)
+          </span>
+          <ShellFrame padded={false}>
+            <NoComputeNotice isOwner />
+          </ShellFrame>
+        </div>
+        <div className="space-y-2">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+            padded (proposed)
+          </span>
+          <ShellFrame padded>
+            <NoComputeNotice isOwner />
+          </ShellFrame>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function GateExample() {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Full-stage gate
+        </h2>
+        <p className="text-sm text-foreground/80">
+          Hard blockers (signed-out private notebook, not found) replace the body with a centered
+          `NotebookAccessGate` rather than a banner.
+        </p>
+      </div>
+      <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+        <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Notebook</span>
+          <span className="ml-auto">Python</span>
+        </div>
+        <div className="min-h-[260px]">
+          <NotebookAccessGate
+            tone="info"
+            icon={<LogIn aria-hidden="true" />}
+            title="Sign in to open this notebook"
+            detail="This notebook is private. Sign in with your account and we'll bring you straight back here."
+            primaryAction={<Button size="sm">Sign in with Anaconda</Button>}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ToneReference() {
+  const tones = ["info", "warning", "error", "success", "debug"] as const;
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Tone reference
+        </h2>
+        <p className="text-sm text-foreground/80">
+          The five `NotebookNotice` tones, for quick contrast in light and dark.
+        </p>
+      </div>
+      <ShellFrame>
+        <NotebookNoticeStack>
+          {tones.map((tone) => (
+            <NotebookNotice
+              key={tone}
+              tone={tone}
+              icon={<AlertCircle className="h-4 w-4" />}
+              title={`${tone[0].toUpperCase()}${tone.slice(1)} tone.`}
+            >
+              The quick brown fox jumps over the lazy dog.
+            </NotebookNotice>
+          ))}
+        </NotebookNoticeStack>
+      </ShellFrame>
+    </section>
+  );
+}

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -331,7 +331,7 @@ function ScenarioCard({ scenario }: { scenario: Scenario }) {
         <span className="text-xs font-medium text-foreground">{scenario.label}</span>
       </div>
       <p className="text-[11px] leading-4 text-muted-foreground">{scenario.note}</p>
-      <div className="overflow-hidden rounded-lg border">{scenario.render()}</div>
+      {scenario.render()}
     </div>
   );
 }
@@ -405,24 +405,22 @@ function ToneReference() {
           height.
         </p>
       </div>
-      <div className="overflow-hidden rounded-lg border">
-        <NotebookNoticeStack className="gap-0">
-          {tones.map((tone, i) => (
-            <NotebookNotice
-              key={tone}
-              tone={tone}
-              title={`${tone[0].toUpperCase()}${tone.slice(1)} tone.`}
-              actions={
-                i < 3 ? (
-                  <NotebookNoticeAction icon={<AlertCircle />}>Action</NotebookNoticeAction>
-                ) : null
-              }
-            >
-              The quick brown fox jumps over the lazy dog.
-            </NotebookNotice>
-          ))}
-        </NotebookNoticeStack>
-      </div>
+      <NotebookNoticeStack className="gap-0">
+        {tones.map((tone, i) => (
+          <NotebookNotice
+            key={tone}
+            tone={tone}
+            title={`${tone[0].toUpperCase()}${tone.slice(1)} tone.`}
+            actions={
+              i < 3 ? (
+                <NotebookNoticeAction icon={<AlertCircle />}>Action</NotebookNoticeAction>
+              ) : null
+            }
+          >
+            The quick brown fox jumps over the lazy dog.
+          </NotebookNotice>
+        ))}
+      </NotebookNoticeStack>
     </section>
   );
 }

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -21,6 +21,7 @@ import { NotebookAccessGate } from "@/components/notebook/NotebookAccessGate";
 import {
   NotebookNotice,
   NotebookNoticeAction,
+  NotebookNoticeDetails,
   NotebookNoticeStack,
 } from "@/components/notebook/NotebookNotice";
 import { cn } from "@/lib/utils";
@@ -49,6 +50,13 @@ const LONG_TRACEBACK = `Traceback (most recent call last):
   File "/opt/anaconda3/lib/python3.13/runpy.py", line 148, in _get_module_details
     return _get_module_details(pkg_main_name, error)
 ModuleNotFoundError: No module named 'ipykernel_launcher'`;
+
+const LONG_ROOM_ERROR = `cloud room rejected frame: room session escalation refused the requested editor scope
+  requested: editor (write cells, write structure, execute)
+  granted:   viewer (read cells, read outputs)
+  reason:    the notebook ACL lists this account as a viewer, and no pending edit-access request was found
+  room:      wss://notebooks.example/rooms/9f3c1e7a-4b2d-4c88-a1f0-5e6d7c8b9a01
+  attempt:   3 of 3 (escalation ladder exhausted; the transport will not retry on its own)`;
 
 const DAEMON_SOCK_ERROR =
   "sync connect (create): Daemon is not running. Endpoint not found at /Users/erikayee/Library/Caches/runt-nightly/worktrees/e0dd4fbd4f3b/runtimed.sock.";
@@ -124,6 +132,25 @@ const viewableScenarios: Scenario[] = [
         onRetry={() => {}}
         onDismiss={() => {}}
       />
+    ),
+  },
+  {
+    id: "long-cloud-message",
+    note: "Cloud connection/load error whose raw text runs long. A lead line stays on the bar and the rest collapses — the region grows with content, so nothing is clipped and nothing scrolls except the open block.",
+    label: "Long cloud error",
+    render: () => (
+      <NotebookNotice
+        tone="warning"
+        icon={<CloudOff className="h-4 w-4" />}
+        title="Live room needs attention."
+        details={
+          <NotebookNoticeDetails label="Show error details">
+            {LONG_ROOM_ERROR}
+          </NotebookNoticeDetails>
+        }
+      >
+        cloud room rejected frame: room session escalation refused the requested editor scope
+      </NotebookNotice>
     ),
   },
   {

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -366,7 +366,7 @@ function ViewableSection() {
           Every state shown at once. Adding a single action never resizes the bar.
         </p>
       </div>
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {viewableScenarios.map((s) => (
           <ScenarioCard key={s.id} scenario={s} />
         ))}
@@ -388,7 +388,7 @@ function NotViewableSection() {
           void.
         </p>
       </div>
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {gateScenarios.map((g) => (
           <div key={g.id} className="space-y-2">
             <span className="text-xs font-medium text-foreground">{g.label}</span>
@@ -427,7 +427,7 @@ function SpacingContrast() {
           proposed container adds breathing room so notices never touch the frame.
         </p>
       </div>
-      <div className="grid gap-6 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         <div className="space-y-2">
           <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
             edge-to-edge (today)

--- a/apps/notebook/gallery/NotebookNoticesGallery.tsx
+++ b/apps/notebook/gallery/NotebookNoticesGallery.tsx
@@ -324,36 +324,6 @@ export function NotebookNoticesGallery() {
   );
 }
 
-/**
- * Frame that mimics the real shell: a toolbar row, the notices region, and a
- * body. Notices sit edge-to-edge in the region (matching shipping desktop/cloud).
- */
-function ShellFrame({
-  children,
-  showBody = true,
-}: {
-  children: React.ReactNode;
-  showBody?: boolean;
-}) {
-  return (
-    <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
-      <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-        <span className="font-medium text-foreground">Notebook</span>
-        <span>Code</span>
-        <span>Markdown</span>
-        <span className="opacity-50">Start compute</span>
-        <span className="ml-auto">Python</span>
-      </div>
-      <div className="border-b bg-background">{children}</div>
-      {showBody ? (
-        <div className="min-h-[96px] bg-background px-6 py-8 text-sm text-muted-foreground">
-          <code className="text-foreground/70">print(&apos;hello&apos;)</code>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 function ScenarioCard({ scenario }: { scenario: Scenario }) {
   return (
     <div className="space-y-2">
@@ -361,7 +331,7 @@ function ScenarioCard({ scenario }: { scenario: Scenario }) {
         <span className="text-xs font-medium text-foreground">{scenario.label}</span>
       </div>
       <p className="text-[11px] leading-4 text-muted-foreground">{scenario.note}</p>
-      <ShellFrame showBody={false}>{scenario.render()}</ShellFrame>
+      <div className="overflow-hidden rounded-lg border">{scenario.render()}</div>
     </div>
   );
 }
@@ -405,20 +375,14 @@ function NotViewableSection() {
           <div key={g.id} className="space-y-2">
             <span className="text-xs font-medium text-foreground">{g.label}</span>
             <p className="text-[11px] leading-4 text-muted-foreground">{g.note}</p>
-            <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
-              <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-                <span className="font-medium text-foreground">Notebook</span>
-                <span className="ml-auto">Python</span>
-              </div>
-              <div className="flex min-h-[220px] flex-col">
-                <NotebookAccessGate
-                  tone={g.tone}
-                  icon={g.icon}
-                  title={g.title}
-                  detail={g.detail}
-                  primaryAction={g.primaryAction}
-                />
-              </div>
+            <div className="flex min-h-[220px] flex-col overflow-hidden rounded-lg border bg-background">
+              <NotebookAccessGate
+                tone={g.tone}
+                icon={g.icon}
+                title={g.title}
+                detail={g.detail}
+                primaryAction={g.primaryAction}
+              />
             </div>
           </div>
         ))}
@@ -441,8 +405,8 @@ function ToneReference() {
           height.
         </p>
       </div>
-      <ShellFrame showBody={false}>
-        <NotebookNoticeStack>
+      <div className="overflow-hidden rounded-lg border">
+        <NotebookNoticeStack className="gap-0">
           {tones.map((tone, i) => (
             <NotebookNotice
               key={tone}
@@ -458,7 +422,7 @@ function ToneReference() {
             </NotebookNotice>
           ))}
         </NotebookNoticeStack>
-      </ShellFrame>
+      </div>
     </section>
   );
 }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -208,7 +208,7 @@ export function NotebookToolbar({
       {showDenoInstallNotice && kernelErrorMessage && (
         <NotebookNotice
           tone="warning"
-          icon={<Info className="size-3.5" />}
+          icon={<Info />}
           title="Deno not available."
           className="border-t border-b-0"
         >
@@ -417,7 +417,7 @@ function CondaEnvYmlMissingBanner({
   return (
     <NotebookNotice
       tone="warning"
-      icon={<Info className="size-3.5" />}
+      icon={<Info />}
       title="Conda environment not built."
       className="border-t border-b-0"
       data-testid="conda-env-yml-missing-banner"
@@ -425,7 +425,7 @@ function CondaEnvYmlMissingBanner({
         command ? (
           <NotebookNoticeAction
             onClick={onCopyCommand}
-            icon={<Copy className="size-3" />}
+            icon={<Copy />}
             data-testid="copy-conda-env-command"
           >
             {copied ? "Copied" : "Copy command"}
@@ -452,7 +452,7 @@ function RuntimeErrorBanner({
   return (
     <NotebookNotice
       tone="warning"
-      icon={<Info className="size-3.5" />}
+      icon={<Info />}
       title={headline}
       className="border-t border-b-0"
       details={

--- a/apps/notebook/src/components/__tests__/component-chroma-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/component-chroma-boundary.test.ts
@@ -29,7 +29,6 @@ const RATCHET_RAW_PALETTE_FILES = [
   "src/components/markdown/markdown-typography.ts",
   "src/components/notebook/DebugBanner.tsx",
   "src/components/notebook/EnvBuildDecisionDialog.tsx",
-  "src/components/notebook/KernelLaunchErrorBanner.tsx",
   "src/components/notebook/NotebookAccessGate.tsx",
   "src/components/notebook/NotebookCommandToolbar.tsx",
   "src/components/notebook/NotebookConnectionIdentity.tsx",

--- a/src/components/notebook/DaemonStatusBanner.tsx
+++ b/src/components/notebook/DaemonStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Loader2, RefreshCw } from "lucide-react";
+import { Loader2, RefreshCw } from "lucide-react";
 import {
   NotebookNotice,
   NotebookNoticeAction,
@@ -44,12 +44,11 @@ export function DaemonStatusBanner({ status, onDismiss, onRetry }: DaemonStatusB
     return (
       <NotebookNotice
         tone="warning"
-        icon={<AlertTriangle className="size-4" />}
         title="Runtime unavailable"
         onDismiss={onDismiss}
         actions={
           onRetry ? (
-            <NotebookNoticeAction onClick={onRetry} icon={<RefreshCw className="size-3" />}>
+            <NotebookNoticeAction onClick={onRetry} icon={<RefreshCw />}>
               Retry
             </NotebookNoticeAction>
           ) : null
@@ -67,7 +66,7 @@ export function DaemonStatusBanner({ status, onDismiss, onRetry }: DaemonStatusB
   const message = getProgressMessage(status);
 
   return (
-    <NotebookNotice tone="info" icon={<Loader2 className="size-3 animate-spin" />} className="py-1">
+    <NotebookNotice tone="info" icon={<Loader2 className="animate-spin" />} className="py-1">
       {message}
     </NotebookNotice>
   );

--- a/src/components/notebook/DaemonStatusBanner.tsx
+++ b/src/components/notebook/DaemonStatusBanner.tsx
@@ -1,5 +1,9 @@
 import { AlertTriangle, Loader2, RefreshCw } from "lucide-react";
-import { NotebookNotice, NotebookNoticeAction } from "@/components/notebook/NotebookNotice";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  NotebookNoticeDetails,
+} from "@/components/notebook/NotebookNotice";
 
 /**
  * Status of the daemon during startup or operation.
@@ -40,7 +44,7 @@ export function DaemonStatusBanner({ status, onDismiss, onRetry }: DaemonStatusB
     return (
       <NotebookNotice
         tone="warning"
-        icon={<AlertTriangle className="size-3" />}
+        icon={<AlertTriangle className="size-4" />}
         title="Runtime unavailable"
         onDismiss={onDismiss}
         actions={
@@ -50,9 +54,11 @@ export function DaemonStatusBanner({ status, onDismiss, onRetry }: DaemonStatusB
             </NotebookNoticeAction>
           ) : null
         }
-        details={status.guidance ? <div>{status.guidance}</div> : null}
+        details={
+          <NotebookNoticeDetails label="Show error details">{status.error}</NotebookNoticeDetails>
+        }
       >
-        <span>{status.error}</span>
+        {status.guidance ?? "Reconnect to try again."}
       </NotebookNotice>
     );
   }

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -1,8 +1,11 @@
 import { AlertCircle, Check, Copy, RotateCw, WifiOff } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
-import { Button } from "@/components/ui/button";
-import { NotebookNotice } from "@/components/notebook/NotebookNotice";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  NotebookNoticeDetails,
+} from "@/components/notebook/NotebookNotice";
 
 const RUNTIME_PEER_DISCONNECTED_ERROR_PREFIX = "runtime peer disconnected:";
 
@@ -104,26 +107,20 @@ export function KernelLaunchErrorBanner({
       title="Kernel failed to start"
       onDismiss={onDismiss}
       details={
-        <pre className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap break-words rounded bg-red-950/5 px-2 py-1 font-mono text-[11px] leading-snug text-red-950/90 dark:bg-red-950/30 dark:text-red-100/90">
-          {errorDetails}
-        </pre>
+        <NotebookNoticeDetails label="Show error details">{errorDetails}</NotebookNoticeDetails>
       }
       actions={
         <>
-          <Button
-            size="sm"
-            variant="secondary"
-            className="h-6 px-2 text-xs"
+          <NotebookNoticeAction
             onClick={copyDetails}
+            icon={copied ? <Check className="size-3" /> : <Copy className="size-3" />}
             data-testid="copy-kernel-launch-error"
           >
-            {copied ? <Check className="size-3 mr-1" /> : <Copy className="size-3 mr-1" />}
             {copied ? "Copied" : "Copy"}
-          </Button>
-          <Button size="sm" variant="secondary" className="h-6 px-2 text-xs" onClick={onRetry}>
-            <RotateCw className="size-3 mr-1" />
+          </NotebookNoticeAction>
+          <NotebookNoticeAction onClick={onRetry} icon={<RotateCw className="size-3" />}>
             Retry
-          </Button>
+          </NotebookNoticeAction>
         </>
       }
     />
@@ -149,18 +146,14 @@ export function ComputeDisconnectedNotice({
       icon={<WifiOff className="size-4" />}
       title="Compute disconnected"
       onDismiss={onDismiss}
-      details={
-        <span>
-          Run any cell to wake compute again
-          {reason ? `; last disconnect: ${reason}` : ""}.
-        </span>
-      }
       actions={
-        <Button size="sm" variant="secondary" className="h-6 px-2 text-xs" onClick={onRetry}>
-          <RotateCw className="size-3 mr-1" />
+        <NotebookNoticeAction onClick={onRetry} icon={<RotateCw className="size-3" />}>
           Retry
-        </Button>
+        </NotebookNoticeAction>
       }
-    />
+    >
+      Run any cell to wake compute again
+      {reason ? `; last disconnect: ${reason}` : ""}.
+    </NotebookNotice>
   );
 }

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -103,7 +103,7 @@ export function KernelLaunchErrorBanner({
   return (
     <NotebookNotice
       tone="error"
-      icon={<AlertCircle className="size-4" />}
+      icon={<AlertCircle />}
       title="Kernel failed to start"
       onDismiss={onDismiss}
       details={
@@ -113,12 +113,12 @@ export function KernelLaunchErrorBanner({
         <>
           <NotebookNoticeAction
             onClick={copyDetails}
-            icon={copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+            icon={copied ? <Check /> : <Copy />}
             data-testid="copy-kernel-launch-error"
           >
             {copied ? "Copied" : "Copy"}
           </NotebookNoticeAction>
-          <NotebookNoticeAction onClick={onRetry} icon={<RotateCw className="size-3" />}>
+          <NotebookNoticeAction onClick={onRetry} icon={<RotateCw />}>
             Retry
           </NotebookNoticeAction>
         </>
@@ -143,11 +143,11 @@ export function ComputeDisconnectedNotice({
   return (
     <NotebookNotice
       tone="warning"
-      icon={<WifiOff className="size-4" />}
+      icon={<WifiOff />}
       title="Compute disconnected"
       onDismiss={onDismiss}
       actions={
-        <NotebookNoticeAction onClick={onRetry} icon={<RotateCw className="size-3" />}>
+        <NotebookNoticeAction onClick={onRetry} icon={<RotateCw />}>
           Retry
         </NotebookNoticeAction>
       }

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { AlertTriangle, Bug, CheckCircle2, Info, XCircle, X } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -40,6 +40,20 @@ const iconClassName: Record<NotebookNoticeTone, string> = {
   debug: "text-violet-600 dark:text-violet-300",
 };
 
+/**
+ * Per-tone default icon so shape — not just color — distinguishes severity
+ * (accessible for color-blind users and quicker to scan). A caller can still
+ * pass a more specific `icon` (e.g. CloudOff for reconnecting); when it does
+ * not, the tone picks the icon. Pass `icon={null}` to opt out entirely.
+ */
+const toneDefaultIcon: Record<NotebookNoticeTone, ReactNode> = {
+  info: <Info className="size-4" />,
+  warning: <AlertTriangle className="size-4" />,
+  error: <XCircle className="size-4" />,
+  success: <CheckCircle2 className="size-4" />,
+  debug: <Bug className="size-4" />,
+};
+
 export function NotebookNoticeStack({
   children,
   className,
@@ -69,10 +83,17 @@ export function NotebookNotice({
   contentClassName,
   "data-testid": dataTestId,
 }: NotebookNoticeProps) {
+  // `undefined` means "no explicit icon" → fall back to the tone default so
+  // shape signals severity. `null` is an explicit opt-out and renders nothing.
+  const resolvedIcon = icon === undefined ? toneDefaultIcon[tone] : icon;
   return (
     <div
       className={cn(
-        "flex min-w-0 items-start gap-3 border-b px-3 py-2 text-xs",
+        // min-h keeps the bar a stable height whether or not an action button
+        // is present, so adding a single button never grows a one-line row.
+        // items-start keeps the icon/actions pinned to the top when the body
+        // wraps to multiple lines (e.g. a collapsed traceback).
+        "flex min-h-9 min-w-0 items-start gap-3 border-b px-3 py-2 text-xs",
         toneClassName[tone],
         className,
       )}
@@ -80,7 +101,7 @@ export function NotebookNotice({
       data-tone={tone}
       data-testid={dataTestId}
     >
-      {icon ? (
+      {resolvedIcon ? (
         <span
           className={cn(
             "mt-0.5 flex size-4 shrink-0 items-center justify-center",
@@ -88,7 +109,7 @@ export function NotebookNotice({
           )}
           aria-hidden="true"
         >
-          {icon}
+          {resolvedIcon}
         </span>
       ) : null}
       <div className={cn("min-w-0 flex-1 space-y-1", contentClassName)}>
@@ -143,7 +164,10 @@ export function NotebookNoticeAction({
       type="button"
       onClick={onClick}
       className={cn(
-        "inline-flex h-6 items-center gap-1 rounded px-2 text-xs font-medium transition-colors hover:bg-current/10",
+        // Reads as a real button: bordered chip with a solid-ish fill from the
+        // tone's currentColor, not a bare text link. h-6 + whitespace-nowrap
+        // keep it from growing the notice row or wrapping.
+        "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-current/25 bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20",
         className,
       )}
       data-testid={dataTestId}

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -35,13 +35,6 @@ const iconClassName: Record<NotebookNoticeTone, string> = {
   debug: "text-violet-600 dark:text-violet-300",
 };
 
-/**
- * Tone → default icon (shape, not only color). Callers may override `icon`, or
- * pass `icon={null}` to hide it. Store Lucide components (not JSX elements):
- * module-scope JSX would run at import time, before node:test suites install
- * React globally. Shell sizes icons (`size-4` / action `size-3`); callers pass
- * shape only.
- */
 const toneDefaultIcon: Record<NotebookNoticeTone, LucideIcon> = {
   info: Info,
   warning: AlertTriangle,

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -36,16 +36,11 @@ const iconClassName: Record<NotebookNoticeTone, string> = {
 };
 
 /**
- * Per-tone default icon so shape — not just color — distinguishes severity
- * (accessible for color-blind users and quicker to scan). A caller can still
- * pass a more specific `icon` (e.g. CloudOff for reconnecting); when it does
- * not, the tone picks the icon. Pass `icon={null}` to opt out entirely.
- *
- * Callers pass shape only — this shell sizes notice icons to `size-4` and
- * action icons to `size-3`. Do not put size classes on passed icons.
- *
- * Components, not elements: module-scope JSX would evaluate at import time,
- * before consumers that install React globally (the node:test suites) run.
+ * Tone → default icon (shape, not only color). Callers may override `icon`, or
+ * pass `icon={null}` to hide it. Store Lucide components (not JSX elements):
+ * module-scope JSX would run at import time, before node:test suites install
+ * React globally. Shell sizes icons (`size-4` / action `size-3`); callers pass
+ * shape only.
  */
 const toneDefaultIcon: Record<NotebookNoticeTone, LucideIcon> = {
   info: Info,
@@ -68,40 +63,23 @@ export function NotebookNotice({
   contentClassName,
   "data-testid": dataTestId,
 }: NotebookNoticeProps) {
-  // `undefined` means "no explicit icon" → fall back to the tone default so
-  // shape signals severity. `null` is an explicit opt-out and renders nothing.
+  // undefined → tone default; null → no icon
   const ToneIcon = toneDefaultIcon[tone];
   const resolvedIcon = icon === undefined ? <ToneIcon /> : icon;
   return (
     <div
-      className={cn(
-        // Column layout: the header row (icon + text + actions + dismiss) sits
-        // on top, and `details` drops to its own full-width row below it — so a
-        // traceback/code block spans the whole notice instead of a sliver
-        // indented beside the icon.
-        "flex min-w-0 flex-col border-b px-3 py-2",
-        toneClassName[tone],
-        className,
-      )}
+      className={cn("flex min-w-0 flex-col border-b px-3 py-2", toneClassName[tone], className)}
       data-slot="notebook-notice"
       data-tone={tone}
       data-testid={dataTestId}
     >
-      {/* Header row. `min-h-9` keeps a bare one-line bar a stable height whether
-          or not it has an action button, but is dropped when a detail row
-          follows: the slack would otherwise land as dead space between the
-          title and the disclosure. items-start pins the icon/actions/dismiss to
-          the top when the body wraps to multiple lines. `@container` scopes the
-          header query below to this notice's own width, so narrow notices wrap
-          their actions regardless of viewport. */}
+      {/* Skip min-h-9 when details follow — otherwise empty gap above the disclosure */}
       <div
         className={cn("@container flex min-w-0 items-start gap-3", details ? undefined : "min-h-9")}
       >
         {resolvedIcon ? (
           <span
             className={cn(
-              // Own icon size here so callers pass shape only (`<CloudOff />`,
-              // `<Loader2 className="animate-spin" />`) without restating size-*.
               "mt-0.5 flex size-4 shrink-0 items-center justify-center [&_svg]:size-4",
               iconClassName[tone],
             )}
@@ -111,14 +89,9 @@ export function NotebookNotice({
           </span>
         ) : null}
         <div className={cn("min-w-0 flex-1", contentClassName)}>
-          {/* Message text and (optional) actions. On a wide notice the actions
-              pin to the right of the text (`@xs:` row); on a narrow notice they
-              wrap onto their own line below the text (default column) so they
-              never squeeze the message. */}
           {title || children || actions ? (
             <div className="flex flex-col gap-1.5 @xs:flex-row @xs:items-start @xs:justify-between @xs:gap-3">
               {title || children ? (
-                // Title on its own line, larger; body smaller beneath it.
                 <div className="min-w-0 space-y-0.5 @xs:flex-1">
                   {title ? <div className="text-sm font-semibold leading-snug">{title}</div> : null}
                   {children ? (
@@ -132,9 +105,6 @@ export function NotebookNotice({
             </div>
           ) : null}
         </div>
-        {/* Dismiss stays pinned to the top-right of the header row (which is
-            `items-start`), so it never moves when actions wrap below the text
-            on a narrow notice. */}
         {onDismiss ? (
           <button
             type="button"
@@ -149,9 +119,6 @@ export function NotebookNotice({
           </button>
         ) : null}
       </div>
-      {/* Full-width detail row: spans the whole notice (not indented beside the
-          icon, not sharing the flex row with the icon/dismiss) so code blocks
-          and tracebacks read edge-to-edge. */}
       {details ? <div className="mt-1 min-w-0">{details}</div> : null}
     </div>
   );
@@ -199,10 +166,6 @@ export function NotebookNoticeAction({
       type="button"
       onClick={onClick}
       className={cn(
-        // Reads as a real button: a borderless chip with a fill drawn from the
-        // tone's currentColor, not a bare text link. h-6 + whitespace-nowrap
-        // keep it from growing the notice row or wrapping. Action icons are
-        // sized here (`[&_svg]:size-3`); callers pass shape only.
         "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20 [&_svg]:size-3",
         className,
       )}
@@ -223,17 +186,7 @@ export interface NotebookNoticeDetailsProps {
   "data-testid"?: string;
 }
 
-/**
- * Collapsible, full-width detail block for tracebacks and raw error strings.
- *
- * Collapsed by default (a `<details>`/`<summary>` disclosure) so a wall of
- * stderr never dominates the notice — the user opens it on demand. When open,
- * the block spans the notice edge-to-edge and wraps long lines, so a traceback
- * is readable in full without horizontal scrolling.
- *
- * Pass this as the `details` slot of a `NotebookNotice`, which drops it onto
- * its own full-width row below the header.
- */
+/** Collapsible traceback / raw error for the `details` slot. */
 export function NotebookNoticeDetails({
   children,
   label = "Show details",

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -19,12 +19,6 @@ export interface NotebookNoticeProps {
   "data-testid"?: string;
 }
 
-export interface NotebookNoticeStackProps {
-  children: ReactNode;
-  className?: string;
-  "data-testid"?: string;
-}
-
 const toneClassName: Record<NotebookNoticeTone, string> = {
   info: "border-sky-500/25 bg-sky-500/10 text-sky-950 dark:text-sky-100",
   warning: "border-amber-500/30 bg-amber-500/10 text-amber-950 dark:text-amber-100",
@@ -60,22 +54,6 @@ const toneDefaultIcon: Record<NotebookNoticeTone, LucideIcon> = {
   success: CheckCircle2,
   debug: Bug,
 };
-
-export function NotebookNoticeStack({
-  children,
-  className,
-  "data-testid": dataTestId,
-}: NotebookNoticeStackProps) {
-  return (
-    <div
-      className={cn("flex flex-col gap-1", className)}
-      data-slot="notebook-notice-stack"
-      data-testid={dataTestId}
-    >
-      {children}
-    </div>
-  );
-}
 
 export function NotebookNotice({
   tone = "info",
@@ -175,6 +153,28 @@ export function NotebookNotice({
           icon, not sharing the flex row with the icon/dismiss) so code blocks
           and tracebacks read edge-to-edge. */}
       {details ? <div className="mt-1 min-w-0">{details}</div> : null}
+    </div>
+  );
+}
+
+export interface NotebookNoticeStackProps {
+  children: ReactNode;
+  className?: string;
+  "data-testid"?: string;
+}
+
+export function NotebookNoticeStack({
+  children,
+  className,
+  "data-testid": dataTestId,
+}: NotebookNoticeStackProps) {
+  return (
+    <div
+      className={cn("flex flex-col gap-1", className)}
+      data-slot="notebook-notice-stack"
+      data-testid={dataTestId}
+    >
+      {children}
     </div>
   );
 }

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -47,6 +47,9 @@ const iconClassName: Record<NotebookNoticeTone, string> = {
  * pass a more specific `icon` (e.g. CloudOff for reconnecting); when it does
  * not, the tone picks the icon. Pass `icon={null}` to opt out entirely.
  *
+ * Callers pass shape only — this shell sizes notice icons to `size-4` and
+ * action icons to `size-3`. Do not put size classes on passed icons.
+ *
  * Components, not elements: module-scope JSX would evaluate at import time,
  * before consumers that install React globally (the node:test suites) run.
  */
@@ -90,7 +93,7 @@ export function NotebookNotice({
   // `undefined` means "no explicit icon" → fall back to the tone default so
   // shape signals severity. `null` is an explicit opt-out and renders nothing.
   const ToneIcon = toneDefaultIcon[tone];
-  const resolvedIcon = icon === undefined ? <ToneIcon className="size-4" /> : icon;
+  const resolvedIcon = icon === undefined ? <ToneIcon /> : icon;
   return (
     <div
       className={cn(
@@ -119,7 +122,9 @@ export function NotebookNotice({
         {resolvedIcon ? (
           <span
             className={cn(
-              "mt-0.5 flex size-4 shrink-0 items-center justify-center",
+              // Own icon size here so callers pass shape only (`<CloudOff />`,
+              // `<Loader2 className="animate-spin" />`) without restating size-*.
+              "mt-0.5 flex size-4 shrink-0 items-center justify-center [&_svg]:size-4",
               iconClassName[tone],
             )}
             aria-hidden="true"
@@ -196,8 +201,9 @@ export function NotebookNoticeAction({
       className={cn(
         // Reads as a real button: a borderless chip with a fill drawn from the
         // tone's currentColor, not a bare text link. h-6 + whitespace-nowrap
-        // keep it from growing the notice row or wrapping.
-        "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20",
+        // keep it from growing the notice row or wrapping. Action icons are
+        // sized here (`[&_svg]:size-3`); callers pass shape only.
+        "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20 [&_svg]:size-3",
         className,
       )}
       data-testid={dataTestId}

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Bug, CheckCircle2, Info, XCircle, X } from "lucide-react";
+import { AlertTriangle, Bug, CheckCircle2, ChevronRight, Info, XCircle, X } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -89,11 +89,11 @@ export function NotebookNotice({
   return (
     <div
       className={cn(
-        // min-h keeps the bar a stable height whether or not an action button
-        // is present, so adding a single button never grows a one-line row.
-        // items-start keeps the icon/actions pinned to the top when the body
-        // wraps to multiple lines (e.g. a collapsed traceback).
-        "flex min-h-9 min-w-0 items-start gap-3 border-b px-3 py-2 text-xs",
+        // Column layout: the header row (icon + text + actions + dismiss) sits
+        // on top, and `details` drops to its own full-width row below it — so a
+        // traceback/code block spans the whole notice instead of a sliver
+        // indented beside the icon.
+        "flex min-w-0 flex-col border-b px-3 py-2",
         toneClassName[tone],
         className,
       )}
@@ -101,45 +101,70 @@ export function NotebookNotice({
       data-tone={tone}
       data-testid={dataTestId}
     >
-      {resolvedIcon ? (
-        <span
-          className={cn(
-            "mt-0.5 flex size-4 shrink-0 items-center justify-center",
-            iconClassName[tone],
-          )}
-          aria-hidden="true"
-        >
-          {resolvedIcon}
-        </span>
-      ) : null}
-      <div className={cn("min-w-0 flex-1 space-y-1", contentClassName)}>
-        {title || children ? (
-          <div className="min-w-0">
-            {title ? <span className="font-medium">{title}</span> : null}
-            {title && children ? <span> </span> : null}
-            {children}
-          </div>
+      {/* Header row. `min-h-9` keeps a bare one-line bar a stable height whether
+          or not it has an action button, but is dropped when a detail row
+          follows: the slack would otherwise land as dead space between the
+          title and the disclosure. items-start pins the icon/actions/dismiss to
+          the top when the body wraps to multiple lines. `@container` scopes the
+          header query below to this notice's own width, so narrow notices wrap
+          their actions regardless of viewport. */}
+      <div
+        className={cn("@container flex min-w-0 items-start gap-3", details ? undefined : "min-h-9")}
+      >
+        {resolvedIcon ? (
+          <span
+            className={cn(
+              "mt-0.5 flex size-4 shrink-0 items-center justify-center",
+              iconClassName[tone],
+            )}
+            aria-hidden="true"
+          >
+            {resolvedIcon}
+          </span>
         ) : null}
-        {details ? <div className="min-w-0">{details}</div> : null}
-      </div>
-      {actions || onDismiss ? (
-        <div className="flex shrink-0 items-center gap-1">
-          {actions}
-          {onDismiss ? (
-            <button
-              type="button"
-              onClick={onDismiss}
-              className={cn(
-                "rounded p-0.5 transition-colors hover:bg-current/10",
-                iconClassName[tone],
-              )}
-              aria-label={dismissLabel}
-            >
-              <X className="size-3" />
-            </button>
+        <div className={cn("min-w-0 flex-1", contentClassName)}>
+          {/* Message text and (optional) actions. On a wide notice the actions
+              pin to the right of the text (`@xs:` row); on a narrow notice they
+              wrap onto their own line below the text (default column) so they
+              never squeeze the message. */}
+          {title || children || actions ? (
+            <div className="flex flex-col gap-1.5 @xs:flex-row @xs:items-start @xs:justify-between @xs:gap-3">
+              {title || children ? (
+                // Title on its own line, larger; body smaller beneath it.
+                <div className="min-w-0 space-y-0.5 @xs:flex-1">
+                  {title ? <div className="text-sm font-semibold leading-snug">{title}</div> : null}
+                  {children ? (
+                    <div className="text-xs leading-snug text-current/80">{children}</div>
+                  ) : null}
+                </div>
+              ) : null}
+              {actions ? (
+                <div className="flex shrink-0 flex-wrap items-center gap-1">{actions}</div>
+              ) : null}
+            </div>
           ) : null}
         </div>
-      ) : null}
+        {/* Dismiss stays pinned to the top-right of the header row (which is
+            `items-start`), so it never moves when actions wrap below the text
+            on a narrow notice. */}
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className={cn(
+              "-mr-0.5 mt-0.5 shrink-0 rounded p-0.5 transition-colors hover:bg-current/10",
+              iconClassName[tone],
+            )}
+            aria-label={dismissLabel}
+          >
+            <X className="size-3" />
+          </button>
+        ) : null}
+      </div>
+      {/* Full-width detail row: spans the whole notice (not indented beside the
+          icon, not sharing the flex row with the icon/dismiss) so code blocks
+          and tracebacks read edge-to-edge. */}
+      {details ? <div className="mt-1 min-w-0">{details}</div> : null}
     </div>
   );
 }
@@ -164,10 +189,10 @@ export function NotebookNoticeAction({
       type="button"
       onClick={onClick}
       className={cn(
-        // Reads as a real button: bordered chip with a solid-ish fill from the
+        // Reads as a real button: a borderless chip with a fill drawn from the
         // tone's currentColor, not a bare text link. h-6 + whitespace-nowrap
         // keep it from growing the notice row or wrapping.
-        "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-current/25 bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20",
+        "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20",
         className,
       )}
       data-testid={dataTestId}
@@ -175,5 +200,44 @@ export function NotebookNoticeAction({
       {icon}
       <span>{children}</span>
     </button>
+  );
+}
+
+export interface NotebookNoticeDetailsProps {
+  /** Raw error text / traceback. Rendered monospace, preserving newlines. */
+  children: string;
+  /** Summary label shown on the collapsed row. */
+  label?: string;
+  className?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Collapsible, full-width detail block for tracebacks and raw error strings.
+ *
+ * Collapsed by default (a `<details>`/`<summary>` disclosure) so a wall of
+ * stderr never dominates the notice — the user opens it on demand. When open,
+ * the block spans the notice edge-to-edge and wraps long lines, so a traceback
+ * is readable in full without horizontal scrolling.
+ *
+ * Pass this as the `details` slot of a `NotebookNotice`, which drops it onto
+ * its own full-width row below the header.
+ */
+export function NotebookNoticeDetails({
+  children,
+  label = "Show details",
+  className,
+  "data-testid": dataTestId,
+}: NotebookNoticeDetailsProps) {
+  return (
+    <details className={cn("group/details min-w-0", className)} data-testid={dataTestId}>
+      <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-xs font-medium text-current/80 transition-colors hover:text-current [&::-webkit-details-marker]:hidden">
+        <ChevronRight className="size-3 transition-transform group-open/details:rotate-90" />
+        {label}
+      </summary>
+      <pre className="mt-1.5 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded bg-current/5 px-2 py-1.5 font-mono text-[11px] leading-snug">
+        {children}
+      </pre>
+    </details>
   );
 }

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -130,7 +130,7 @@ export function NotebookNoticeStack({
 }: NotebookNoticeStackProps) {
   return (
     <div
-      className={cn("flex flex-col gap-1", className)}
+      className={cn("flex flex-col gap-0", className)}
       data-slot="notebook-notice-stack"
       data-testid={dataTestId}
     >

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, Bug, CheckCircle2, ChevronRight, Info, XCircle, X } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -45,13 +46,16 @@ const iconClassName: Record<NotebookNoticeTone, string> = {
  * (accessible for color-blind users and quicker to scan). A caller can still
  * pass a more specific `icon` (e.g. CloudOff for reconnecting); when it does
  * not, the tone picks the icon. Pass `icon={null}` to opt out entirely.
+ *
+ * Components, not elements: module-scope JSX would evaluate at import time,
+ * before consumers that install React globally (the node:test suites) run.
  */
-const toneDefaultIcon: Record<NotebookNoticeTone, ReactNode> = {
-  info: <Info className="size-4" />,
-  warning: <AlertTriangle className="size-4" />,
-  error: <XCircle className="size-4" />,
-  success: <CheckCircle2 className="size-4" />,
-  debug: <Bug className="size-4" />,
+const toneDefaultIcon: Record<NotebookNoticeTone, LucideIcon> = {
+  info: Info,
+  warning: AlertTriangle,
+  error: XCircle,
+  success: CheckCircle2,
+  debug: Bug,
 };
 
 export function NotebookNoticeStack({
@@ -85,7 +89,8 @@ export function NotebookNotice({
 }: NotebookNoticeProps) {
   // `undefined` means "no explicit icon" → fall back to the tone default so
   // shape signals severity. `null` is an explicit opt-out and renders nothing.
-  const resolvedIcon = icon === undefined ? toneDefaultIcon[tone] : icon;
+  const ToneIcon = toneDefaultIcon[tone];
+  const resolvedIcon = icon === undefined ? <ToneIcon className="size-4" /> : icon;
   return (
     <div
       className={cn(

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -159,7 +159,7 @@ export function NotebookNoticeAction({
       type="button"
       onClick={onClick}
       className={cn(
-        "inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20 [&_svg]:size-3",
+        "inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md bg-current/10 px-2 text-xs font-medium transition-colors hover:bg-current/20 [&_svg]:size-3 [&_svg]:shrink-0",
         className,
       )}
       data-testid={dataTestId}

--- a/src/components/notebook/PoolErrorBanner.tsx
+++ b/src/components/notebook/PoolErrorBanner.tsx
@@ -48,12 +48,12 @@ function PoolErrorItem({ envType, error, onDismiss, onOpenSettings }: PoolErrorI
   return (
     <NotebookNotice
       tone="warning"
-      icon={isTimeout ? <Clock className="size-3" /> : <AlertTriangle className="size-3" />}
+      icon={isTimeout ? <Clock /> : <AlertTriangle />}
       title={error.message}
       onDismiss={onDismiss}
       actions={
         showSettingsButton(error) && onOpenSettings ? (
-          <NotebookNoticeAction onClick={onOpenSettings} icon={<Settings className="size-3" />}>
+          <NotebookNoticeAction onClick={onOpenSettings} icon={<Settings />}>
             Settings
           </NotebookNoticeAction>
         ) : null

--- a/src/components/notebook/UntrustedBanner.tsx
+++ b/src/components/notebook/UntrustedBanner.tsx
@@ -10,7 +10,7 @@ export function UntrustedBanner({ onReviewClick }: UntrustedBannerProps) {
   return (
     <NotebookNotice
       tone="warning"
-      icon={<ShieldAlert className="size-4" />}
+      icon={<ShieldAlert />}
       actions={
         <Button
           size="sm"

--- a/src/components/notebook/__tests__/NotebookNotice.test.tsx
+++ b/src/components/notebook/__tests__/NotebookNotice.test.tsx
@@ -9,7 +9,7 @@ describe("NotebookNotice", () => {
     render(
       <NotebookNotice
         tone="warning"
-        icon={<AlertTriangle className="h-3 w-3" />}
+        icon={<AlertTriangle />}
         title="Runtime unavailable"
         details={<pre>socket timed out</pre>}
       >

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -115,8 +115,10 @@ export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./Note
 export {
   NotebookNotice,
   NotebookNoticeAction,
+  NotebookNoticeDetails,
   NotebookNoticeStack,
   type NotebookNoticeActionProps,
+  type NotebookNoticeDetailsProps,
   type NotebookNoticeProps,
   type NotebookNoticeStackProps,
   type NotebookNoticeTone,


### PR DESCRIPTION
## Summary
- Collapse long / traceback error details behind a `NotebookNoticeDetails` disclosure so notices stay readable instead of clipping mid-line.
- Route host banners (daemon, kernel launch, cloud notices) through that disclosure pattern and keep calm guidance in the notice body.
- Own notice/action icon sizing in the `NotebookNotice` shell so callers pass shape only; widen action icon↔label gap so chips don't read flush at size-3.
- Stop cloud host CSS from restyling shared notices (layout-only `.cloud-notebook-notices` region) so tone washes, padding, and borders match desktop.
- Stack notices with no gap by default (`NotebookNoticeStack`).
- Add a notebook notices gallery for reviewing states; strip exploratory chrome (fake toolbar, proposed padding contrast) so fixtures show the real surfaces.

<img width="806" height="315" alt="Screenshot 2026-07-31 at 7 28 47 AM" src="https://github.com/user-attachments/assets/4b5377dd-48c3-48e9-8510-c4372669d4ae" />

## Test plan
- [ ] Open `http://localhost:5174/gallery/` → **Runtime unavailable (desktop)** and **Kernel failed to start**; confirm guidance is the body and raw error is behind **Show error details**
- [ ] Expand details: monospace block wraps fully without clipping the lead line
- [ ] Elements → Runtime surfaces → `DaemonStatusBanner` / `KernelLaunchErrorBanner` fixtures match the same layout
- [ ] Spot-check cloud notices after `pnpm --dir apps/notebook-cloud run build:viewer` (or a fresh `dev:browser`): tone/padding/borders match desktop; stacked notices sit flush; action icon and label have clear spacing
- [ ] Narrow gallery/viewport: notice cards and action bar do not overflow