### PR TITLE
fix(sift): refine image columns across stream batches

### DIFF
--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -36,7 +36,8 @@ struct DataStore {
     num_cols: usize,
     col_names: Vec<String>,
     col_types: Vec<String>, // "numeric", "categorical", "boolean", "timestamp", "image"
-    /// Set once the value-based image sniff has run over the first batches.
+    /// Set once every candidate column has either sampled enough leading
+    /// non-null values, found a non-image value, or reached stream completion.
     image_columns_refined: bool,
     col_timezones: Vec<Option<String>>,
     /// Original column arrays saved before casting, keyed by column index.
@@ -178,19 +179,22 @@ fn is_sniffable_string_data_type(dt: &DataType) -> bool {
 /// Requires unanimity rather than a majority: a false positive routes a text
 /// column through the image path, where cells render blank. A false negative
 /// only leaves the column as text, which is what it would have been anyway.
-fn column_sniffs_as_images(batches: &[RecordBatch], col: usize) -> bool {
-    let mut seen = 0usize;
-    let mut matched = 0usize;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ImageColumnSniff {
+    Pending,
+    Image,
+    NotImage,
+}
 
-    for batch in batches {
+fn sniff_image_column(store: &DataStore, col: usize) -> ImageColumnSniff {
+    let mut seen = 0usize;
+
+    for batch in &store.batches {
         if col >= batch.num_columns() {
-            return false;
+            return ImageColumnSniff::NotImage;
         }
         let column = batch.column(col);
         for row in 0..column.len() {
-            if seen >= IMAGE_SNIFF_SAMPLE {
-                return seen > 0 && matched == seen;
-            }
             if cell_is_null(column.as_ref(), row) {
                 continue;
             }
@@ -199,9 +203,12 @@ fn column_sniffs_as_images(batches: &[RecordBatch], col: usize) -> bool {
                     let Some(value) = string_value_at(column.as_ref(), row) else {
                         continue;
                     };
+                    if !looks_like_base64_image(value) {
+                        return ImageColumnSniff::NotImage;
+                    }
                     seen += 1;
-                    if looks_like_base64_image(value) {
-                        matched += 1;
+                    if seen >= IMAGE_SNIFF_SAMPLE {
+                        return ImageColumnSniff::Image;
                     }
                 }
                 DataType::List(_) | DataType::LargeList(_) => {
@@ -220,18 +227,29 @@ fn column_sniffs_as_images(batches: &[RecordBatch], col: usize) -> bool {
                         let Some(value) = string_value_at(inner.as_ref(), i) else {
                             continue;
                         };
+                        if !looks_like_base64_image(value) {
+                            return ImageColumnSniff::NotImage;
+                        }
                         seen += 1;
-                        if looks_like_base64_image(value) {
-                            matched += 1;
+                        if seen >= IMAGE_SNIFF_SAMPLE {
+                            return ImageColumnSniff::Image;
                         }
                     }
                 }
-                _ => return false,
+                _ => return ImageColumnSniff::NotImage,
             }
         }
     }
 
-    seen > 0 && matched == seen
+    if store.streaming_complete {
+        if seen > 0 {
+            ImageColumnSniff::Image
+        } else {
+            ImageColumnSniff::NotImage
+        }
+    } else {
+        ImageColumnSniff::Pending
+    }
 }
 
 /// Upgrade string columns whose values are base64 data URIs to `"image"`.
@@ -239,13 +257,17 @@ fn column_sniffs_as_images(batches: &[RecordBatch], col: usize) -> bool {
 /// Type alone cannot answer this: `List<Utf8>` is how several HuggingFace
 /// datasets carry images, and it is also how they carry ordinary text.
 fn refine_image_columns(store: &mut DataStore) {
-    if store.image_columns_refined || store.batches.is_empty() {
+    if store.image_columns_refined {
+        return;
+    }
+    if store.batches.is_empty() {
+        store.image_columns_refined = store.streaming_complete;
         return;
     }
     let Some(schema) = store.schema.clone() else {
         return;
     };
-    store.image_columns_refined = true;
+    let mut pending = false;
 
     for (col, field) in schema.fields().iter().enumerate() {
         if store.col_types.get(col).map(String::as_str) == Some("image") {
@@ -254,10 +276,14 @@ fn refine_image_columns(store: &mut DataStore) {
         if !is_sniffable_string_data_type(field.data_type()) {
             continue;
         }
-        if column_sniffs_as_images(&store.batches, col) {
-            store.col_types[col] = "image".to_string();
+        match sniff_image_column(store, col) {
+            ImageColumnSniff::Pending => pending = true,
+            ImageColumnSniff::Image => store.col_types[col] = "image".to_string(),
+            ImageColumnSniff::NotImage => {}
         }
     }
+
+    store.image_columns_refined = !pending;
 }
 
 fn is_binary_data_type(dt: &DataType) -> bool {
@@ -525,6 +551,7 @@ fn store_batches(
     let mut store = empty_streaming_store();
     append_batches_to_store(&mut store, schema, batches)?;
     store.streaming_complete = true;
+    refine_image_columns(&mut store);
 
     let handle = {
         let mut h = NEXT_HANDLE.lock().unwrap_or_else(|e| e.into_inner());
@@ -616,6 +643,7 @@ pub fn finish_arrow_stream_store(handle: u32) -> Result<(), JsValue> {
             .get_mut(&handle)
             .ok_or_else(|| JsValue::from_str(&format!("Invalid handle: {}", handle)))?;
         store.streaming_complete = true;
+        refine_image_columns(store);
         Ok(())
     })
 }
@@ -2896,6 +2924,8 @@ mod tests {
         let batch = RecordBatch::try_new(schema.clone(), vec![array]).expect("record batch");
         let mut store = empty_streaming_store();
         append_batches_to_store(&mut store, schema, vec![batch]).expect("append");
+        store.streaming_complete = true;
+        refine_image_columns(&mut store);
         store
     }
 
@@ -2974,6 +3004,45 @@ mod tests {
         let arr = StringArray::from(vec![None as Option<&str>, None, None]);
         let store = store_from_string_column(DataType::Utf8, Arc::new(arr) as ArrayRef);
         assert_eq!(store.col_types[0], "categorical");
+    }
+
+    #[test]
+    fn image_sniff_waits_for_non_null_values_across_stream_chunks() {
+        let schema = Arc::new(Schema::new(vec![Field::new("image", DataType::Utf8, true)]));
+        let null_chunk = ipc_stream(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![None::<&str>, None])) as ArrayRef],
+        );
+        let first = data_uri("first");
+        let second = data_uri("second");
+        let image_chunk = ipc_stream(
+            schema,
+            vec![Arc::new(StringArray::from(vec![first.as_str(), second.as_str()])) as ArrayRef],
+        );
+        let handle = create_arrow_stream_store();
+
+        append_arrow_stream_chunk(handle, &null_chunk).expect("append null-only chunk");
+        let after_nulls = with_store(handle, |store| {
+            (store.image_columns_refined, store.col_types[0].clone())
+        })
+        .expect("store");
+        assert_eq!(after_nulls, (false, "categorical".to_string()));
+
+        append_arrow_stream_chunk(handle, &image_chunk).expect("append image chunk");
+        let before_finish = with_store(handle, |store| {
+            (store.image_columns_refined, store.col_types[0].clone())
+        })
+        .expect("store");
+        assert_eq!(before_finish, (false, "categorical".to_string()));
+
+        finish_arrow_stream_store(handle).expect("finish stream");
+        let after_finish = with_store(handle, |store| {
+            (store.image_columns_refined, store.col_types[0].clone())
+        })
+        .expect("store");
+        assert_eq!(after_finish, (true, "image".to_string()));
+
+        free(handle);
     }
 
     #[test]

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -13,7 +13,9 @@ const predicateModule = vi.hoisted(() => ({
   num_rows: vi.fn(() => 2),
   num_cols: vi.fn(() => 2),
   col_names: vi.fn(() => ["id", "name"]),
-  col_type: vi.fn((_handle: number, col: number) => (col === 0 ? "numeric" : "categorical")),
+  col_type: vi.fn((_handle: number, col: number): string =>
+    col === 0 ? "numeric" : "categorical",
+  ),
   col_timezone: vi.fn(() => null),
   store_histogram: vi.fn(() => []),
   store_temporal_histogram: vi.fn(() => []),
@@ -30,6 +32,8 @@ const predicateModule = vi.hoisted(() => ({
     col === 0 ? String(row + 1) : `row ${row + 1}`,
   ),
   get_cell_f64: vi.fn((_handle: number, row: number) => row + 1),
+  get_cell_image_count: vi.fn(() => 0),
+  get_cell_image_bytes_at: vi.fn(() => new Uint8Array()),
   free: vi.fn(),
 }));
 
@@ -506,6 +510,41 @@ describe("SiftTable", () => {
     });
     expect(predicateModule.create_arrow_stream_store).toHaveBeenCalledTimes(1);
     expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+  });
+
+  it("refreshes mounted columns when stream completion refines an image type", async () => {
+    vi.useRealTimers();
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: true as const,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      }),
+    );
+    predicateModule.col_type.mockImplementation((_handle: number, col: number) => {
+      if (col === 0) return "numeric";
+      return predicateModule.finish_arrow_stream_store.mock.calls.length > 0
+        ? "image"
+        : "categorical";
+    });
+
+    const source: SiftSource = {
+      kind: "arrow-stream-manifest",
+      manifest: {
+        chunks: [{ url: "http://127.0.0.1:9000/blob/chunk-0", row_count: 2 }],
+        complete: true,
+      },
+    };
+    const { container } = render(<SiftTable source={source} />);
+
+    await waitFor(() => {
+      expect(predicateModule.finish_arrow_stream_store).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(container.querySelectorAll('.sift-type-icon[title="image"]')).toHaveLength(1);
+    });
 
     vi.unstubAllGlobals();
     vi.useFakeTimers();

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -95,11 +95,11 @@ type ManifestStore = {
   chunkKeys: string[];
   tableData: TableData;
   columns: Column[];
+  refreshColumnTypes: (columnOverrides?: Record<string, Partial<Column>>) => TableData | null;
   pandasIndexCols: Set<string>;
   /** Overrides this store was built with. A change forces a rebuild. */
   columnOverrides: Record<string, Partial<Column>> | undefined;
   finished: boolean;
-  dispose: () => void;
 };
 
 function arrowStreamChunkKeys(manifest: ArrowStreamManifest): string[] {
@@ -392,7 +392,7 @@ export function SiftTable({
       engineDivRef.current = null;
       // Manifest-effect cleanup deliberately leaves a mounted store alone, so
       // unmount is the only place a committed store gets freed.
-      storeRef.current?.dispose();
+      storeRef.current?.tableData.dispose?.();
       storeRef.current = null;
       footerControlRootRef.current?.unmount();
       footerControlRootRef.current = null;
@@ -524,6 +524,11 @@ export function SiftTable({
         });
         mod.append_arrow_stream_chunk(store.handle, bytes);
         store.chunkKeys.push(chunkKeys[i]);
+        const refinedTableData = store.refreshColumnTypes(store.columnOverrides);
+        if (refinedTableData) {
+          store.tableData = refinedTableData;
+          store.columns = refinedTableData.columns;
+        }
         store.tableData.rowCount = mod.num_rows(store.handle);
         updateWasmSummaries(
           mod,
@@ -532,7 +537,11 @@ export function SiftTable({
           store.columns,
           store.pandasIndexCols,
         );
-        engineRef.current?.onBatchAppended();
+        if (refinedTableData) {
+          engineRef.current?.replaceData(store.tableData, { streaming: true });
+        } else {
+          engineRef.current?.onBatchAppended();
+        }
         emitLoadMilestone(startedAt, {
           source: "arrow-stream-manifest",
           phase: "chunk-appended",
@@ -546,7 +555,22 @@ export function SiftTable({
       if (manifest.complete !== false) {
         mod.finish_arrow_stream_store(store.handle);
         store.finished = true;
-        engineRef.current?.setStreamingDone();
+        const refinedTableData = store.refreshColumnTypes(store.columnOverrides);
+        if (refinedTableData) {
+          store.tableData = refinedTableData;
+          store.columns = refinedTableData.columns;
+          store.tableData.rowCount = mod.num_rows(store.handle);
+          updateWasmSummaries(
+            mod,
+            store.handle,
+            store.tableData,
+            store.columns,
+            store.pandasIndexCols,
+          );
+          engineRef.current?.replaceData(store.tableData, { streaming: false });
+        } else {
+          engineRef.current?.setStreamingDone();
+        }
         emitLoadMilestone(startedAt, {
           source: "arrow-stream-manifest",
           phase: "streaming-complete",
@@ -605,7 +629,8 @@ export function SiftTable({
         mod.num_rows(handle),
       );
       const pandasIndexCols = pandasIndexColumnsFromHints(columnHints);
-      const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+      const { tableData, columns, prefetchViewport, refreshColumnTypes } =
+        createWasmTableData(handle);
       disposePendingStore = () => tableData.dispose?.();
       tableData.prefetchViewport = prefetchViewport;
       tableData.recomputeSummaries = () =>
@@ -647,10 +672,10 @@ export function SiftTable({
         chunkKeys: arrowStreamChunkKeys(manifest).slice(0, 1),
         tableData,
         columns,
+        refreshColumnTypes,
         pandasIndexCols,
         columnOverrides,
         finished: false,
-        dispose: () => tableData.dispose?.(),
       };
       storeRef.current = store;
 

--- a/packages/sift/src/wasm-table-data.test.ts
+++ b/packages/sift/src/wasm-table-data.test.ts
@@ -99,4 +99,41 @@ describe("createWasmTableData", () => {
     expect(tableData.getCellRaw(0, 0)).toEqual([imageBytes]);
     expect(predicateModule.get_cell_string).not.toHaveBeenCalled();
   });
+
+  it("refreshes a resolved image type without freeing the store during handoff", () => {
+    const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    predicateModule.num_cols.mockReturnValueOnce(1);
+    predicateModule.col_names.mockReturnValueOnce(["image"]);
+    predicateModule.col_type.mockReturnValueOnce("categorical").mockReturnValueOnce("image");
+    predicateModule.is_null.mockReturnValueOnce(false);
+    predicateModule.get_cell_image_count.mockReturnValueOnce(1);
+    predicateModule.get_cell_image_bytes_at.mockReturnValueOnce(imageBytes);
+
+    const { tableData, refreshColumnTypes } = createWasmTableData(7);
+    const refreshed = refreshColumnTypes();
+
+    expect(refreshed).not.toBeNull();
+    expect(refreshed?.columns[0].columnType).toBe("image");
+    expect(refreshed?.getCellRaw(0, 0)).toEqual([imageBytes]);
+
+    tableData.dispose?.();
+    expect(predicateModule.free).not.toHaveBeenCalled();
+    refreshed?.dispose?.();
+    expect(predicateModule.free).toHaveBeenCalledTimes(1);
+    expect(predicateModule.free).toHaveBeenCalledWith(7);
+  });
+
+  it("keeps an explicit column type override when WASM refinement resolves", () => {
+    predicateModule.num_cols.mockReturnValueOnce(1);
+    predicateModule.col_names.mockReturnValueOnce(["image"]);
+    predicateModule.col_type.mockReturnValueOnce("categorical").mockReturnValueOnce("image");
+
+    const { tableData, refreshColumnTypes } = createWasmTableData(7);
+    const refreshed = refreshColumnTypes({ image: { columnType: "categorical" } });
+
+    expect(refreshed).toBeNull();
+    expect(tableData.columns[0].columnType).toBe("categorical");
+    tableData.dispose?.();
+    expect(predicateModule.free).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/sift/src/wasm-table-data.ts
+++ b/packages/sift/src/wasm-table-data.ts
@@ -32,6 +32,12 @@ export type WasmTableHandle = {
   columns: Column[];
   /** Prefetch visible rows into a JS-side cache. Call before render. */
   prefetchViewport: (dataRowIndices: number[]) => void;
+  /**
+   * Re-read resolved WASM column types. A changed type returns a replacement
+   * TableData lease that can be handed to the table engine without freeing
+   * the shared WASM store during the swap.
+   */
+  refreshColumnTypes: (columnOverrides?: Record<string, Partial<Column>>) => TableData | null;
 };
 
 /**
@@ -43,13 +49,12 @@ export function createWasmTableData(
   columnOverrides?: Record<string, Partial<Column>>,
 ): WasmTableHandle {
   const mod = getModuleSync();
-  let disposed = false;
 
   const numRows = mod.num_rows(handle);
   const numCols = mod.num_cols(handle);
   const names: string[] = mod.col_names(handle);
 
-  const columns: Column[] = [];
+  let columns: Column[] = [];
   for (let c = 0; c < numCols; c++) {
     const wasmType = mod.col_type(handle, c);
     const colType = mapColType(wasmType);
@@ -68,6 +73,23 @@ export function createWasmTableData(
 
   // Viewport cache: maps data row index → { strings[], raws[] }
   const cache = new Map<number, { strings: string[]; raws: unknown[] }>();
+  let leaseCount = 0;
+  let storeFreed = false;
+
+  function acquireDispose() {
+    leaseCount += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      leaseCount -= 1;
+      if (leaseCount === 0 && !storeFreed) {
+        storeFreed = true;
+        mod.free(handle);
+        cache.clear();
+      }
+    };
+  }
 
   function prefetchViewport(dataRowIndices: number[]) {
     if (dataRowIndices.length === 0) return;
@@ -106,7 +128,7 @@ export function createWasmTableData(
     }
   }
 
-  const tableData: TableData = {
+  let tableData: TableData = {
     columns,
     rowCount: numRows,
     getCell(row: number, col: number): string {
@@ -261,13 +283,37 @@ export function createWasmTableData(
       }
       return mod.store_filter_rows(handle, specs);
     },
-    dispose() {
-      if (disposed) return;
-      disposed = true;
-      mod.free(handle);
-      cache.clear();
-    },
+    dispose: acquireDispose(),
   };
 
-  return { handle, tableData, columns, prefetchViewport };
+  function refreshColumnTypes(
+    refreshOverrides?: Record<string, Partial<Column>>,
+  ): TableData | null {
+    let changed = false;
+    const nextColumns = columns.map((column, col) => {
+      const override = refreshOverrides?.[column.key];
+      const columnType = override?.columnType ?? mapColType(mod.col_type(handle, col));
+      const numeric = override?.numeric ?? columnType === "numeric";
+      if (columnType === column.columnType && numeric === column.numeric) return column;
+      changed = true;
+      return {
+        ...column,
+        columnType,
+        numeric,
+      };
+    });
+    if (!changed) return null;
+
+    columns = nextColumns;
+    cache.clear();
+    tableData = {
+      ...tableData,
+      columns,
+      columnSummaries: columns.map(() => null),
+      dispose: acquireDispose(),
+    };
+    return tableData;
+  }
+
+  return { handle, tableData, columns, prefetchViewport, refreshColumnTypes };
 }


### PR DESCRIPTION
Follow-up to #4103 from the lifecycle review around #4106.

## Problem

Value-based image detection was guarded by a one-way `image_columns_refined` latch. The first Arrow batch set that latch even when every candidate value was null. Later batches containing base64 image data URIs therefore stayed `categorical`.

There was a second lifecycle seam behind the same symptom: a mounted Sift table read its WASM column types only from the first chunk. Even if the Rust store refined a type later, the existing table kept rendering the original categorical column.

## Fix

- Model image sniffing as pending, image, or not-image.
- Keep sampling leading non-null values across chunks until the 32-value bound is reached, a non-image value resolves the column, or the stream completes.
- Retry pending refinement when the store is finished, including static IPC/Parquet stores.
- Re-read resolved WASM column types after chunk appends and completion.
- Replace the mounted table when a type changes while keeping the shared WASM store alive through a small reference-counted lease.
- Preserve explicit column type and numeric overrides during refresh.

The sample remains bounded and unanimous: any sampled non-image value keeps the column on the text path.

## Regression evidence

Before the fix:

- The Rust stream regression failed after the null-only chunk with `(true, "categorical")` instead of `(false, "categorical")`.
- The React regression finished the stream but found zero image type icons instead of one.

Both now pass and exercise the complete null-only chunk → image chunk → stream completion flow.

## Verification

- `cargo test -p sift-wasm` — 39 unit tests and 2 IPC integration tests pass.
- `pnpm --dir packages/sift test` — 193/193 tests pass.
- `cargo xtask wasm sift`
- `pnpm --dir packages/sift build:lib`
- `cargo xtask lint --fix`
