### PR TITLE
chore: stop Claude Code stamping session links on commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "enabledPlugins": {
     "async-rust-lsp@nteract-plugins": true
   },


### PR DESCRIPTION
Cloud and Remote Control Claude Code sessions append a `Claude-Session:` trailer pointing at claude.ai to every commit and PR body they create. 64 commits and 79 PRs on `main` already carry one, spanning 2026-06-21 through 2026-07-09 and exposing three session ids. This turns it off.

## Design decision

The obvious knob, `includeCoAuthoredBy`, does not cover this. It is deprecated, and it only ever gated the `Co-Authored-By` line and the "Generated with Claude Code" footer. The session link is a separate flag:

> `attribution.sessionUrl` - Whether to append the claude.ai session link to commits and PRs created from web or Remote Control sessions (default: true). Set to false to omit the Claude-Session trailer and PR-body link.

So the full `attribution` block goes in, covering all three surfaces at once.

| Field | Value | Suppresses |
| --- | --- | --- |
| `commit` | `""` | `Co-Authored-By` trailer on commits |
| `pr` | `""` | attribution footer in PR bodies |
| `sessionUrl` | `false` | `Claude-Session:` trailer and PR-body link |

This lands in the repo's tracked settings rather than user-level settings because cloud sessions check out fresh and read what is committed. A user-level setting on one laptop does not reach them.

## Cleanup

The 79 existing PR descriptions are being stripped separately via `gh`. The 64 commit trailers already on `main` stay put. Rewriting them means a force-push that breaks every clone, fork, and SHA reference in the repo, which is not worth it for a trailer.
