### PR TITLE
fix(sync): name the daemon command in connect errors, and make the runtimed-node lead runnable

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "enabledPlugins": {
     "async-rust-lsp@nteract-plugins": true
   },

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -26,6 +26,8 @@ hex = { workspace = true }
 uuid = { workspace = true }
 log = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
+# Connect errors name the command that starts a daemon, and which command that
+# is depends on dev-mode vs an installed build. This crate owns that answer.
+runt-workspace = { path = "../runt-workspace" }
 
 [dev-dependencies]
-runt-workspace = { path = "../runt-workspace" }

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -198,17 +198,22 @@ macro_rules! connect_stream {
             Ok(stream) => stream,
             Err(e) => {
                 let path_display = path.display();
+                // Every consumer that is not the desktop app reaches this arm
+                // with no idea what to run next, and the answer differs between
+                // a source checkout and an installed build. `runt-workspace`
+                // already knows which, so carry its guidance into the message.
+                let guidance = runt_workspace::daemon_unavailable_guidance();
                 return Err(match e.kind() {
                     std::io::ErrorKind::NotFound => SyncError::DaemonUnavailable {
                         message: format!(
-                            "Daemon is not running. Endpoint not found at {path_display}."
+                            "Daemon is not running. Endpoint not found at {path_display}. {guidance}"
                         ),
                         source: e,
                     },
                     std::io::ErrorKind::ConnectionRefused => SyncError::DaemonUnavailable {
                         message: format!(
                             "Daemon connection refused at {path_display}. \
-                             The daemon may have crashed or is restarting."
+                             The daemon may have crashed or is restarting. {guidance}"
                         ),
                         source: e,
                     },
@@ -1078,6 +1083,36 @@ mod bootstrap_tests {
         assert_eq!(
             actual.capabilities.actor_label.as_deref(),
             Some("local:kyle/desktop:typed")
+        );
+    }
+    /// A caller that is not the desktop app hits this path with no idea what to
+    /// run next, so the message has to name the command itself.
+    #[tokio::test]
+    async fn missing_daemon_error_names_the_command_that_starts_one() {
+        let missing = std::path::PathBuf::from("/tmp/nteract-does-not-exist/runtimed.sock");
+        let result = connect_open(
+            missing.clone(),
+            std::path::PathBuf::from("/tmp/nteract-does-not-exist/notebook.ipynb"),
+            "test",
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("connecting to a nonexistent socket must fail");
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("Daemon is not running"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains(&missing.display().to_string()),
+            "error should name the endpoint it tried: {message}"
+        );
+        let guidance = runt_workspace::daemon_unavailable_guidance();
+        assert!(
+            message.contains(&guidance),
+            "error should carry the daemon guidance ({guidance}): {message}"
         );
     }
 }

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -1,31 +1,49 @@
 # `@runtimed/node`
 
 Run Python from Node in a kernel that stays alive between calls. Variables and
-imports persist, dependencies install mid-session via uv, plots come back
-inline.
+imports persist, dependencies install mid-session via uv, and plots come back
+as image data in the cell result.
 
 **Before** — new process every call, no memory:
 
-```ts
-execSync('python -c "import pandas as pd; df = pd.read_csv(\'data.csv\'); print(df.shape)"')
-// next call: pandas re-imported, df gone, ~2s cold start
+```js
+execSync('python -c "import pandas as pd; df = pd.read_csv(\'data.csv\'); print(df.shape)"');
+// next call: pandas re-imported, df gone, startup cost paid again
 ```
 
 **After** — one session, state sticks:
 
-```ts
+```js
 const { createNotebook } = require("@runtimed/node");
 
-const session = await createNotebook({ workingDir: "./project" });
-await session.runCell('import pandas as pd; df = pd.read_csv("data.csv")');
-await session.runCell('df.groupby("region").sum()'); // df still there
-await session.addDependencies(["seaborn"]); // no restart
-await session.syncEnvironment();
-await session.runCell("sns.heatmap(df.corr())"); // returns the image
+async function main() {
+  const session = await createNotebook({ workingDir: "./project" });
+
+  await session.runCell('import pandas as pd; df = pd.read_csv("data.csv")');
+  await session.runCell('df.groupby("region").sum()'); // df still there
+
+  await session.addDependencies(["seaborn"]); // no restart
+  await session.syncEnvironment(); // df survives this
+
+  const result = await session.runCell(
+    "import seaborn as sns; sns.heatmap(df.corr(numeric_only=True))",
+  );
+
+  // Plot arrives as a display_data output. `dataJson` carries base64 PNG under
+  // "image/png"; `blobUrlsJson` carries a daemon URL for the same bytes.
+  const plot = result.outputs.find((output) => output.outputType === "display_data");
+  console.log(Object.keys(JSON.parse(plot.dataJson))); // ["image/png", "text/plain", ...]
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 ```
 
-Built for agent loops where one session spans many turns. Running a script
-once? Use a subprocess.
+Built for agent loops where one session spans many turns. Session startup costs
+a couple of seconds and then every later call is cheap, so the win grows with
+the number of turns. Running a script once? Use a subprocess.
 
 Node.js bindings for the nteract `runtimed` daemon. This package lets Node,
 Bun, and other CommonJS-compatible runtimes create notebooks, run Python cells,


### PR DESCRIPTION
Two fixes from trying to verify the `@runtimed/node` README against a live session and failing three times before understanding why.

## Connect errors named the endpoint but not the remedy

A failed daemon connection said this and stopped:

```
Daemon is not running. Endpoint not found at
/Users/me/Library/Caches/runt-nightly/worktrees/4caa3d6153d6/runtimed.sock.
```

The remedy differs by context. A source checkout wants `cargo xtask dev-daemon`; an installed build wants `runt daemon status`. `runt_workspace::daemon_unavailable_guidance()` already decides which, and until now only the desktop app asked it. Every other caller reached that arm blind.

It matters most for `@runtimed/node`, which is pitched at agent loops. An agent author is precisely the caller with no daemon already running. It also catches anyone working in this repo, since `.envrc` exports `RUNTIMED_DEV=1` and points them at a per-worktree socket that nothing starts.

The guidance now rides on the not-found and connection-refused messages:

```
Daemon is not running. Endpoint not found at <path>. Start the dev daemon with: cargo xtask dev-daemon
```

`runt-workspace` moves from a dev-dependency to a real one. It is a paths-and-naming crate over `dirs`, `hex`, `serde`, `serde_json`, and `sha2`.

## The README lead could not run

Verified against a live session. Three defects:

**It raised before reaching the daemon.** `require()` plus top-level await gives `ERR_AMBIGUOUS_MODULE_SYNTAX`. Wrapped in `main()` now, matching the Basic Usage section directly below it.

**Two runtime errors after that.** `sns.heatmap(...)` was called without importing seaborn, and `df.corr()` raises `could not convert string to float: 'west'` on the demonstrated frame under pandas 2.x. Seaborn is imported and `corr` takes `numeric_only=True`.

**"Plots come back inline" left the reader nothing to act on.** A plot is a `display_data` output whose `dataJson` carries base64 PNG under `image/png`, alongside `blobUrlsJson` pointing at the same bytes on the daemon. The snippet now reaches the output and names both routes.

**"~2s cold start" blamed the wrong side.** A subprocess importing pandas takes 0.23s here. Session startup through the first cell takes 2.29s. The session is the slower start; it wins by amortizing across turns, which is what the copy says now.

## Measured

Against a live dev daemon:

| Claim | Result |
| --- | --- |
| State persists across calls | `df.shape` is `(4, 3)` in a later call |
| Deps install mid-session, no restart | seaborn `0.13.2` importable, `df` still `(4, 3)` |
| Plot returns image data | `image/png` at 16.8 KB base64, plus a blob URL |
| Subprocess cold start | 0.23s, not ~2s |
| Session startup + first cell | 2.29s |

The corrected snippet was extracted from the README and run verbatim. The only substitutions were the require path and the working directory.

## Verification

`notebook-sync` is 92 tests green, with a regression test asserting the message carries the endpoint and the guidance. `cargo xtask lint --fix` and `vp check` both clean.

The guidance was confirmed by following it: the message said `cargo xtask dev-daemon`, that started a daemon, and the verification above then ran. Every measurement here exists because of the first fix.

## Not included

Starting a daemon automatically when a binary is on disk is the other half of making this package usable cold. It raises process-ownership questions worth deciding on their own, since `ensure_daemon_via_sidecar` assumes an app that owns the daemon's lifetime and a Node script does not obviously own anything.

## Correction

An earlier revision of this description claimed a version check would have turned a 122-second hang against a stale daemon into an immediate answer. That was wrong and is retracted.

`PROTOCOL_VERSION` is `4` on main and the stable 2.6.2 daemon reports `4`, so the two matched and no mismatch occurred. The cause of that hang is unrelated and still being tracked down.

Version handling also already exists and is more considered than that line implied. `notebook-wire/AGENTS.md` documents the policy: the preamble hard-rejects incompatible versions at connect, `Pool` stays version-tolerant so older stable apps can probe during an upgrade, and other channels require `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`. `check_daemon_protocol_version` then warns rather than errors on a capabilities difference, with a comment explaining that the preamble already did the hard rejection.

The real gap there is narrower: that warning is a `log::warn!`, so a Node consumer never sees it. Surfacing it through the returned error or session metadata is worth doing, and is not what this PR did.

None of this affects the change that landed. The guidance fix and the README correction stand on their own.

