### PR TITLE
feat(runt): warn at workstation startup when ipykernel is missing

### DIFF
--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -68,6 +68,46 @@ pub fn strip_base(installed: &[String], base: &[&str]) -> Vec<String> {
         .collect()
 }
 
+/// Resolve the default Python interpreter: first `python3`, then `python`,
+/// searched across `path_var` (the `PATH` environment value).
+///
+/// Shared so the workstation CLI can probe the same interpreter the
+/// `workstation-agent` will pick when `--python-path` is omitted.
+pub fn resolve_python_on_path(path_var: Option<&str>) -> Option<std::path::PathBuf> {
+    let path_var = path_var?;
+    let names: &[&str] = if cfg!(windows) {
+        &["python3.exe", "python.exe", "python3", "python"]
+    } else {
+        &["python3", "python"]
+    };
+    for name in names {
+        for dir in std::env::split_paths(path_var) {
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+            let candidate = dir.join(name);
+            if is_executable_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
 /// Diagnostic result for checking whether a prepared Python environment can
 /// import `ipykernel`.
 #[cfg(feature = "runtime")]
@@ -427,5 +467,32 @@ mod site_packages_has_ipykernel_tests {
         std::fs::create_dir_all(purelib.join("ipykernel")).unwrap();
 
         assert!(sibling_site_packages_with_ipykernel(&purelib).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod resolve_python_on_path_tests {
+    use super::*;
+
+    #[test]
+    fn prefers_python3_over_python() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path();
+        for name in ["python", "python3"] {
+            let path = bin.join(name);
+            std::fs::write(&path, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+        let path_var = bin.to_string_lossy().into_owned();
+        let resolved = resolve_python_on_path(Some(&path_var)).unwrap();
+        assert!(resolved
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("python3")));
+        assert!(resolve_python_on_path(None).is_none());
     }
 }

--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -357,11 +357,33 @@ async fn run(python_path: Option<PathBuf>, working_directory: Option<PathBuf>) -
         resolved.display_name,
         runtimed_bin.display()
     );
-    if let Some(path) = &python_path {
-        println!("Python interpreter: {}", path.display());
+    // Resolve the interpreter the agent will use so the preflight below probes
+    // the same one: `workstation_agent_args` omits `--python-path` when it
+    // wasn't passed, and the daemon then falls back to `resolve_python_on_path`.
+    let effective_python = python_path
+        .clone()
+        .or_else(|| kernel_env::resolve_python_on_path(std::env::var("PATH").ok().as_deref()));
+    match &effective_python {
+        Some(path) => println!("Python interpreter: {}", path.display()),
+        None => eprintln!(
+            "Warning: no python3 or python found on PATH; kernels cannot launch. \
+             Pass --python-path."
+        ),
     }
     if let Some(path) = &working_directory {
         println!("Working directory: {}", path.display());
+    }
+
+    // The `current_python` workstation policy launches kernels against this
+    // interpreter as-is and never installs packages, so a missing `ipykernel`
+    // becomes a raw `runpy.py` traceback in the browser. Warn here — where an
+    // operator is at a terminal — but keep serving: refusing to start would
+    // hide the workstation from the panel entirely, which reads as a mystery
+    // absence rather than a fixable error.
+    if let Some(path) = &effective_python {
+        if let Some(warning) = ipykernel_preflight_warning(&kernel_env::diagnose_ipykernel(path)) {
+            eprintln!("{warning}");
+        }
     }
 
     let mut command = std::process::Command::new(&runtimed_bin);
@@ -382,6 +404,56 @@ async fn run(python_path: Option<PathBuf>, working_directory: Option<PathBuf>) -
         .with_context(|| format!("failed to launch {}", runtimed_bin.display()))?;
 
     std::process::exit(status.code().unwrap_or(1));
+}
+
+/// A probe failure carries the interpreter's raw stderr, which for a non-Python
+/// executable echoes the whole probe script back. Keep the warning to one line.
+fn first_line_truncated(message: &str, max_chars: usize) -> String {
+    let line = message.lines().next().unwrap_or("").trim();
+    if line.chars().count() <= max_chars {
+        return line.to_string();
+    }
+    let head: String = line.chars().take(max_chars).collect();
+    format!("{head}…")
+}
+
+/// Render an operator-facing warning for a non-`Present` ipykernel diagnostic,
+/// or `None` when the interpreter can import it.
+fn ipykernel_preflight_warning(diagnostic: &kernel_env::IpykernelDiagnostic) -> Option<String> {
+    use kernel_env::IpykernelDiagnostic as D;
+    match diagnostic {
+        D::Present { .. } => None,
+        D::Missing { python_path, .. } => {
+            let python = python_path.display();
+            Some(format!(
+                "Warning: ipykernel is not installed in {python}; kernels cannot launch.\n         Install it with: {python} -m pip install ipykernel"
+            ))
+        }
+        D::SitePackagesMismatch {
+            python_path,
+            purelib,
+            candidates,
+            ..
+        } => {
+            let python = python_path.display();
+            let found = candidates
+                .iter()
+                .map(|path| format!("\n           - {}", path.display()))
+                .collect::<String>();
+            Some(format!(
+                "Warning: {python} cannot import ipykernel; kernels cannot launch.\n         Its site-packages is {purelib}, but ipykernel is installed under:{found}\n         Install it for this interpreter with: {python} -m pip install ipykernel",
+                purelib = purelib.display()
+            ))
+        }
+        D::InterpreterProbeFailed {
+            python_path,
+            message,
+        } => Some(format!(
+            "Warning: could not probe {python} for ipykernel: {message}\n         Kernels may fail to launch.",
+            python = python_path.display(),
+            message = first_line_truncated(message, 200)
+        )),
+    }
 }
 
 fn workstation_agent_args(
@@ -1164,6 +1236,62 @@ pub(crate) fn read_credential_file(path: &Path) -> Result<Option<WorkstationCred
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ipykernel_preflight_warning_names_interpreter_and_pip_command() {
+        assert_eq!(
+            ipykernel_preflight_warning(&kernel_env::IpykernelDiagnostic::Present {
+                python_path: PathBuf::from("/usr/bin/python3"),
+                purelib: PathBuf::from("/usr/lib/python3/dist-packages"),
+            }),
+            None
+        );
+
+        let missing = ipykernel_preflight_warning(&kernel_env::IpykernelDiagnostic::Missing {
+            python_path: PathBuf::from("/usr/bin/python3"),
+            purelib: PathBuf::from("/usr/lib/python3/dist-packages"),
+            import_error: Some("ModuleNotFoundError: No module named 'ipykernel'".to_string()),
+        })
+        .expect("missing ipykernel must warn");
+        assert!(missing.contains("/usr/bin/python3 -m pip install ipykernel"));
+
+        let mismatch =
+            ipykernel_preflight_warning(&kernel_env::IpykernelDiagnostic::SitePackagesMismatch {
+                python_path: PathBuf::from("/usr/bin/python3"),
+                purelib: PathBuf::from("/usr/lib/python3.10/site-packages"),
+                import_error: None,
+                candidates: vec![PathBuf::from("/usr/lib/python3.11/site-packages")],
+            })
+            .expect("site-packages mismatch must warn");
+        assert!(mismatch.contains("/usr/lib/python3.11/site-packages"));
+
+        let probe_failed =
+            ipykernel_preflight_warning(&kernel_env::IpykernelDiagnostic::InterpreterProbeFailed {
+                python_path: PathBuf::from("/usr/bin/python3"),
+                message: "exited with status 127".to_string(),
+            })
+            .expect("probe failure must warn");
+        assert!(probe_failed.contains("exited with status 127"));
+    }
+
+    #[test]
+    fn probe_failure_warning_stays_on_one_line() {
+        // A non-Python executable echoes the whole probe script to stderr.
+        let warning =
+            ipykernel_preflight_warning(&kernel_env::IpykernelDiagnostic::InterpreterProbeFailed {
+                python_path: PathBuf::from("/bin/ls"),
+                message: format!("ls: import json, sysconfig\n{}\nmore", "x".repeat(400)),
+            })
+            .expect("probe failure must warn");
+
+        assert_eq!(
+            warning.lines().count(),
+            2,
+            "warning + remediation line only"
+        );
+        assert!(warning.contains("ls: import json, sysconfig"));
+        assert!(!warning.contains("xxxx"));
+    }
 
     fn sample_credentials() -> WorkstationCredentialFile {
         WorkstationCredentialFile {

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -214,43 +214,6 @@ fn parse_meminfo_total_bytes(meminfo: &str) -> Option<u64> {
     Some(kb * 1024)
 }
 
-/// Resolve the default Python interpreter: first `python3`, then `python`,
-/// searched across `path_var` (the `PATH` environment value).
-pub fn resolve_python_on_path(path_var: Option<&str>) -> Option<PathBuf> {
-    let path_var = path_var?;
-    let names: &[&str] = if cfg!(windows) {
-        &["python3.exe", "python.exe", "python3", "python"]
-    } else {
-        &["python3", "python"]
-    };
-    for name in names {
-        for dir in std::env::split_paths(path_var) {
-            if dir.as_os_str().is_empty() {
-                continue;
-            }
-            let candidate = dir.join(name);
-            if is_executable_file(&candidate) {
-                return Some(candidate);
-            }
-        }
-    }
-    None
-}
-
-#[cfg(unix)]
-fn is_executable_file(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    match std::fs::metadata(path) {
-        Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
-        Err(_) => false,
-    }
-}
-
-#[cfg(not(unix))]
-fn is_executable_file(path: &Path) -> bool {
-    path.is_file()
-}
-
 /// Build the spawn plan for one attach job. Mirrors `buildAttachJobSpawnPlan`
 /// in `hosted-workstation-agent-core.mjs`, with `--auth-kind workstation`
 /// because the agent holds a pairing-flow workstation credential.
@@ -2371,27 +2334,5 @@ mod tests {
     fn path_segment_encoding() {
         assert_eq!(encode_path_segment("ws-lab2"), "ws-lab2");
         assert_eq!(encode_path_segment("a b/c"), "a%20b%2Fc");
-    }
-
-    #[test]
-    fn resolve_python_prefers_python3() {
-        let dir = tempfile::tempdir().unwrap();
-        let bin = dir.path();
-        for name in ["python", "python3"] {
-            let path = bin.join(name);
-            std::fs::write(&path, "#!/bin/sh\n").unwrap();
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
-            }
-        }
-        let path_var = bin.to_string_lossy().into_owned();
-        let resolved = resolve_python_on_path(Some(&path_var)).unwrap();
-        assert!(resolved
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.starts_with("python3")));
-        assert!(resolve_python_on_path(None).is_none());
     }
 }

--- a/crates/runtimed/src/workstation/mod.rs
+++ b/crates/runtimed/src/workstation/mod.rs
@@ -25,8 +25,7 @@ pub mod environments;
 pub mod launch_on_attach;
 
 pub use agent_loop::{
-    resolve_python_on_path, run_workstation_agent, WorkstationAgentOptions, DEFAULT_HEARTBEAT_MS,
-    DEFAULT_POLL_MS,
+    run_workstation_agent, WorkstationAgentOptions, DEFAULT_HEARTBEAT_MS, DEFAULT_POLL_MS,
 };
 pub use allocate::{
     allocate_current_python_runtime, current_python_launch_working_dir,
@@ -38,6 +37,7 @@ pub use environments::{
     environments_from_pool_state, list_environments, EnvKind, EnvironmentPolicy,
     WorkstationEnvironment,
 };
+pub use kernel_env::resolve_python_on_path;
 pub use launch_on_attach::{
     build_current_python_launch, CurrentPythonLaunch, CURRENT_PYTHON_ENV_SOURCE,
 };

--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -95,6 +95,15 @@ runt workstation service install --start
 runt workstation run
 ```
 
+   The workstation's `current_python` policy launches kernels against that
+   interpreter as-is and never installs packages into it, so the interpreter
+   must already have `ipykernel`. Startup probes it and warns without refusing
+   to serve; install it on the workstation and restart the agent:
+
+```bash
+/usr/bin/python3 -m pip install ipykernel
+```
+
 4. Check what the credential sees:
 
 ```bash


### PR DESCRIPTION
## The problem

<img width="809" height="327" alt="Screenshot 2026-07-31 at 7 29 19 AM" src="https://github.com/user-attachments/assets/fcfc494f-45a1-4b73-9dba-cd88d2bee309" />

Started from this screenshot. End of desc explains more about why it doesn't fix the banner (would be a bigger change), but does help.

---

The workstation `current_python` policy (`crates/runtimed/src/workstation/launch_on_attach.rs`) launches kernels against the machine's interpreter **as-is**, with package management disabled. There is no env-prepare step that could add `ipykernel`.

So if that interpreter lacks `ipykernel`, every launch dies with a raw `runpy.py` / `ModuleNotFoundError` traceback — and it surfaces in a **browser**, potentially on another continent from the operator who could fix it with one `pip install`. Worse, it is not classified as a typed `missing_ipykernel` reason: `kernel_env::diagnose_ipykernel` only runs for the `uv:inline` / `conda:inline` / `uv:pep723` arms, not `uv:current_python`.

Before this change `runt workstation run` printed the interpreter path only when you passed `--python-path`, and never checked anything.

## The change

Probe at `runt workstation run` startup — the one moment an operator is sitting at a terminal — and print the interpreter plus the exact remediation:

```
Python interpreter: /usr/bin/python3
Warning: ipykernel is not installed in /usr/bin/python3; kernels cannot launch.
         Install it with: /usr/bin/python3 -m pip install ipykernel
```

**It warns; it does not refuse.** Exiting non-zero would keep the workstation from ever appearing in the panel, trading a fixable error message for a mystery absence.

### The one structural change, and why it was forced

The preflight must probe the interpreter the daemon will *actually* use, or it is worse than nothing — a check that reports "fine" while kernels keep failing.

`workstation_agent_args` omits `--python-path` when the operator didn't pass one, and the daemon then falls back to `resolve_python_on_path` (`crates/runtimed/src/main.rs`). That function lived inside the `runtimed` crate, and `runt` does not depend on `runtimed` (only `runtimed-client` / `runtimed-service`), so the CLI could not call it.

Both crates already depend on `kernel-env`, so the resolver moved there:

```mermaid
flowchart LR
  subgraph runtcrate[crate runt - CLI binary]
    RUN[workstation_cli.rs<br/>NEW preflight]
  end
  subgraph runtimedcrate[crate runtimed - daemon binary]
    MAIN[main.rs<br/>workstation-agent]
    MOD[workstation/mod.rs<br/>re-export retargeted]
  end
  subgraph shared[crate kernel-env - shared lib]
    RESOLVE[resolve_python_on_path<br/>MOVED here]
    DIAG[diagnose_ipykernel<br/>already existed]
  end
  RUN -->|spawns as subprocess| MAIN
  MAIN --> MOD
  MOD --> RESOLVE
  RUN -->|same resolver| RESOLVE
  RUN -->|same probe| DIAG
  MAIN --> DIAG
```

That makes "CLI and daemon pick the same Python" true by construction rather than by coincidence. The alternative — duplicating the ~25-line PATH search in `runt` — gets a one-file diff at the cost of two copies that drift into exactly the silent failure above.

## Reading the diff

| File | Δ | Role |
|---|---|---|
| `crates/runt/src/workstation_cli.rs` | +130/−2 | All new logic. ~60 lines of that is two tests. |
| `crates/kernel-env/src/lib.rs` | +67 | Destination of the move (function + `is_executable_file` + its test). |
| `crates/runtimed/src/workstation/agent_loop.rs` | −59 | Source of the move. Deletion only. |
| `crates/runtimed/src/workstation/mod.rs` | +2/−2 | `pub use` retargeted at `kernel_env`. |
| `docs/runbooks/remote-workstation.md` | +9 | The runbook never stated the `ipykernel` requirement. |

Net new code across the three refactor files is **+7 lines** (a doc comment and `std::path::` qualifiers); the function bodies diff clean.

`mod.rs` is the only file with blast radius, and it is a 4-line diff: retargeting the re-export is why `crates/runtimed/src/main.rs` still says `runtimed::workstation::resolve_python_on_path(...)` and compiles untouched.

`ipykernel_preflight_warning` is a pure function from diagnostic to `Option<String>` — no I/O, so all four arms are unit-testable: present, missing, site-packages mismatch (ABI-mismatched sibling), and probe failure. `first_line_truncated` exists because pointing `--python-path` at a non-Python executable makes it echo the entire probe script to stderr.

## Test plan

- [x] `cargo test -p kernel-env --lib` — 95 pass, including the relocated resolver test
- [x] `cargo test -p runt --bins` — 30 pass, including the two new preflight tests
- [x] `cargo check -p runtimed` — proves every existing caller still resolves through the re-export
- [x] `cargo xtask lint --fix` clean
- [x] Real binary driven through each path: venv without `ipykernel` → warns and continues; after `pip install ipykernel` → silent (no false positive); no `--python-path` → resolves and reports the PATH interpreter; `--python-path /bin/ls` → one-line probe-failure warning; empty `PATH` → no-interpreter warning

## Known limits

This narrows the window; it does not close it. The probe runs **once at startup**, so a later `pip uninstall`, a rebuilt venv, or a system update changing which `python3` wins on `PATH` all leave the agent running past a check that is no longer true. And the runbook's recommended happy path (`workstation service install --start`) sends this warning to the systemd journal, where nobody looks.

The complete fix is a daemon-side check in the `uv:current_python` launch arm emitting a typed reason the browser can render with remediation. That is deliberately **not** in this PR — it is a separate, larger change to the launch path. The screenshot that started this investigation would still look the same after this change; only the operator's terminal improves.

Co-Authored-By: Claude <noreply@anthropic.com>