### PR TITLE
fix(cloud): reset copy-link state on share popover close

### DIFF
--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -332,8 +332,15 @@ export function CloudSharingControls({
     }
   };
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setCopyState("idle");
+    }
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button variant="ghost" size="sm" className="gap-1.5" title="Share notebook">
           <Share2 className="size-3.5" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- Stacked on #4122. `CloudSharingControls` kept `copyState` in React state but never reset it on popover close, so reopening the Share popover showed a stale "Copied link"/"Copy failed" label from the previous session.
- Added an `onOpenChange` handler that resets `copyState` to `"idle"` whenever the popover closes.

## Test plan
- [x] Verified locally via Playwright against the notebook-cloud dev server (rebuilt with #4122's reworked sharing panel): clicked Copy link (label became "Copied link" / "Link copied."), closed the popover, reopened it, and confirmed it now reads "Copy link" with no stale message.

![Share popover after reopen](https://anaconda.com/api/projects/cc5a1842-3bf9-46f9-a8f0-1eae36f85ad4/files/2026-08-03T18-35-50_copy-state-after-reopen.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)