### PR TITLE
fix(markdown): render safe HTML images

### DIFF
--- a/apps/notebook/e2e/fixtures/markdown-parity.ts
+++ b/apps/notebook/e2e/fixtures/markdown-parity.ts
@@ -21,6 +21,8 @@ export const MARKDOWN_CELL_PARITY_SOURCE = [
   "",
   '<button id="markdown-parity-raw-html">raw html becomes text</button>',
   "",
+  '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="HTML image" width="24px">',
+  "",
   "```python",
   "print('highlighted code block')",
   "```",

--- a/apps/notebook/e2e/markdown-parity.spec.ts
+++ b/apps/notebook/e2e/markdown-parity.spec.ts
@@ -46,11 +46,14 @@ test.describe("markdown parity", () => {
     await expect(taskCheckboxes.nth(0)).toBeChecked();
     await expect(taskCheckboxes.nth(1)).not.toBeChecked();
 
-    // The parity contract is safety and fast host rendering: raw HTML from
-    // markdown must not become live DOM in the parent notebook surface. Simple
-    // inline wrappers may contribute escaped text, but never elements or attrs.
+    // The parity contract is safety and fast host rendering: arbitrary raw HTML
+    // must not become live DOM in the parent notebook surface. Approved image
+    // metadata is projected through the same safe path as Markdown images.
     await expect(markdownCell.locator("#markdown-parity-raw-html")).toHaveCount(0);
     await expect(renderedMarkdown.getByText("raw html becomes text")).toBeVisible();
+    const htmlImage = renderedMarkdown.getByRole("img", { name: "HTML image" });
+    await expect(htmlImage).toBeVisible();
+    await expect(htmlImage).toHaveCSS("width", "24px");
 
     await expect(renderedMarkdown.locator("pre")).toContainText("highlighted code block");
 

--- a/crates/nteract-markdown-engine/src/render_json.rs
+++ b/crates/nteract-markdown-engine/src/render_json.rs
@@ -102,8 +102,10 @@ fn collect_block(
         item_ordered: None,
         item_path: Vec::new(),
         image_alt: None,
+        image_height: None,
         image_src: None,
         image_title: None,
+        image_width: None,
         link_href: None,
         link_title: None,
         position_index,
@@ -141,7 +143,11 @@ fn collect_block(
         }
         NodeKind::Html => {
             let raw = block.fallback.copy_text.as_str();
-            if let Some(fragment) = safe_inline_html(raw) {
+            if let Some(image) = safe_html_image(raw) {
+                kind = "paragraph";
+                element = "p";
+                add_html_image_run(&mut context, block.span.start, block.span.end, image);
+            } else if let Some(fragment) = safe_inline_html(raw) {
                 kind = "paragraph";
                 element = "p";
                 let run = context.add_run(
@@ -416,7 +422,9 @@ fn collect_inline(
         NodeKind::InlineMath => collect_delimited_inline(source, context, node, "math-source"),
         NodeKind::Html => {
             let raw = node.fallback.copy_text.as_str();
-            if let Some(fragment) = safe_inline_html(raw) {
+            if let Some(image) = safe_html_image(raw) {
+                add_html_image_run(context, node.span.start, node.span.end, image);
+            } else if let Some(fragment) = safe_inline_html(raw) {
                 let run = context.add_run(
                     node.span.start + fragment.open_len,
                     node.span.start + fragment.close_start,
@@ -704,8 +712,10 @@ impl PositionIndex {
 struct RunContext<'a> {
     block_id: String,
     image_alt: Option<String>,
+    image_height: Option<String>,
     image_src: Option<String>,
     image_title: Option<String>,
+    image_width: Option<String>,
     inline_index: usize,
     item_checked: Option<bool>,
     item_depth: Option<usize>,
@@ -785,8 +795,10 @@ impl RunContext<'_> {
             island_inline,
             island_tag,
             image_alt: self.image_alt.clone(),
+            image_height: self.image_height.clone(),
             image_src: self.image_src.clone(),
             image_title: self.image_title.clone(),
+            image_width: self.image_width.clone(),
             inline_id,
             item_checked: self.item_checked,
             item_depth: self.item_depth,
@@ -840,8 +852,10 @@ struct JsonRun {
     island_inline: bool,
     island_tag: Option<String>,
     image_alt: Option<String>,
+    image_height: Option<String>,
     image_src: Option<String>,
     image_title: Option<String>,
+    image_width: Option<String>,
     inline_id: String,
     item_checked: Option<bool>,
     item_depth: Option<usize>,
@@ -875,8 +889,16 @@ impl JsonRun {
             push_json_key_string(output, "imageAlt", alt);
             output.push(',');
         }
+        if let Some(height) = &self.image_height {
+            push_json_key_string(output, "imageHeight", height);
+            output.push(',');
+        }
         if let Some(title) = &self.image_title {
             push_json_key_string(output, "imageTitle", title);
+            output.push(',');
+        }
+        if let Some(width) = &self.image_width {
+            push_json_key_string(output, "imageWidth", width);
             output.push(',');
         }
         push_json_key_string(output, "inlineId", &self.inline_id);
@@ -1160,6 +1182,165 @@ struct SafeInlineHtml<'a> {
     open_len: usize,
     close_start: usize,
     text: &'a str,
+}
+
+struct SafeHtmlImage {
+    alt: Option<String>,
+    height: Option<String>,
+    src: String,
+    title: Option<String>,
+    width: Option<String>,
+}
+
+fn add_html_image_run(
+    context: &mut RunContext<'_>,
+    source_start: usize,
+    source_end: usize,
+    image: SafeHtmlImage,
+) {
+    let previous_alt = context.image_alt.take();
+    let previous_height = context.image_height.take();
+    let previous_src = context.image_src.take();
+    let previous_title = context.image_title.take();
+    let previous_width = context.image_width.take();
+
+    context.image_alt = image.alt;
+    context.image_height = image.height;
+    context.image_src = Some(image.src);
+    context.image_title = image.title;
+    context.image_width = image.width;
+
+    let run = context.add_run(
+        source_start,
+        source_end,
+        context.image_alt.clone().unwrap_or_default(),
+        "image",
+        None,
+    );
+    context.syntax_spans.push(JsonSyntaxSpan::new(
+        context.position_index,
+        source_start,
+        source_end,
+        Some(run.inline_id.clone()),
+        run.rendered_text_utf16[1],
+        "nearest-visible",
+    ));
+
+    context.image_alt = previous_alt;
+    context.image_height = previous_height;
+    context.image_src = previous_src;
+    context.image_title = previous_title;
+    context.image_width = previous_width;
+}
+
+fn safe_html_image(raw: &str) -> Option<SafeHtmlImage> {
+    let raw = raw.trim();
+    let inner = raw.strip_prefix('<')?.strip_suffix('>')?.trim();
+    let inner = inner.strip_suffix('/').unwrap_or(inner).trim_end();
+    let tag_end = inner
+        .find(|character: char| character.is_ascii_whitespace())
+        .unwrap_or(inner.len());
+    if !inner[..tag_end].eq_ignore_ascii_case("img") {
+        return None;
+    }
+
+    let mut alt = None;
+    let mut height = None;
+    let mut src = None;
+    let mut title = None;
+    let mut width = None;
+    let attributes = inner[tag_end..].as_bytes();
+    let mut cursor = 0;
+
+    while cursor < attributes.len() {
+        while attributes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if cursor >= attributes.len() {
+            break;
+        }
+
+        let name_start = cursor;
+        while attributes
+            .get(cursor)
+            .is_some_and(|byte| !byte.is_ascii_whitespace() && *byte != b'=' && *byte != b'/')
+        {
+            cursor += 1;
+        }
+        if cursor == name_start {
+            return None;
+        }
+        let name = std::str::from_utf8(&attributes[name_start..cursor])
+            .ok()?
+            .to_ascii_lowercase();
+
+        while attributes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if attributes.get(cursor) != Some(&b'=') {
+            continue;
+        }
+        cursor += 1;
+        while attributes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+
+        let value = match attributes.get(cursor).copied() {
+            Some(quote @ (b'\'' | b'"')) => {
+                cursor += 1;
+                let value_start = cursor;
+                while attributes.get(cursor).is_some_and(|byte| *byte != quote) {
+                    cursor += 1;
+                }
+                if attributes.get(cursor) != Some(&quote) {
+                    return None;
+                }
+                let value = std::str::from_utf8(&attributes[value_start..cursor]).ok()?;
+                cursor += 1;
+                value
+            }
+            Some(_) => {
+                let value_start = cursor;
+                while attributes
+                    .get(cursor)
+                    .is_some_and(|byte| !byte.is_ascii_whitespace())
+                {
+                    cursor += 1;
+                }
+                std::str::from_utf8(&attributes[value_start..cursor]).ok()?
+            }
+            None => return None,
+        };
+        let value = decode_html_attribute(value);
+
+        match name.as_str() {
+            "alt" if alt.is_none() => alt = Some(value),
+            "height" if height.is_none() => height = Some(value),
+            "src" if src.is_none() => src = Some(value),
+            "title" if title.is_none() => title = Some(value),
+            "width" if width.is_none() => width = Some(value),
+            _ => {}
+        }
+    }
+
+    let src = src.filter(|src| !src.trim().is_empty())?;
+    Some(SafeHtmlImage {
+        alt,
+        height,
+        src,
+        title,
+        width,
+    })
+}
+
+fn decode_html_attribute(value: &str) -> String {
+    value
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&#x27;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
 }
 
 fn safe_inline_html(raw: &str) -> Option<SafeInlineHtml<'_>> {
@@ -1573,5 +1754,41 @@ mod tests {
         assert!(json.contains("\"imageAlt\":\"Plot alt\""));
         assert!(json.contains("\"imageTitle\":\"Daily plot\""));
         assert!(json.contains("\"renderedText\":\"Plot alt\""));
+    }
+
+    #[test]
+    fn projects_standalone_html_image_metadata_for_host_renderer() {
+        let json = project_to_json(
+            "<img src=\"https://example.com/plot.webp?1\" alt=\"Plot alt\" title=\"Daily plot\" width=\"500px\" height=\"320\" onerror=\"alert(1)\">\n",
+        );
+
+        assert!(json.contains("\"kind\":\"paragraph\""), "{json}");
+        assert!(json.contains("\"semantic\":\"image\""), "{json}");
+        assert!(
+            json.contains("\"imageSrc\":\"https://example.com/plot.webp?1\""),
+            "{json}"
+        );
+        assert!(json.contains("\"imageAlt\":\"Plot alt\""), "{json}");
+        assert!(json.contains("\"imageTitle\":\"Daily plot\""), "{json}");
+        assert!(json.contains("\"imageWidth\":\"500px\""), "{json}");
+        assert!(json.contains("\"imageHeight\":\"320\""), "{json}");
+        assert!(!json.contains("onerror"), "{json}");
+    }
+
+    #[test]
+    fn projects_inline_html_images_without_losing_surrounding_text() {
+        let json = project_to_json(
+            "before <IMG SRC='https://example.com/plot.webp?a=1&amp;b=2' ALT='A > B' WIDTH='50%' /> after",
+        );
+
+        assert!(json.contains("\"renderedText\":\"before \""), "{json}");
+        assert!(json.contains("\"semantic\":\"image\""), "{json}");
+        assert!(
+            json.contains("\"imageSrc\":\"https://example.com/plot.webp?a=1&b=2\""),
+            "{json}"
+        );
+        assert!(json.contains("\"imageAlt\":\"A > B\""), "{json}");
+        assert!(json.contains("\"imageWidth\":\"50%\""), "{json}");
+        assert!(json.contains("\"renderedText\":\" after\""), "{json}");
     }
 }

--- a/crates/nteract-markdown-engine/src/render_json.rs
+++ b/crates/nteract-markdown-engine/src/render_json.rs
@@ -1249,7 +1249,7 @@ fn safe_html_image(raw: &str) -> Option<SafeHtmlImage> {
     let mut src = None;
     let mut title = None;
     let mut width = None;
-    let attributes = inner[tag_end..].as_bytes();
+    let attributes = &inner.as_bytes()[tag_end..];
     let mut cursor = 0;
 
     while cursor < attributes.len() {

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1041,7 +1041,30 @@ function ProjectedImage({ run }: { run: MarkdownProjectionRun }) {
     return alt ? <span>{alt}</span> : null;
   }
 
-  return <MarkdownImage src={src} alt={alt} title={run.imageTitle} loading="lazy" />;
+  return (
+    <MarkdownImage
+      src={src}
+      alt={alt}
+      title={run.imageTitle}
+      loading="lazy"
+      style={safeImageDimensions(run)}
+    />
+  );
+}
+
+function safeImageDimensions(run: MarkdownProjectionRun): CSSProperties | undefined {
+  const width = safeImageDimension(run.imageWidth);
+  const height = safeImageDimension(run.imageHeight);
+  return width || height ? { width, height } : undefined;
+}
+
+function safeImageDimension(value: string | undefined): string | undefined {
+  const match = value?.trim().match(/^(\d+(?:\.\d+)?)(px|%)?$/i);
+  if (!match) return undefined;
+
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount) || amount < 0) return undefined;
+  return `${amount}${match[2]?.toLowerCase() ?? "px"}`;
 }
 
 function safeImageSrc(src: string | undefined): string | null {

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -1769,8 +1769,10 @@ describe("ProjectedMarkdownView", () => {
             {
               blockId: "image",
               imageAlt: "Plot alt",
+              imageHeight: "320",
               imageSrc: "attachment:plot.png",
               imageTitle: "Daily plot",
+              imageWidth: "500px",
               inlineId: "img0",
               listItemIndex: null,
               renderedText: "Plot alt",
@@ -1787,6 +1789,7 @@ describe("ProjectedMarkdownView", () => {
     const image = screen.getByRole("img", { name: "Plot alt" });
     expect(image).toHaveAttribute("src", "attachment:plot.png");
     expect(image).toHaveAttribute("title", "Daily plot");
+    expect(image).toHaveStyle({ height: "320px", width: "500px" });
     expect(image).toHaveClass("border", "shadow-sm");
     expect(image.closest("figure")).toHaveClass("my-5");
     expect(screen.getByText("Daily plot")).toHaveClass("text-xs", "text-muted-foreground");
@@ -1868,6 +1871,46 @@ describe("ProjectedMarkdownView", () => {
 
     expect(screen.queryByRole("img")).toBeNull();
     expect(screen.getByText("Bad image")).toBeInTheDocument();
+  });
+
+  it("ignores unsafe projected image dimensions", () => {
+    render(
+      <ProjectedMarkdownView
+        plan={plan({
+          blocks: [
+            {
+              blockId: "image",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 32],
+              sourceSpanUtf16: [0, 32],
+              syntaxSpans: [],
+              text: "Safe image",
+            },
+          ],
+          runs: [
+            {
+              blockId: "image",
+              imageAlt: "Safe image",
+              imageHeight: "1px; position: fixed",
+              imageSrc: "https://example.com/plot.webp",
+              imageWidth: "calc(100vw)",
+              inlineId: "img0",
+              listItemIndex: null,
+              renderedText: "Safe image",
+              renderedTextUtf16: [0, 10],
+              semantic: "image",
+              sourceSpanByte: [0, 32],
+              sourceSpanUtf16: [0, 32],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Safe image" })).not.toHaveAttribute("style");
   });
 
   it("marks the projected block and run for an active source position", () => {

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -379,6 +379,26 @@ describe("markdown projection", () => {
     expect(canRenderMarkdownProjectionInHost(plan)).toBe(true);
   });
 
+  it("projects standalone HTML images through the safe host image path", () => {
+    const plan = projectMarkdownPlan(
+      '<img src="https://example.com/plot.webp?1" alt="Plot alt" width="500px">',
+    );
+
+    expect(plan?.blocks).toEqual([
+      expect.objectContaining({ element: "p", kind: "paragraph" }),
+    ]);
+    expect(plan?.runs).toEqual([
+      expect.objectContaining({
+        imageAlt: "Plot alt",
+        imageSrc: "https://example.com/plot.webp?1",
+        imageWidth: "500px",
+        renderedText: "Plot alt",
+        semantic: "image",
+      }),
+    ]);
+    expect(canRenderMarkdownProjectionInHost(plan)).toBe(true);
+  });
+
   it("maps source cursor positions back to projected rendered blocks and runs", () => {
     const source = "# Heading\n\nA paragraph with **focus**.\n\n- [ ] checkbox\n";
     const plan = projectMarkdownPlan(source);

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -44,8 +44,10 @@ export interface MarkdownProjectionAnchor {
 export interface MarkdownProjectionRun {
   readonly blockId: string;
   readonly imageAlt?: string;
+  readonly imageHeight?: string;
   readonly imageSrc?: string;
   readonly imageTitle?: string;
+  readonly imageWidth?: string;
   readonly inlineId: string;
   readonly listItemIndex: number | null;
   readonly listItemChecked?: boolean;


### PR DESCRIPTION
## Summary

- project standalone Markdown-cell `<img>` tags through the existing safe host image renderer
- preserve `src`, `alt`, `title`, `width`, and `height` while dropping event handlers and other raw attributes
- keep arbitrary raw HTML inert and retain the existing URL and dimension safety checks

## Verification

- `cargo test -p nteract-markdown-engine`
- `pnpm test:run src/lib/__tests__/markdown-projection.test.ts src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --dir apps/notebook test:e2e:browser -- markdown-parity.spec.ts`

## Scope

This intentionally does not change cell insertion affordances or introduce a notebook reading mode.
