### PR TITLE
build(cloud): add celld packaging spike

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -38,6 +38,26 @@ the gitignored `runtimed-wasm` bindings before TypeScript reads them. Use
 `pnpm --dir apps/notebook-cloud wasm` when you explicitly want a full
 `runtimed-wasm` rebuild.
 
+### celld packaging spike
+
+The celld manifest is deliberately separate from `wrangler.toml`. It declares
+the current Worker, static assets, and three active Durable Object classes, but
+omits D1 and R2 because celld does not implement those bindings yet. This is a
+bundle compatibility check, not a functional self-hosted deployment.
+
+Install celld, then run:
+
+```bash
+pnpm --dir apps/notebook-cloud celld:dry-run
+```
+
+Set `CELLD_BIN=/absolute/path/to/celld` to test a downloaded binary that is not
+on `PATH`. The command builds the current viewer and WASM artifacts, adds the
+required esbuild `.wasm` loader, and invokes `celld deploy --dry-run`; it does
+not write a deployment to object storage. A live proof still needs an
+S3-compatible fleet bucket, a celld node, and replacements for the D1 catalog
+and R2 artifact boundaries.
+
 With Wrangler running:
 
 ```bash

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -12,6 +12,7 @@
     "deploy:main": "node scripts/deploy-main.mjs",
     "deploy:renderer-assets": "wrangler deploy -c wrangler.renderer-assets.toml",
     "deploy:check": "curl -fsS https://preview.runt.run/api/health",
+    "celld:dry-run": "pnpm run build && node scripts/celld-dry-run.mjs",
     "ops:cloudflare:usage": "node scripts/cloudflare-usage.mjs --script nteract-notebook-cloud --script nteract-notebook-cloud-assets",
     "auth:preview:health": "node scripts/preview-auth-health.mjs",
     "pretypecheck": "cargo xtask wasm-ensure-runtime",
@@ -47,8 +48,8 @@
     "lucide-react": "^0.513.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "rxjs": "^7.8.2",
-    "runtimed": "workspace:*"
+    "runtimed": "workspace:*",
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
@@ -58,6 +59,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^6.0.1",
+    "esbuild": "^0.28.0",
     "tailwindcss": "^4.1.8",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",

--- a/apps/notebook-cloud/scripts/celld-dry-run.mjs
+++ b/apps/notebook-cloud/scripts/celld-dry-run.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const APP_ROOT_URL = new URL("../", import.meta.url);
+const CONFIG_URL = new URL("../wrangler.celld.jsonc", import.meta.url);
+const ESBUILD_WRAPPER_URL = new URL("./celld-esbuild.sh", import.meta.url);
+
+export const CELLD_DRY_RUN_BUCKET = "s3://nteract-celld-dry-run";
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  main().catch((error) => {
+    console.error(`[celld-dry-run] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}
+
+export function celldDryRunArgs(configPath = fileURLToPath(CONFIG_URL)) {
+  return ["deploy", "--config", configPath, "--bucket", CELLD_DRY_RUN_BUCKET, "--dry-run"];
+}
+
+async function main() {
+  const celldBinary = process.env.CELLD_BIN || "celld";
+  const configPath = fileURLToPath(CONFIG_URL);
+  const esbuildWrapperPath = fileURLToPath(ESBUILD_WRAPPER_URL);
+
+  console.log(`[celld-dry-run] bundling ${configPath} with ${celldBinary}`);
+
+  await run(celldBinary, celldDryRunArgs(configPath), {
+    ...process.env,
+    CELLD_ESBUILD: esbuildWrapperPath,
+  });
+}
+
+function run(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: fileURLToPath(APP_ROOT_URL),
+      env,
+      stdio: "inherit",
+    });
+
+    child.on("error", (error) => {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        reject(new Error(`${command} was not found; install celld or set CELLD_BIN to its path`));
+        return;
+      }
+      reject(error);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`celld exited with ${signal ? `signal ${signal}` : `code ${code}`}`));
+    });
+  });
+}
+
+function isMainModule(importMetaUrl, scriptPath) {
+  return Boolean(scriptPath && fileURLToPath(importMetaUrl) === resolve(scriptPath));
+}

--- a/apps/notebook-cloud/scripts/celld-esbuild.sh
+++ b/apps/notebook-cloud/scripts/celld-esbuild.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+exec esbuild "$@" --loader:.wasm=binary

--- a/apps/notebook-cloud/test/celld-config.test.mjs
+++ b/apps/notebook-cloud/test/celld-config.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFile, stat } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+import { CELLD_DRY_RUN_BUCKET, celldDryRunArgs } from "../scripts/celld-dry-run.mjs";
+
+const CONFIG_URL = new URL("../wrangler.celld.jsonc", import.meta.url);
+const ESBUILD_WRAPPER_URL = new URL("../scripts/celld-esbuild.sh", import.meta.url);
+
+describe("celld packaging spike", () => {
+  it("declares only the currently active Durable Object classes", async () => {
+    const config = await readConfig();
+
+    assert.deepEqual(config.durable_objects.bindings, [
+      { name: "NOTEBOOK_ROOMS", class_name: "NotebookRoom" },
+      { name: "WORKSTATION_EVENTS", class_name: "WorkstationEvents" },
+      { name: "OWNER_COMPUTE_INDEX", class_name: "OwnerComputeIndex" },
+    ]);
+    assert.deepEqual(config.migrations, [
+      {
+        tag: "celld-v1",
+        new_sqlite_classes: ["NotebookRoom", "WorkstationEvents", "OwnerComputeIndex"],
+      },
+    ]);
+  });
+
+  it("keeps unsupported D1 and R2 bindings out of the celld manifest", async () => {
+    const config = await readConfig();
+
+    assert.equal("d1_databases" in config, false);
+    assert.equal("r2_buckets" in config, false);
+    assert.deepEqual(config.assets, {
+      directory: "./dist",
+      binding: "ASSETS",
+      run_worker_first: true,
+    });
+  });
+
+  it("uses a non-writing deployment command and the WASM loader override", async () => {
+    const wrapper = await readFile(ESBUILD_WRAPPER_URL, "utf8");
+    const wrapperStat = await stat(ESBUILD_WRAPPER_URL);
+    const args = celldDryRunArgs("/tmp/wrangler.celld.jsonc");
+
+    assert.notEqual(wrapperStat.mode & 0o111, 0);
+    assert.match(wrapper, /--loader:\.wasm=binary/);
+    assert.deepEqual(args, [
+      "deploy",
+      "--config",
+      "/tmp/wrangler.celld.jsonc",
+      "--bucket",
+      CELLD_DRY_RUN_BUCKET,
+      "--dry-run",
+    ]);
+  });
+});
+
+async function readConfig() {
+  const source = await readFile(CONFIG_URL, "utf8");
+  return JSON.parse(source.replace(/,\s*([}\]])/g, "$1"));
+}

--- a/apps/notebook-cloud/wrangler.celld.jsonc
+++ b/apps/notebook-cloud/wrangler.celld.jsonc
@@ -1,0 +1,37 @@
+{
+  "name": "nteract-notebook-cloud-celld-spike",
+  "main": "./src/index.ts",
+  "compatibility_date": "2024-11-06",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "NOTEBOOK_ROOMS",
+        "class_name": "NotebookRoom",
+      },
+      {
+        "name": "WORKSTATION_EVENTS",
+        "class_name": "WorkstationEvents",
+      },
+      {
+        "name": "OWNER_COMPUTE_INDEX",
+        "class_name": "OwnerComputeIndex",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "celld-v1",
+      "new_sqlite_classes": ["NotebookRoom", "WorkstationEvents", "OwnerComputeIndex"],
+    },
+  ],
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": true,
+  },
+  "vars": {
+    "DEPLOYMENT_ENV": "celld-spike",
+    "NOTEBOOK_CLOUD_ALLOWED_ORIGINS": "http://127.0.0.1:8080",
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,6 +629,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       tailwindcss:
         specifier: ^4.1.8
         version: 4.2.2


### PR DESCRIPTION
## Stack

- Base: #4128
- This PR: reproducible celld packaging and bundle compatibility spike

## Summary

- add a celld-specific Wrangler JSONC manifest for the current Worker, static assets, and three active Durable Object classes
- add a dry-run command that builds the real viewer/WASM artifacts and invokes celld without writing a deployment
- add an explicit esbuild dependency and `.wasm` loader wrapper required by the current celld bundler
- test that the manifest excludes unsupported D1/R2 bindings and does not resurrect deleted Durable Object classes

## Measured result

Using celld v0.1.0 on Apple Silicon, the checked-in command successfully bundled:

- the current notebook-cloud Worker
- 61 static assets with 52 unique bodies
- `NotebookRoom`, `WorkstationEvents`, and `OwnerComputeIndex`
- the `runtimed-wasm` import through the explicit `.wasm` loader

celld reported 6,430.14 KiB raw / 1,870.26 KiB gzip and produced dry-run version `501a778eb6e3ca41`. Nothing was written to object storage.

The first reproducibility run failed because the loader wrapper inherited no directly available `esbuild` binary. This PR now declares `esbuild` explicitly in the cloud app rather than relying on a transitive absolute path.

## Deliberate limits

- no D1 catalog implementation
- no R2/artifact replacement
- no Postgres control service
- no production ingress or identity configuration
- no claim that the Worker has booted on a live celld node yet

Routes requiring D1 or R2 remain unavailable by design. This PR establishes the packaging floor before introducing either backend.

## Local live-node result

A disposable local probe used celld v0.1.0 with MinIO `RELEASE.2025-09-06T17-38-46Z`:

- celld uploaded the immutable Worker version, manifest, asset index, and 52 content-addressed asset bodies
- publishing `deploy/.../current.json` failed twice because celld's create-if-absent conditional write treated MinIO's missing-key response as an ambiguous CAS failure
- after manually seeding the deployment pointer and fleet peer secret for diagnosis only, node startup failed on the same CAS behavior while creating its node lease
- the process exited with `node authority was not established before wake scan` before binding its HTTP listener

No workaround is committed. This result blocks the MinIO-backed live profile at celld's fleet storage layer, before nteract Worker JavaScript executes. The next live probe should use an object store with celld-verified conditional-write semantics or a celld/MinIO compatibility fix.

## Verification

- `node --test apps/notebook-cloud/test/celld-config.test.mjs`
- `CELLD_BIN=/absolute/path/to/celld pnpm --dir apps/notebook-cloud celld:dry-run`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`

The full `pnpm --dir apps/notebook-cloud test` suite was also run. The new celld tests pass, but the existing suite remains red on failures outside this PR's diff, including stale viewer source-text expectations, workstation attachment fixtures that omit `accelerators: null`, renderer artifact drift, and other current room/sharing assertions. The stacked diff does not modify the corresponding runtime, viewer, or pre-existing test files, so those failures are recorded rather than folded into this packaging spike.

## Next experiment

Repeat the live probe against an object store with celld-verified conditional-write semantics, then probe `/api/health`, static assets, and Durable Object construction. Record each failure before adding the Postgres or artifact adapters.
