### PR TITLE
feat(ui): Updates to page layout

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,4 +1,3 @@
-import { House } from "lucide-react";
 import { DocumentTitle } from "@/components/notebook/DocumentTitle";
 import {
   cloudNotebookRouteTitleFromPathname,
@@ -28,10 +27,6 @@ export function CloudNotebookTitle({
       renameSaving={renameSaving}
       renameError={renameError}
       onRename={onRename}
-      homeHref="/n"
-      homeAriaLabel="Open notebooks dashboard"
-      homeTitle="Notebooks"
-      homeIcon={<House aria-hidden="true" />}
       inputAriaLabel="Notebook title"
       inputName="notebook-title"
       placeholder="Untitled notebook"
@@ -43,7 +38,6 @@ export function CloudNotebookTitle({
 
 export const cloudNotebookTitleClassNames = {
   group: "cloud-notebook-title-group",
-  homeLink: "cloud-notebook-home-link",
   title: "cloud-notebook-title",
   staticTitle: "cloud-notebook-title-static",
   form: "cloud-notebook-title-form",

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -94,28 +94,62 @@ body {
   flex: 1;
 }
 
+.cloud-startup-main {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
 .cloud-startup-rail {
-  display: grid;
-  width: 3rem;
-  flex: 0 0 3rem;
-  place-items: start center;
-  gap: 1.25rem;
+  display: flex;
+  width: 3.5rem;
+  flex: 0 0 3.5rem;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
   border-right: 1px solid var(--border);
-  padding-top: 2rem;
+  padding: 0.75rem 0.5rem;
   color: color-mix(in srgb, var(--foreground) 48%, transparent);
-  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  background: var(--background);
 }
 
-.cloud-startup-rail svg,
-.cloud-startup-rail span {
-  width: 1.125rem;
-  height: 1.125rem;
+.cloud-startup-rail > * {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 0.75rem;
 }
 
-.cloud-startup-rail span {
+.cloud-startup-rail > svg {
+  width: 1rem;
+  height: 1rem;
+  padding: 0.625rem;
+  box-sizing: content-box;
+}
+
+.cloud-startup-rail > span:not(.cloud-startup-rail-home)::after {
+  width: 1rem;
+  height: 1rem;
   border-radius: 4px;
   background: currentColor;
   opacity: 0.24;
+  content: "";
+}
+
+.cloud-startup-rail-home {
+  margin-bottom: 1rem;
+  color: var(--background);
+  background: var(--foreground);
+}
+
+.cloud-startup-rail-home svg {
+  width: 1rem;
+  height: 1rem;
+  stroke-width: 2.25;
 }
 
 .cloud-startup-stage {
@@ -196,6 +230,16 @@ body {
   overflow: hidden;
 }
 
+.cloud-notebook-stage > [data-slot="notebook-document-toolbar"],
+.cloud-notebook-stage > [data-slot="notebook-document-stage-toolbar"] {
+  flex: 0 0 auto;
+  z-index: 16;
+}
+
+.cloud-notebook-stage-toolbar {
+  position: static;
+}
+
 /* Region chrome only — do not restyle [data-slot="notebook-notice"] /
    notebook-notice-stack; shared NotebookNotice owns tone, border-b, padding,
    and stack gap. Size to content so multi-notice stacks and disclosures are
@@ -260,32 +304,6 @@ body {
   gap: 0.75rem;
   min-width: 0;
   max-width: 100%;
-}
-
-.cloud-notebook-home-link {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 6px;
-  color: color-mix(in srgb, var(--foreground) 74%, transparent);
-  text-decoration: none;
-}
-
-.cloud-notebook-home-link:hover {
-  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
-}
-
-.cloud-notebook-home-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
-  outline-offset: 2px;
-}
-
-.cloud-notebook-home-link svg {
-  width: 1.125rem;
-  height: 1.125rem;
 }
 
 .cloud-notebook-title-form {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -149,37 +149,39 @@ function ViewerStartupError({ message }: { message: string }) {
 function ViewerStartupLoading({ title }: { title: string }) {
   return (
     <main className="cloud-startup-shell" aria-busy="true">
-      <header className="cloud-startup-toolbar">
-        <div className="cloud-notebook-title-group">
-          <a className="cloud-notebook-home-link" href="/n" aria-label="Open notebooks dashboard">
+      <div className="cloud-startup-workspace">
+        <aside className="cloud-startup-rail" aria-hidden="true">
+          <span className="cloud-startup-rail-home">
             <House aria-hidden="true" />
-          </a>
-          <div className="cloud-notebook-title">
-            <h1 className="cloud-startup-title">{title}</h1>
-            <p className="cloud-startup-status" role="status">
-              <Loader2 aria-hidden="true" />
-              Opening notebook
-            </p>
-          </div>
-        </div>
-        <div className="cloud-startup-toolbar-actions" aria-hidden="true">
-          <span />
-          <span />
-          <span />
-        </div>
-      </header>
-      <div className="cloud-startup-workspace" aria-hidden="true">
-        <aside className="cloud-startup-rail">
+          </span>
           <BookOpen aria-hidden="true" />
           <span />
         </aside>
-        <section className="cloud-startup-stage">
-          <div className="cloud-startup-cell">
-            <span className="cloud-startup-line cloud-startup-line--wide" />
-            <span className="cloud-startup-line" />
-            <span className="cloud-startup-line cloud-startup-line--short" />
-          </div>
-        </section>
+        <div className="cloud-startup-main">
+          <header className="cloud-startup-toolbar">
+            <div className="cloud-notebook-title-group">
+              <div className="cloud-notebook-title">
+                <h1 className="cloud-startup-title">{title}</h1>
+                <p className="cloud-startup-status" role="status">
+                  <Loader2 aria-hidden="true" />
+                  Opening notebook
+                </p>
+              </div>
+            </div>
+            <div className="cloud-startup-toolbar-actions" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </div>
+          </header>
+          <section className="cloud-startup-stage" aria-hidden="true">
+            <div className="cloud-startup-cell">
+              <span className="cloud-startup-line cloud-startup-line--wide" />
+              <span className="cloud-startup-line" />
+              <span className="cloud-startup-line cloud-startup-line--short" />
+            </div>
+          </section>
+        </div>
       </div>
     </main>
   );

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -24,10 +24,7 @@ import {
   useHasIsolatedOutputs,
   useIsolatedRenderer,
 } from "@/components/isolated/isolated-renderer-context";
-import {
-  NotebookRailHomeButton,
-  type NotebookRailPanelId,
-} from "@/components/notebook-rail";
+import { NotebookRailHomeButton, type NotebookRailPanelId } from "@/components/notebook-rail";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import {
   markdownProjectionMatchesSource,
@@ -1609,25 +1606,26 @@ export function NotebookViewer({
     onCreateOutputComment: handleRequestOutputComment,
     onActivateCommentThread: handleActivateCommentThread,
   });
-  const identityControls = liveRoomDisabledStatus?.kind === "loading" ? null : (
-    <NotebookConnectionIdentity
-      capabilities={shellCapabilities}
-      connectionStatus$={connectionStatus$}
-      accountDetail={authState.oidcClaims?.email?.trim() ?? null}
-      accountActions={
-        <>
-          <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
-            <Settings aria-hidden="true" />
-            Settings
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={signOutOfNotebook}>
-            <LogOut aria-hidden="true" />
-            Sign out
-          </DropdownMenuItem>
-        </>
-      }
-    />
-  );
+  const identityControls =
+    liveRoomDisabledStatus?.kind === "loading" ? null : (
+      <NotebookConnectionIdentity
+        capabilities={shellCapabilities}
+        connectionStatus$={connectionStatus$}
+        accountDetail={authState.oidcClaims?.email?.trim() ?? null}
+        accountActions={
+          <>
+            <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
+              <Settings aria-hidden="true" />
+              Settings
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={signOutOfNotebook}>
+              <LogOut aria-hidden="true" />
+              Sign out
+            </DropdownMenuItem>
+          </>
+        }
+      />
+    );
   const rail = (
     <NotebookDocumentRail
       leadingSlot={<NotebookRailHomeButton href="/n" />}

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -24,7 +24,10 @@ import {
   useHasIsolatedOutputs,
   useIsolatedRenderer,
 } from "@/components/isolated/isolated-renderer-context";
-import type { NotebookRailPanelId } from "@/components/notebook-rail";
+import {
+  NotebookRailHomeButton,
+  type NotebookRailPanelId,
+} from "@/components/notebook-rail";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import {
   markdownProjectionMatchesSource,
@@ -37,7 +40,9 @@ import {
   NotebookSettingsDrawer,
   notebookToolbarActors,
   NotebookCommentsPanel,
+  NotebookCommandToolbar,
   NotebookDocumentToolbar,
+  NotebookToolbarFrame,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
@@ -1604,8 +1609,29 @@ export function NotebookViewer({
     onCreateOutputComment: handleRequestOutputComment,
     onActivateCommentThread: handleActivateCommentThread,
   });
+  const identityControls = liveRoomDisabledStatus?.kind === "loading" ? null : (
+    <NotebookConnectionIdentity
+      capabilities={shellCapabilities}
+      connectionStatus$={connectionStatus$}
+      accountDetail={authState.oidcClaims?.email?.trim() ?? null}
+      accountActions={
+        <>
+          <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
+            <Settings aria-hidden="true" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={signOutOfNotebook}>
+            <LogOut aria-hidden="true" />
+            Sign out
+          </DropdownMenuItem>
+        </>
+      }
+    />
+  );
   const rail = (
     <NotebookDocumentRail
+      leadingSlot={<NotebookRailHomeButton href="/n" />}
+      trailingSlot={identityControls}
       viewModel={notebookViewModel}
       activePanelId={renderedActiveRailPanel}
       collapsed={railCollapsed}
@@ -1749,33 +1775,13 @@ export function NotebookViewer({
           />
         ) : null
       }
-      identityControls={
-        // Connection/identity slot: self-identity avatar + connectivity dot
-        // (the stable bridge survives transport replacement; the dot keeps
-        // frozen runtime chrome interpretable while reconnecting).
-        notebookHeaderChrome.showConnectionIdentity ? (
-          <NotebookConnectionIdentity
-            capabilities={shellCapabilities}
-            connectionStatus$={connectionStatus$}
-            accountDetail={authState.oidcClaims?.email?.trim() ?? null}
-            accountActions={
-              <>
-                <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
-                  <Settings aria-hidden="true" />
-                  Settings
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={signOutOfNotebook}>
-                  <LogOut aria-hidden="true" />
-                  Sign out
-                </DropdownMenuItem>
-              </>
-            }
-          />
-        ) : null
-      }
-      reserveCommandToolbar={editAccessPending}
-      commandToolbar={{
-        leadingControls: (
+    />
+  );
+  const stageToolbar = showCloudCommandToolbar ? (
+    <NotebookToolbarFrame className="cloud-notebook-stage-toolbar">
+      <NotebookCommandToolbar
+        capabilities={shellCapabilities}
+        leadingControls={
           <button
             type="button"
             className="cloud-mobile-rail-toggle hidden h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -1785,25 +1791,25 @@ export function NotebookViewer({
           >
             <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
           </button>
-        ),
-        runtime: toolbarRuntime,
-        runtimeTarget: shellCapabilities.runtime.target ?? null,
-        environmentManager: toolbarEnvironmentManager,
-        environmentPanelOpen: activeRailPanel === "packages" && !railCollapsed,
-        runtimeStatus: cloudRuntimeStatus,
-        addCellControlsDisabled: editAccessPending,
-        addAfterCellId: toolbarAddAfterCellId,
-        onAddCell: handleCloudAddCell,
-        onStartRuntime: handleCloudStartRuntime,
-        onInterruptRuntime: handleCloudInterruptRuntime,
-        onRestartRuntime: handleCloudRestartRuntime,
-        onRunAllCells: handleCloudRunAllCells,
-        onRestartAndRunAll: handleCloudRestartAndRunAll,
-        onTogglePackages: handleTogglePackagesRail,
-        workstationAction,
-      }}
-    />
-  );
+        }
+        runtime={toolbarRuntime}
+        runtimeTarget={shellCapabilities.runtime.target ?? null}
+        environmentManager={toolbarEnvironmentManager}
+        environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+        runtimeStatus={cloudRuntimeStatus}
+        addCellControlsDisabled={editAccessPending}
+        addAfterCellId={toolbarAddAfterCellId}
+        onAddCell={handleCloudAddCell}
+        onStartRuntime={handleCloudStartRuntime}
+        onInterruptRuntime={handleCloudInterruptRuntime}
+        onRestartRuntime={handleCloudRestartRuntime}
+        onRunAllCells={handleCloudRunAllCells}
+        onRestartAndRunAll={handleCloudRestartAndRunAll}
+        onTogglePackages={handleTogglePackagesRail}
+        workstationAction={workstationAction}
+      />
+    </NotebookToolbarFrame>
+  ) : null;
   const notebookViewSurface = projectCloudNotebookViewSurface({
     // A signed-out gate owns the stage: suppress the empty NotebookView so it
     // does not paint a blank canvas behind the gate.
@@ -1940,8 +1946,11 @@ export function NotebookViewer({
         }
         stageClassName="cloud-notebook-stage"
         toolbar={toolbar}
+        toolbarPlacement="stage"
+        stageToolbar={stageToolbar}
         toolbarLabel="Notebook view status and controls"
         notices={notices}
+        noticesPlacement="stage"
         noticesClassName="cloud-notebook-notices"
         capabilities={shellCapabilities}
         rail={notebookStageGated ? undefined : rail}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2002,48 +2002,6 @@ function AppContent() {
               onDismiss={() => setDismissedLaunchError(errorDetails)}
             />
           )}
-        <NotebookToolbar
-          kernelStatus={displayKernelStatus}
-          statusKey={displayStatusKey}
-          lifecycle={lifecycle}
-          errorReason={errorReason}
-          kernelErrorMessage={errorDetails}
-          envSource={envSource}
-          condaPython={condaDependencies?.python ?? null}
-          condaChannels={condaDependencies?.channels ?? null}
-          projectContext={runtimeState.project_context}
-          envTypeHint={envTypeHint}
-          envProgress={envProgress.isActive || envProgress.error ? envProgress : null}
-          runtime={runtime}
-          onStartKernel={handleStartKernel}
-          onInterruptKernel={interruptKernel}
-          onRestartKernel={handleRestartKernel}
-          onRunAllCells={handleRunAllCells}
-          onRestartAndRunAll={handleRestartAndRunAll}
-          focusedCellId={focusedCellId}
-          lastCellId={cellIds.length > 0 ? cellIds[cellIds.length - 1] : null}
-          onAddCell={handleAddCell}
-          onToggleDependencies={handleTogglePackagesRail}
-          isDepsOpen={packagesRailOpen}
-          capabilities={shellCapabilities}
-          depsOutOfSync={envSyncState ? !envSyncState.inSync : false}
-          updateStatus={updateStatus}
-          updateVersion={updateVersion}
-          onRestartToUpdate={restartToUpdate}
-          trailingControls={
-            // Connection/identity slot: renders nothing for a purely local
-            // session (isRemoteNotebookContext) — conditionality is the
-            // point. The source derives from daemon lifecycle events (the
-            // IPC transport's status is constant in practice). Hosted rooms
-            // compose daemon and bridge health, so their copy names the whole
-            // notebook connection rather than only the first hop.
-            <NotebookConnectionIdentity
-              capabilities={shellCapabilities}
-              connectionStatus$={desktopConnectionStatus}
-              connectionLabel={hostedNotebookUrl ? "Notebook connection" : "Daemon connection"}
-            />
-          }
-        />
         {globalFind.isOpen && (
           <GlobalFindBar
             query={globalFind.query}
@@ -2092,12 +2050,55 @@ function AppContent() {
               </NotebookNotice>
             ) : null
           }
+          toolbarPlacement="stage"
+          toolbarClassName="shrink-0"
+          toolbarLabel="Notebook execution and runtime controls"
+          toolbar={
+            <NotebookToolbar
+              kernelStatus={displayKernelStatus}
+              statusKey={displayStatusKey}
+              lifecycle={lifecycle}
+              errorReason={errorReason}
+              kernelErrorMessage={errorDetails}
+              envSource={envSource}
+              condaPython={condaDependencies?.python ?? null}
+              condaChannels={condaDependencies?.channels ?? null}
+              projectContext={runtimeState.project_context}
+              envTypeHint={envTypeHint}
+              envProgress={envProgress.isActive || envProgress.error ? envProgress : null}
+              runtime={runtime}
+              onStartKernel={handleStartKernel}
+              onInterruptKernel={interruptKernel}
+              onRestartKernel={handleRestartKernel}
+              onRunAllCells={handleRunAllCells}
+              onRestartAndRunAll={handleRestartAndRunAll}
+              focusedCellId={focusedCellId}
+              lastCellId={cellIds.length > 0 ? cellIds[cellIds.length - 1] : null}
+              onAddCell={handleAddCell}
+              onToggleDependencies={handleTogglePackagesRail}
+              isDepsOpen={packagesRailOpen}
+              capabilities={shellCapabilities}
+              depsOutOfSync={envSyncState ? !envSyncState.inSync : false}
+              updateStatus={updateStatus}
+              updateVersion={updateVersion}
+              onRestartToUpdate={restartToUpdate}
+            />
+          }
           stageClassName={cn(
-            "flex-row min-w-0 flex-1",
+            "min-w-0 flex-1",
             !railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
           )}
           rail={
             <NotebookDocumentRail
+              trailingSlot={
+                <NotebookConnectionIdentity
+                  capabilities={shellCapabilities}
+                  connectionStatus$={desktopConnectionStatus}
+                  connectionLabel={
+                    hostedNotebookUrl ? "Notebook connection" : "Daemon connection"
+                  }
+                />
+              }
               viewModel={notebookViewModel}
               activePanelId={renderedActiveRailPanel}
               collapsed={railCollapsed}
@@ -2238,7 +2239,7 @@ function AppContent() {
             />
           }
         >
-          <div className="flex min-w-0 flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1">
             <CrdtBridgeProvider
               getHandle={getHandle}
               onSyncNeeded={triggerSync}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2094,9 +2094,7 @@ function AppContent() {
                 <NotebookConnectionIdentity
                   capabilities={shellCapabilities}
                   connectionStatus$={desktopConnectionStatus}
-                  connectionLabel={
-                    hostedNotebookUrl ? "Notebook connection" : "Daemon connection"
-                  }
+                  connectionLabel={hostedNotebookUrl ? "Notebook connection" : "Daemon connection"}
                 />
               }
               viewModel={notebookViewModel}

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -690,11 +690,14 @@ describe("connection/identity slot wiring", () => {
   it("App.tsx mounts the slot on the daemon-lifecycle source with scoped copy", () => {
     // Source-text pin mirroring the cloud guardrail: deleting the desktop
     // mount, feeding it the IPC transport again, or dropping the scoped
-    // connection label must fail here.
+    // connection label must fail here. The slot lives on the rail's
+    // trailingSlot (not the toolbar) so both hosts mount identity chrome in
+    // the same place; the assertion follows the mount rather than pinning
+    // one owner's prop name.
     // vp test runs from the repo root.
     const appSource = readFileSync(resolve(process.cwd(), "apps/notebook/src/App.tsx"), "utf8");
     expect(appSource).toMatch(
-      /trailingControls=\{[\s\S]{0,600}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{desktopConnectionStatus\}[\s\S]{0,200}?connectionLabel=\{hostedNotebookUrl \? "Notebook connection" : "Daemon connection"\}/,
+      /trailingSlot=\{[\s\S]{0,600}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{desktopConnectionStatus\}[\s\S]{0,200}?connectionLabel=\{hostedNotebookUrl \? "Notebook connection" : "Daemon connection"\}/,
     );
     expect(appSource).toMatch(
       /createDesktopConnectionStatusSource\([\s\S]{0,160}?host\.daemonEvents,[\s\S]{0,80}?host\.daemon\.autoReconnect,[\s\S]{0,80}?hostedBridgeStatus\$/,

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -39,6 +39,8 @@ export interface NotebookRailProps {
   workstationsPanel?: ReactNode;
   /** Rendered inline with the Workstations panel title. */
   workstationsPanelAction?: ReactNode;
+  leadingSlot?: ReactNode;
+  trailingSlot?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
@@ -64,6 +66,8 @@ export function NotebookRail({
   commentsPanel,
   workstationsPanel,
   workstationsPanelAction,
+  leadingSlot,
+  trailingSlot,
   onActivePanelChange,
   onCollapsedChange,
   onSelectOutlineItem,
@@ -95,6 +99,8 @@ export function NotebookRail({
       items={railButtons}
       panelTitle={title}
       panelAction={activePanelId === "workstations" ? workstationsPanelAction : undefined}
+      leadingSlot={leadingSlot}
+      trailingSlot={trailingSlot}
       panelClassName={NOTEBOOK_RAIL_PANEL_CLASS_NAME}
       className={className}
       dataTestId="notebook-rail"

--- a/src/components/notebook-rail/NotebookRailHomeButton.tsx
+++ b/src/components/notebook-rail/NotebookRailHomeButton.tsx
@@ -1,0 +1,30 @@
+import { House } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface NotebookRailHomeButtonProps {
+  href: string;
+  label?: string;
+  className?: string;
+}
+
+export function NotebookRailHomeButton({
+  href,
+  label = "Notebooks",
+  className,
+}: NotebookRailHomeButtonProps) {
+  return (
+    <a
+      href={href}
+      aria-label={label}
+      title={label}
+      data-slot="notebook-rail-home"
+      className={cn(
+        "flex size-9 items-center justify-center rounded-xl bg-foreground text-background transition-colors",
+        "hover:bg-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        className,
+      )}
+    >
+      <House className="size-4" strokeWidth={2.25} aria-hidden="true" />
+    </a>
+  );
+}

--- a/src/components/notebook-rail/index.ts
+++ b/src/components/notebook-rail/index.ts
@@ -12,10 +12,7 @@ export {
   type NotebookRailPanelId,
   type NotebookRailProps,
 } from "./NotebookRail";
-export {
-  NotebookRailHomeButton,
-  type NotebookRailHomeButtonProps,
-} from "./NotebookRailHomeButton";
+export { NotebookRailHomeButton, type NotebookRailHomeButtonProps } from "./NotebookRailHomeButton";
 export type {
   NotebookOutlineHrefTarget,
   NotebookOutlineItem,

--- a/src/components/notebook-rail/index.ts
+++ b/src/components/notebook-rail/index.ts
@@ -12,6 +12,10 @@ export {
   type NotebookRailPanelId,
   type NotebookRailProps,
 } from "./NotebookRail";
+export {
+  NotebookRailHomeButton,
+  type NotebookRailHomeButtonProps,
+} from "./NotebookRailHomeButton";
 export type {
   NotebookOutlineHrefTarget,
   NotebookOutlineItem,

--- a/src/components/notebook/NotebookDocumentRail.tsx
+++ b/src/components/notebook/NotebookDocumentRail.tsx
@@ -15,6 +15,8 @@ export interface NotebookDocumentRailProps {
   commentsPanel?: ReactNode;
   workstationsPanel?: ReactNode;
   workstationsPanelAction?: ReactNode;
+  leadingSlot?: ReactNode;
+  trailingSlot?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
@@ -34,6 +36,8 @@ export function NotebookDocumentRail({
   commentsPanel,
   workstationsPanel,
   workstationsPanelAction,
+  leadingSlot,
+  trailingSlot,
   onActivePanelChange,
   onCollapsedChange,
   onSelectOutlineItem,
@@ -53,6 +57,8 @@ export function NotebookDocumentRail({
       commentsPanel={commentsPanel}
       workstationsPanel={workstationsPanel}
       workstationsPanelAction={workstationsPanelAction}
+      leadingSlot={leadingSlot}
+      trailingSlot={trailingSlot}
       onActivePanelChange={onActivePanelChange}
       onCollapsedChange={onCollapsedChange}
       onSelectOutlineItem={onSelectOutlineItem}

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -10,7 +10,10 @@ export interface NotebookDocumentShellProps {
   rootElement?: "div" | "main";
   rail?: ReactNode;
   toolbar?: ReactNode;
+  toolbarPlacement?: "shell" | "stage";
+  stageToolbar?: ReactNode;
   notices?: ReactNode;
+  noticesPlacement?: "shell" | "stage";
   children: ReactNode;
   capabilities?: NotebookShellCapabilities;
   className?: string;
@@ -25,7 +28,10 @@ export function NotebookDocumentShell({
   rootElement = "div",
   rail,
   toolbar,
+  toolbarPlacement = "shell",
+  stageToolbar,
   notices,
+  noticesPlacement = "shell",
   children,
   capabilities,
   className,
@@ -36,6 +42,20 @@ export function NotebookDocumentShell({
   stageLabel = "Notebook",
 }: NotebookDocumentShellProps) {
   const Root = rootElement as ElementType;
+  const toolbarSlot = toolbar ? (
+    <div
+      className={toolbarClassName}
+      aria-label={toolbarLabel}
+      data-slot="notebook-document-toolbar"
+    >
+      {toolbar}
+    </div>
+  ) : null;
+  const noticesSlot = notices ? (
+    <div className={noticesClassName} data-slot="notebook-document-notices">
+      {notices}
+    </div>
+  ) : null;
 
   return (
     <Root
@@ -51,20 +71,8 @@ export function NotebookDocumentShell({
       data-runtime-connected={capabilities?.runtime.connected}
       data-slot="notebook-document-shell"
     >
-      {toolbar ? (
-        <div
-          className={toolbarClassName}
-          aria-label={toolbarLabel}
-          data-slot="notebook-document-toolbar"
-        >
-          {toolbar}
-        </div>
-      ) : null}
-      {notices ? (
-        <div className={noticesClassName} data-slot="notebook-document-notices">
-          {notices}
-        </div>
-      ) : null}
+      {toolbarPlacement === "shell" ? toolbarSlot : null}
+      {noticesPlacement === "shell" ? noticesSlot : null}
       <div className="flex min-h-0 flex-1 overflow-hidden" data-slot="notebook-document-body">
         {rail}
         <section
@@ -72,6 +80,11 @@ export function NotebookDocumentShell({
           aria-label={stageLabel}
           data-slot="notebook-document-stage"
         >
+          {toolbarPlacement === "stage" ? toolbarSlot : null}
+          {noticesPlacement === "stage" ? noticesSlot : null}
+          {stageToolbar ? (
+            <div data-slot="notebook-document-stage-toolbar">{stageToolbar}</div>
+          ) : null}
           {children}
         </section>
       </div>

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -24,6 +24,8 @@ export interface RailProps<PanelId extends string = string> {
   onCollapsedChange: (collapsed: boolean) => void;
   /** Rendered inline with the panel title, right-aligned. */
   panelAction?: ReactNode;
+  leadingSlot?: ReactNode;
+  trailingSlot?: ReactNode;
   panelClassName?: string;
   className?: string;
   dataTestId?: string;
@@ -37,6 +39,8 @@ export function Rail<PanelId extends string = string>({
   items,
   panelTitle,
   panelAction,
+  leadingSlot,
+  trailingSlot,
   panelClassName,
   children,
   onActivePanelChange,
@@ -52,7 +56,8 @@ export function Rail<PanelId extends string = string>({
       data-testid={dataTestId}
       data-collapsed={collapsed ? "true" : "false"}
     >
-      <div className="flex w-12 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 px-2 py-3">
+      <div className="flex w-14 shrink-0 flex-col items-center gap-1 border-r bg-background px-2 py-3">
+        {leadingSlot ? <div className="mb-4 flex flex-col items-center">{leadingSlot}</div> : null}
         {items.map((item) => (
           <RailButton
             key={item.id}
@@ -71,6 +76,9 @@ export function Rail<PanelId extends string = string>({
             }}
           />
         ))}
+        {trailingSlot ? (
+          <div className="mt-auto flex flex-col items-center pt-4">{trailingSlot}</div>
+        ) : null}
       </div>
 
       {!collapsed && (
@@ -127,12 +135,12 @@ export function RailButton({
       onClick={onClick}
       data-slot={dataSlot}
       className={cn(
-        "flex size-8 items-center justify-center rounded-md border text-xs transition-colors",
+        "flex size-9 items-center justify-center rounded-xl text-xs transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
         active
-          ? "border-primary bg-primary text-primary-foreground"
-          : "border-transparent text-muted-foreground hover:border-border hover:bg-background hover:text-foreground",
-        disabled && "cursor-not-allowed opacity-40 hover:border-transparent hover:bg-transparent",
+          ? "bg-foreground text-background"
+          : "text-foreground/70 hover:bg-muted hover:text-foreground",
+        disabled && "cursor-not-allowed opacity-40 hover:bg-transparent",
       )}
     >
       <Icon className="size-4" aria-hidden="true" />

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -137,8 +137,8 @@ describe("RailButton", () => {
 
     expect(screen.getByRole("button", { name: "Outline" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "Outline" })).toHaveClass(
-      "border-primary",
-      "bg-primary",
+      "bg-foreground",
+      "text-background",
     );
   });
 


### PR DESCRIPTION
Created a side rail with the home button and avatar on it. Moved the header to show above the notebook area. Moved the notebook utilities above the notebook to the right of the notebook panel. 

OLD:
<img width="3022" height="1470" alt="image" src="https://github.com/user-attachments/assets/a477132b-b6da-47d6-98d6-ff171dbfc76d" />

NEW:
<img width="1508" height="732" alt="image" src="https://github.com/user-attachments/assets/0c7ee6b3-534b-4844-a1f7-38b2ca9cd055" />
