### PR TITLE
fix(kernel): attach Arrow buffers from worker displays

### DIFF
--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
@@ -1,8 +1,10 @@
 """Buffer-attachment hook — shared between ``display_pub`` and ``displayhook``.
 
 When the DataFrame formatter emits an output bundle, it stashes the Arrow
-bytes in a thread-local dict keyed by the blob-ref hash. Later, when the
-Jupyter message is about to go on the wire, this hook:
+bytes in a thread-local dict keyed by the blob-ref hash. Accessing that stash
+also installs the hook for the current thread because IPython publisher hooks
+are thread-local. Later, when the Jupyter message is about to go on the wire,
+this hook:
 
 1. Looks at the message's ``content.data`` for our ref MIME.
 2. If present, pops the pending bytes by hash.
@@ -31,7 +33,17 @@ _pending = threading.local()
 
 
 def pending_buffers() -> dict[str, bytes]:
-    """Return the per-thread pending-buffers dict, creating it lazily."""
+    """Return the per-thread pending-buffers dict, creating it lazily.
+
+    Formatters can run on worker threads when user code calls ``display()``
+    from an executor. IPython keeps publisher hooks thread-local, so the
+    extension's main-thread installation is not visible there. Install on
+    stash access to ensure the later publish on this same thread can attach
+    the pending bytes.
+    """
+    ip = _get_ipython()
+    if ip is not None:
+        install(ip)
     if not hasattr(_pending, "buffers"):
         _pending.buffers = {}
     return _pending.buffers

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -313,6 +313,74 @@ def test_install_registers_on_both_seats_once():
     assert len(ip.displayhook._hooks) == 1
 
 
+def test_worker_thread_display_attaches_arrow_buffers():
+    """A worker-thread display must publish every declared Arrow blob."""
+    import time
+
+    from jupyter_client import KernelManager
+    from jupyter_client.kernelspec import KernelSpec
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    kernel_manager = KernelManager(kernel_name="nteract-launcher-test")
+    kernel_manager._kernel_spec = KernelSpec(  # noqa: SLF001
+        argv=[
+            sys.executable,
+            "-m",
+            "nteract_kernel_launcher",
+            "-f",
+            "{connection_file}",
+        ],
+        display_name="nteract launcher test",
+        language="python",
+    )
+    kernel_manager.start_kernel()
+    client = kernel_manager.client()
+    client.start_channels()
+    try:
+        client.wait_for_ready(timeout=30)
+        message_id = client.execute(
+            """
+from concurrent.futures import ThreadPoolExecutor
+import polars as pl
+from IPython.display import display
+
+df = pl.DataFrame({"a": range(100_000), "b": [f"x{i}" for i in range(100_000)]})
+ThreadPoolExecutor(1).submit(display, df).result()
+"""
+        )
+
+        display_messages = []
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            message = client.get_iopub_msg(timeout=max(0.1, deadline - time.monotonic()))
+            if message.get("parent_header", {}).get("msg_id") != message_id:
+                continue
+            message_type = message.get("header", {}).get("msg_type")
+            if message_type == "display_data":
+                display_messages.append(message)
+            if (
+                message_type == "status"
+                and message.get("content", {}).get("execution_state") == "idle"
+            ):
+                break
+
+        assert len(display_messages) == 1
+        display_message = display_messages[0]
+        ref_bundle = display_message["content"]["data"][BLOB_REF_MIME]
+        refs = ref_bundle.get("refs", [ref_bundle])
+        buffers = display_message.get("buffers", [])
+
+        assert refs
+        assert len(buffers) == len(refs)
+        for ref in refs:
+            buffer = bytes(buffers[ref["buffer_index"]])
+            assert len(buffer) == ref["size"]
+            assert hashlib.sha256(buffer).hexdigest() == ref["hash"]
+    finally:
+        client.stop_channels()
+        kernel_manager.shutdown_kernel(now=True)
+
+
 # ─── LLM formatter contract ──────────────────────────────────────────────
 
 

--- a/python/runtimed/tests/test_dx_integration.py
+++ b/python/runtimed/tests/test_dx_integration.py
@@ -49,7 +49,9 @@ pytest.importorskip(
 sys.path.insert(0, str(Path(__file__).parent))
 
 from test_daemon_integration import (  # noqa: E402, F401, F811
+    _set_python_kernelspec,
     async_create_cell_and_wait_for_sync,
+    async_shutdown_and_start_kernel,
     async_start_kernel_with_retry,
     client,
     daemon_health_check,
@@ -266,6 +268,50 @@ df
     table = _read_arrow_table(bytes(arrow_bytes))
     assert table.num_rows == 3
     assert set(table.column_names) == {"a", "b"}
+
+
+@pytest.mark.integration
+async def test_polars_worker_thread_display_publishes_arrow_blob(session):  # noqa: F811
+    """Worker-thread ``display()`` must publish bytes for every Arrow ref."""
+    pytest.importorskip("polars")
+    await _set_python_kernelspec(session, uv_deps=["polars", "pyarrow"])
+    await async_shutdown_and_start_kernel(session, kernel_type="python", env_source="uv:inline")
+
+    display_id = await async_create_cell_and_wait_for_sync(
+        session,
+        """
+from concurrent.futures import ThreadPoolExecutor
+import polars as pl
+from IPython.display import display
+
+df = pl.DataFrame({"a": range(100_000), "b": [f"x{i}" for i in range(100_000)]})
+ThreadPoolExecutor(1).submit(display, df).result()
+""",
+    )
+    result = await session.execute_cell(display_id)
+    assert result.success, f"worker-thread display failed: {result.error}"
+
+    rich_outputs = [output for output in result.outputs if output.output_type == "display_data"]
+    assert len(rich_outputs) == 1
+    output = rich_outputs[0]
+    assert BLOB_REF_MIME not in output.data
+
+    arrow_bytes = output.data.get(ARROW_STREAM_MIME)
+    assert isinstance(arrow_bytes, (bytes, bytearray)), (
+        f"Arrow stream blob did not resolve. keys: {list(output.data.keys())}"
+    )
+    table = _read_arrow_table(bytes(arrow_bytes))
+    assert table.num_rows == 50_000
+    assert set(table.column_names) == {"a", "b"}
+
+    manifest = _arrow_manifest(output.data)
+    assert manifest["summary"] == {
+        "total_rows": 100_000,
+        "included_rows": 50_000,
+        "sampled": True,
+        "sample_strategy": "head",
+    }
+    assert manifest["chunks"][0]["hash"] == hashlib.sha256(bytes(arrow_bytes)).hexdigest()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- install nteract output-buffer hooks on the thread that formats reference-backed output
- cover worker-thread Polars displays with a real kernel transport regression test
- cover the full kernel-to-daemon Arrow blob-store round trip

## Root cause

IPython publisher hooks are thread-local. The launcher installed its hook on the main kernel thread, but Polars formatting performed from a worker thread could stash Arrow bytes without attaching them to the outgoing display message. The manifest reached the frontend with a content hash, while the daemon never received the corresponding bytes, so the desktop blob fetch returned 404.

## Verification

- `cargo xtask lint --fix`
- `.venv/bin/python -m pytest python/nteract-kernel-launcher/tests/ -q` (123 passed)
- branch-built daemon integration: `python/runtimed/tests/test_dx_integration.py::test_polars_worker_thread_display_publishes_arrow_blob` (1 passed)
- `cargo xtask build --rust-only --skip-tauri`
