### PR TITLE
feat(node): publish native relay release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       wasm_changed: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || steps.filter.outputs.wasm == 'true' }}
       python_changed: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || steps.filter.outputs.python == 'true' }}
       node_changed: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || steps.filter.outputs.node == 'true' }}
+      node_release_changed: ${{ steps.filter.outputs.node_release == 'true' }}
       windows_changed: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || steps.filter.outputs.windows == 'true' }}
     steps:
       - uses: actions/checkout@v6
@@ -168,6 +169,20 @@ jobs:
               - "pnpm-lock.yaml"
               - "Cargo.toml"
               - "Cargo.lock"
+            node_release:
+              - ".github/workflows/build.yml"
+              - ".github/workflows/release-common.yml"
+              - ".github/workflows/publish-npm.yml"
+              - "packages/runtimed-node/**"
+              - "crates/runtimed-node/**"
+              - "crates/build-metadata/**"
+              - "crates/runt-workspace/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - "rust-toolchain.toml"
             windows:
               - ".github/workflows/build.yml"
               - "crates/notebook/nsis/**"
@@ -843,6 +858,12 @@ jobs:
       - name: Build runtimed-node N-API package
         run: pnpm --dir packages/runtimed-node build:debug
 
+      - name: Test runtimed-node release asset contract
+        run: pnpm --dir packages/runtimed-node test:release-assets
+
+      - name: Build runtimed daemon for native session integration
+        run: cargo build -p runtimed
+
       - name: Test runtimed-node Arrow IPC native integration
         run: vp test run packages/runtimed-node/tests/arrow-ipc.test.ts
         env:
@@ -859,6 +880,130 @@ jobs:
 
       - name: Check nteract pi package tarball
         run: pnpm --dir plugins/nteract/pi pack:dry-run
+
+  native-release-packages:
+    name: Native release package (${{ matrix.target }})
+    needs: [changes]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.node_release_changed == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            runner: macos-15
+            expected_arch: arm64
+            expected_rust_host: aarch64-apple-darwin
+          - target: darwin-x64
+            runner: macos-15-intel
+            expected_arch: x64
+            expected_rust_host: x86_64-apple-darwin
+          - target: linux-x64-gnu
+            runner: ubuntu-24.04
+            expected_arch: x64
+            expected_rust_host: x86_64-unknown-linux-gnu
+          - target: win32-x64-msvc
+            runner: windows-2025
+            expected_arch: x64
+            expected_rust_host: x86_64-pc-windows-msvc
+    env:
+      NTERACT_BUILD_GIT_HASH: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "runtimed-node-package-${{ matrix.target }}"
+
+      - uses: ./.github/actions/repair-macos-rust-toolchain
+        if: runner.os == 'macOS'
+
+      - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
+
+      - name: Set up Node with pnpm cache
+        if: runner.os != 'Windows'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Set up Node
+        if: runner.os == 'Windows'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Verify native runner architecture
+        shell: bash
+        env:
+          EXPECTED_ARCH: ${{ matrix.expected_arch }}
+          EXPECTED_RUST_HOST: ${{ matrix.expected_rust_host }}
+        run: |
+          NODE_ARCH=$(node -p "process.arch")
+          RUST_HOST=$(rustc --print host-tuple)
+          if [ "$NODE_ARCH" != "$EXPECTED_ARCH" ]; then
+            echo "::error::Node architecture $NODE_ARCH does not match expected $EXPECTED_ARCH for ${{ matrix.target }}"
+            exit 1
+          fi
+          if [ "$RUST_HOST" != "$EXPECTED_RUST_HOST" ]; then
+            echo "::error::Rust host $RUST_HOST does not match expected $EXPECTED_RUST_HOST for ${{ matrix.target }}"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build native binding
+        run: pnpm --dir packages/runtimed-node build
+
+      - name: Verify native binding source revision
+        shell: bash
+        run: |
+          ACTUAL_REVISION=$(node -e "process.stdout.write(require('./packages/runtimed-node/src/index.cjs').bindingSourceRevision())")
+          if [[ "$NTERACT_BUILD_GIT_HASH" != "$ACTUAL_REVISION"* ]]; then
+            echo "::error::Native binding source revision $ACTUAL_REVISION is not a prefix of $NTERACT_BUILD_GIT_HASH"
+            exit 1
+          fi
+
+      - name: Assemble, pack, and load release archives
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          RELEASE_VERSION="0.0.0-ci.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+          PLATFORM_PACK="$RUNNER_TEMP/platform-pack"
+          WRAPPER_PACK="$RUNNER_TEMP/wrapper-pack"
+          RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
+          mkdir -p "$PLATFORM_PACK" "$WRAPPER_PACK" "$RELEASE_ASSETS"
+
+          pnpm --dir packages/runtimed-node assemble:platform -- --expected-target "$TARGET"
+          pnpm --dir "packages/runtimed-node/npm/$TARGET" pack:dry-run
+          pnpm --dir "packages/runtimed-node/npm/$TARGET" pack --pack-destination "$PLATFORM_PACK"
+          node packages/runtimed-node/scripts/release-assets.mjs rename \
+            --release-version "$RELEASE_VERSION" \
+            --target "$TARGET" \
+            --input-dir "$PLATFORM_PACK" \
+            --output-dir "$RELEASE_ASSETS"
+
+          pnpm --dir packages/runtimed-node pack:release -- --output-dir "$WRAPPER_PACK"
+          node packages/runtimed-node/scripts/release-assets.mjs rename \
+            --release-version "$RELEASE_VERSION" \
+            --target wrapper \
+            --input-dir "$WRAPPER_PACK" \
+            --output-dir "$RELEASE_ASSETS"
+
+          node packages/runtimed-node/scripts/release-assets.mjs smoke \
+            --source-revision "$NTERACT_BUILD_GIT_HASH" \
+            --target "$TARGET" \
+            --wrapper "$RELEASE_ASSETS/runtimed-node-wrapper-${RELEASE_VERSION}.tgz" \
+            --platform "$RELEASE_ASSETS/runtimed-node-${TARGET}-${RELEASE_VERSION}.tgz"
 
   clippy-and-tests:
     name: Clippy & Tests (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,9 +174,10 @@ jobs:
               - ".github/workflows/release-common.yml"
               - ".github/workflows/publish-npm.yml"
               - "packages/runtimed-node/**"
-              - "crates/runtimed-node/**"
-              - "crates/build-metadata/**"
-              - "crates/runt-workspace/**"
+              # runtimed-node compiles a broad local Rust dependency graph into
+              # each native addon. Keep this conservative so a crate change
+              # cannot bypass the four-platform package/load matrix.
+              - "crates/**"
               - "package.json"
               - "pnpm-lock.yaml"
               - "pnpm-workspace.yaml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -964,15 +964,6 @@ jobs:
       - name: Build native binding
         run: pnpm --dir packages/runtimed-node build
 
-      - name: Verify native binding source revision
-        shell: bash
-        run: |
-          ACTUAL_REVISION=$(node -e "process.stdout.write(require('./packages/runtimed-node/src/index.cjs').bindingSourceRevision())")
-          if [[ "$NTERACT_BUILD_GIT_HASH" != "$ACTUAL_REVISION"* ]]; then
-            echo "::error::Native binding source revision $ACTUAL_REVISION is not a prefix of $NTERACT_BUILD_GIT_HASH"
-            exit 1
-          fi
-
       - name: Assemble, pack, and load release archives
         shell: bash
         env:
@@ -1001,7 +992,6 @@ jobs:
             --output-dir "$RELEASE_ASSETS"
 
           node packages/runtimed-node/scripts/release-assets.mjs smoke \
-            --source-revision "$NTERACT_BUILD_GIT_HASH" \
             --target "$TARGET" \
             --wrapper "$RELEASE_ASSETS/runtimed-node-wrapper-${RELEASE_VERSION}.tgz" \
             --platform "$RELEASE_ASSETS/runtimed-node-${TARGET}-${RELEASE_VERSION}.tgz"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,12 +50,20 @@ jobs:
         include:
           - target: darwin-arm64
             runner: macos-latest
+            expected_arch: arm64
+            expected_rust_host: aarch64-apple-darwin
           - target: darwin-x64
-            runner: macos-14
+            runner: macos-15-intel
+            expected_arch: x64
+            expected_rust_host: x86_64-apple-darwin
           - target: linux-x64-gnu
             runner: ubuntu-latest
+            expected_arch: x64
+            expected_rust_host: x86_64-unknown-linux-gnu
           - target: win32-x64-msvc
             runner: windows-latest
+            expected_arch: x64
+            expected_rust_host: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,6 +80,23 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
+
+      - name: Verify native runner architecture
+        shell: bash
+        env:
+          EXPECTED_ARCH: ${{ matrix.expected_arch }}
+          EXPECTED_RUST_HOST: ${{ matrix.expected_rust_host }}
+        run: |
+          NODE_ARCH=$(node -p "process.arch")
+          RUST_HOST=$(rustc --print host-tuple)
+          if [ "$NODE_ARCH" != "$EXPECTED_ARCH" ]; then
+            echo "::error::Node architecture $NODE_ARCH does not match expected $EXPECTED_ARCH for ${{ matrix.target }}"
+            exit 1
+          fi
+          if [ "$RUST_HOST" != "$EXPECTED_RUST_HOST" ]; then
+            echo "::error::Rust host $RUST_HOST does not match expected $EXPECTED_RUST_HOST for ${{ matrix.target }}"
+            exit 1
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,6 +11,7 @@ name: Publish npm packages
 # Before using this workflow, configure npm trusted publishing for:
 # - @runtimed/node
 # - @runtimed/node-darwin-arm64
+# - @runtimed/node-darwin-x64
 # - @runtimed/node-linux-x64-gnu
 # - @runtimed/node-win32-x64-msvc
 # - @nteract/pi
@@ -49,6 +50,8 @@ jobs:
         include:
           - target: darwin-arm64
             runner: macos-latest
+          - target: darwin-x64
+            runner: macos-14
           - target: linux-x64-gnu
             runner: ubuntu-latest
           - target: win32-x64-msvc
@@ -105,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [darwin-arm64, linux-x64-gnu, win32-x64-msvc]
+        target: [darwin-arm64, darwin-x64, linux-x64-gnu, win32-x64-msvc]
     steps:
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -113,6 +113,8 @@ jobs:
     name: Build runtimed-node release asset (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     needs: [compute-version]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1689,7 +1689,7 @@ jobs:
             echo "| macOS | x64 (Intel) | \`${DAEMON_NAME}-darwin-x64\` |"
             echo "| Windows | x64 | \`${DAEMON_NAME}-windows-x64.exe\` |"
             echo ''
-            echo '### `@runtimed/node` (embedding)'
+            echo "### \`@runtimed/node\` (embedding)"
             echo ''
             echo 'Install the wrapper archive together with exactly one native platform archive. The asset manifest records the npm package version and source revision for the set.'
             echo ''

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -119,12 +119,20 @@ jobs:
         include:
           - target: darwin-arm64
             runner: macos-15
+            expected_arch: arm64
+            expected_rust_host: aarch64-apple-darwin
           - target: darwin-x64
-            runner: macos-14
+            runner: macos-15-intel
+            expected_arch: x64
+            expected_rust_host: x86_64-apple-darwin
           - target: linux-x64-gnu
             runner: ubuntu-24.04
+            expected_arch: x64
+            expected_rust_host: x86_64-unknown-linux-gnu
           - target: win32-x64-msvc
             runner: windows-2025
+            expected_arch: x64
+            expected_rust_host: x86_64-pc-windows-msvc
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -157,6 +165,23 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
+
+      - name: Verify native runner architecture
+        shell: bash
+        env:
+          EXPECTED_ARCH: ${{ matrix.expected_arch }}
+          EXPECTED_RUST_HOST: ${{ matrix.expected_rust_host }}
+        run: |
+          NODE_ARCH=$(node -p "process.arch")
+          RUST_HOST=$(rustc --print host-tuple)
+          if [ "$NODE_ARCH" != "$EXPECTED_ARCH" ]; then
+            echo "::error::Node architecture $NODE_ARCH does not match expected $EXPECTED_ARCH for ${{ matrix.target }}"
+            exit 1
+          fi
+          if [ "$RUST_HOST" != "$EXPECTED_RUST_HOST" ]; then
+            echo "::error::Rust host $RUST_HOST does not match expected $EXPECTED_RUST_HOST for ${{ matrix.target }}"
+            exit 1
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -109,6 +109,111 @@ jobs:
             apps/notebook/src/renderer-plugins/
             target/xtask/*.fingerprint
 
+  build-runtimed-node:
+    name: Build runtimed-node release asset (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    needs: [compute-version]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            runner: macos-15
+          - target: darwin-x64
+            runner: macos-14
+          - target: linux-x64-gnu
+            runner: ubuntu-24.04
+          - target: win32-x64-msvc
+            runner: windows-2025
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Set up Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "runtimed-node-release-${{ matrix.target }}"
+
+      - uses: ./.github/actions/repair-macos-rust-toolchain
+        if: runner.os == 'macOS'
+
+      - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
+
+      - name: Set up Node with pnpm cache
+        if: runner.os != 'Windows'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Set up Node
+        if: runner.os == 'Windows'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test release asset contract
+        if: matrix.target == 'linux-x64-gnu'
+        run: pnpm --dir packages/runtimed-node test:release-assets
+
+      - name: Build native binding
+        run: pnpm --dir packages/runtimed-node build
+
+      - name: Verify native binding source revision
+        shell: bash
+        run: |
+          ACTUAL_REVISION=$(node -e "process.stdout.write(require('./packages/runtimed-node/src/index.cjs').bindingSourceRevision())")
+          if [[ "$GITHUB_SHA" != "$ACTUAL_REVISION"* ]]; then
+            echo "::error::Native binding source revision $ACTUAL_REVISION is not a prefix of release commit $GITHUB_SHA"
+            exit 1
+          fi
+
+      - name: Assemble and verify platform package
+        run: |
+          pnpm --dir packages/runtimed-node assemble:platform -- --expected-target "${{ matrix.target }}"
+          pnpm --dir packages/runtimed-node/npm/${{ matrix.target }} pack:dry-run
+
+      - name: Pack deterministic platform release asset
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/platform-pack" "$RUNNER_TEMP/release-assets"
+          pnpm --dir packages/runtimed-node/npm/${{ matrix.target }} pack --pack-destination "$RUNNER_TEMP/platform-pack"
+          node packages/runtimed-node/scripts/release-assets.mjs rename \
+            --release-version "${{ needs.compute-version.outputs.version }}" \
+            --target "${{ matrix.target }}" \
+            --input-dir "$RUNNER_TEMP/platform-pack" \
+            --output-dir "$RUNNER_TEMP/release-assets"
+
+      - name: Pack deterministic wrapper release asset
+        if: matrix.target == 'linux-x64-gnu'
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/wrapper-pack"
+          pnpm --dir packages/runtimed-node pack:dry-run
+          pnpm --dir packages/runtimed-node pack --pack-destination "$RUNNER_TEMP/wrapper-pack"
+          node packages/runtimed-node/scripts/release-assets.mjs rename \
+            --release-version "${{ needs.compute-version.outputs.version }}" \
+            --target wrapper \
+            --input-dir "$RUNNER_TEMP/wrapper-pack" \
+            --output-dir "$RUNNER_TEMP/release-assets"
+
+      - name: Upload runtimed-node release asset
+        uses: actions/upload-artifact@v7
+        with:
+          name: runtimed-node-release-${{ matrix.target }}
+          path: ${{ runner.temp }}/release-assets/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
   build-linux:
     name: Build Linux Executables
     runs-on: ubuntu-22.04
@@ -1185,6 +1290,7 @@ jobs:
         build-notebook-linux-x64,
         smoke-fedora-appimage,
         build-python-wheels,
+        build-runtimed-node,
       ]
     steps:
       - name: Checkout
@@ -1263,6 +1369,24 @@ jobs:
           name: nteract-linux-x64
           path: ./notebook-linux-x64
 
+      - name: Download runtimed-node release assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: runtimed-node-release-*
+          path: ./runtimed-node-assets
+          merge-multiple: true
+
+      - name: Verify runtimed-node assets and generate manifest
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          node packages/runtimed-node/scripts/release-assets.mjs manifest \
+            --release-version "$VERSION" \
+            --source-revision "$SOURCE_REVISION" \
+            --assets-dir runtimed-node-assets \
+            --output "runtimed-node-assets/runtimed-node-assets-${VERSION}.json"
+
       - name: Report downloaded release artifact sizes
         run: |
           echo "Downloaded artifact directories:"
@@ -1271,7 +1395,8 @@ jobs:
             notebook-macos-arm64 \
             notebook-macos-x64 \
             notebook-windows-x64 \
-            notebook-linux-x64
+            notebook-linux-x64 \
+            runtimed-node-assets
           echo ""
           echo "Downloaded artifact files:"
           find \
@@ -1280,6 +1405,7 @@ jobs:
             notebook-macos-x64 \
             notebook-windows-x64 \
             notebook-linux-x64 \
+            runtimed-node-assets \
             -type f -printf "%12s  %p\n" | sort -nr
 
       - name: Prepare release assets
@@ -1324,6 +1450,10 @@ jobs:
           cp "notebook-macos-x64/nteract-${CHANNEL}-darwin-x64.app.tar.gz.sig" release-assets/
           cp "notebook-windows-x64/nteract-${CHANNEL}-windows-x64.exe.sig" release-assets/
           cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.AppImage.sig" release-assets/ 2>/dev/null || true
+          # Node wrapper + native packages for embedding hosts. Their filenames
+          # use the nteract release version while package.json retains the npm
+          # package version validated by the release manifest.
+          cp runtimed-node-assets/* release-assets/
 
       - name: Generate updater manifest (latest.json)
         env:
@@ -1534,6 +1664,19 @@ jobs:
             echo "| macOS | x64 (Intel) | \`${DAEMON_NAME}-darwin-x64\` |"
             echo "| Windows | x64 | \`${DAEMON_NAME}-windows-x64.exe\` |"
             echo ''
+            echo '### `@runtimed/node` (embedding)'
+            echo ''
+            echo 'Install the wrapper archive together with exactly one native platform archive. The asset manifest records the npm package version and source revision for the set.'
+            echo ''
+            echo '| Platform | Architecture | Native archive |'
+            echo '|----------|--------------|----------------|'
+            echo "| macOS | ARM64 (Apple Silicon) | \`runtimed-node-darwin-arm64-${TAG_NAME#v}.tgz\` |"
+            echo "| macOS | x64 (Intel) | \`runtimed-node-darwin-x64-${TAG_NAME#v}.tgz\` |"
+            echo "| Linux (glibc) | x64 | \`runtimed-node-linux-x64-gnu-${TAG_NAME#v}.tgz\` |"
+            echo "| Windows | x64 | \`runtimed-node-win32-x64-msvc-${TAG_NAME#v}.tgz\` |"
+            echo ''
+            echo "Wrapper: \`runtimed-node-wrapper-${TAG_NAME#v}.tgz\`. Manifest: \`runtimed-node-assets-${TAG_NAME#v}.json\`. Verify each downloaded archive against the SHA-256 \`digest\` returned for that asset by the GitHub Releases API before unpacking it."
+            echo ''
             echo '## Release highlights'
             echo ''
             cat release-highlights.md
@@ -1579,6 +1722,8 @@ jobs:
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-x64.app.tar.gz.sig
             ./release-assets/nteract-${{ inputs.version_suffix }}-windows-x64.exe
             ./release-assets/nteract-${{ inputs.version_suffix }}-windows-x64.exe.sig
+            ./release-assets/runtimed-node-*.tgz
+            ./release-assets/runtimed-node-assets-*.json
             ./release-assets/latest.json
             ./wheels/*.whl
 

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -195,15 +195,6 @@ jobs:
       - name: Build native binding
         run: pnpm --dir packages/runtimed-node build
 
-      - name: Verify native binding source revision
-        shell: bash
-        run: |
-          ACTUAL_REVISION=$(node -e "process.stdout.write(require('./packages/runtimed-node/src/index.cjs').bindingSourceRevision())")
-          if [[ "$GITHUB_SHA" != "$ACTUAL_REVISION"* ]]; then
-            echo "::error::Native binding source revision $ACTUAL_REVISION is not a prefix of release commit $GITHUB_SHA"
-            exit 1
-          fi
-
       - name: Assemble and verify platform package
         run: |
           pnpm --dir packages/runtimed-node assemble:platform -- --expected-target "${{ matrix.target }}"
@@ -236,7 +227,6 @@ jobs:
             exit 1
           fi
           node packages/runtimed-node/scripts/release-assets.mjs smoke \
-            --source-revision "$GITHUB_SHA" \
             --target "${{ matrix.target }}" \
             --wrapper "$WRAPPER_ARCHIVE" \
             --platform "$RUNNER_TEMP/release-assets/runtimed-node-${{ matrix.target }}-${{ needs.compute-version.outputs.version }}.tgz"

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -218,13 +218,31 @@ jobs:
             --input-dir "$RUNNER_TEMP/platform-pack" \
             --output-dir "$RUNNER_TEMP/release-assets"
 
-      - name: Pack deterministic wrapper release asset
-        if: matrix.target == 'linux-x64-gnu'
+      - name: Pack deterministic wrapper package
         shell: bash
         run: |
           mkdir -p "$RUNNER_TEMP/wrapper-pack"
           pnpm --dir packages/runtimed-node pack:dry-run
-          pnpm --dir packages/runtimed-node pack --pack-destination "$RUNNER_TEMP/wrapper-pack"
+          pnpm --dir packages/runtimed-node pack:release -- --output-dir "$RUNNER_TEMP/wrapper-pack"
+
+      - name: Load isolated release archives
+        shell: bash
+        run: |
+          WRAPPER_ARCHIVE=$(find "$RUNNER_TEMP/wrapper-pack" -maxdepth 1 -name '*.tgz' -print -quit)
+          if [ -z "$WRAPPER_ARCHIVE" ]; then
+            echo "::error::No wrapper package tarball found"
+            exit 1
+          fi
+          node packages/runtimed-node/scripts/release-assets.mjs smoke \
+            --source-revision "$GITHUB_SHA" \
+            --target "${{ matrix.target }}" \
+            --wrapper "$WRAPPER_ARCHIVE" \
+            --platform "$RUNNER_TEMP/release-assets/runtimed-node-${{ matrix.target }}-${{ needs.compute-version.outputs.version }}.tgz"
+
+      - name: Add wrapper release asset
+        if: matrix.target == 'linux-x64-gnu'
+        shell: bash
+        run: |
           node packages/runtimed-node/scripts/release-assets.mjs rename \
             --release-version "${{ needs.compute-version.outputs.version }}" \
             --target wrapper \

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -281,6 +281,11 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "packages/runtimed-node/npm/darwin-x64/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
         path: "packages/runtimed-node/npm/linux-x64-gnu/package.json",
         format: Format::Json,
         matches: 1,

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -150,9 +150,11 @@ The manifest's `source_revision` is the full nteract release commit and
 binding. Packaged hosts should require the latter to match
 `bindingSourceRevision()` and the commit suffix carried by the selected daemon,
 and require the full revision to match any notebook web manifest before opening
-the browser peer. The workflow also loads each native binding on its build
-runner and checks that `bindingSourceRevision()` identifies the release commit
-before it can be attached to a release.
+the browser peer. The `node_api_version` field records the minimum Node-API
+level; a host must check `Number(process.versions.napi)` before loading the
+native package. The workflow also loads each native binding on its build runner
+and checks that `bindingSourceRevision()` identifies the release commit before
+it can be attached to a release.
 
 ## Basic Usage
 

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -145,6 +145,13 @@ asset record to contain a `sha256:` `digest` and verify that digest against the
 downloaded bytes. The manifest intentionally does not duplicate checksums;
 GitHub's asset digest is authoritative.
 
+For hosts that extract the two archives directly, `@runtimed/node/relay` is the
+self-contained embedding surface: it needs only the wrapper and matching native
+package. The package root (`@runtimed/node`) also exposes the higher-level
+session API and requires its normal runtime dependencies, including `rxjs`.
+Install the archives through a package manager or supply those declared
+dependencies in the host when using the package root.
+
 The manifest's `source_revision` is the full nteract release commit and
 `binding_source_revision` is the short revision compiled into the native
 binding. Packaged hosts should require the latter to match

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -122,6 +122,38 @@ npm install @runtimed/node
 The native binding is installed through an optional platform package such as
 `@runtimed/node-darwin-arm64` or `@runtimed/node-linux-x64-gnu`.
 
+Embedding hosts that acquire binaries without npm can use the matching nteract
+GitHub release instead. Every release publishes a wrapper archive, one native
+archive per supported desktop target, and a JSON asset manifest. Archive names
+use the nteract release version so the wrapper, native binding, daemon, and web
+assets can be selected from one immutable release even though the npm package
+inside each archive has its own version:
+
+| Target | Release archive |
+|---|---|
+| Wrapper | `runtimed-node-wrapper-${releaseVersion}.tgz` |
+| macOS arm64 | `runtimed-node-darwin-arm64-${releaseVersion}.tgz` |
+| macOS x64 | `runtimed-node-darwin-x64-${releaseVersion}.tgz` |
+| Linux x64 (glibc) | `runtimed-node-linux-x64-gnu-${releaseVersion}.tgz` |
+| Windows x64 | `runtimed-node-win32-x64-msvc-${releaseVersion}.tgz` |
+| Asset manifest | `runtimed-node-assets-${releaseVersion}.json` |
+
+Download the wrapper and exactly one native archive. Install them as the
+package names recorded in the manifest (`@runtimed/node` and its matching
+optional platform package). Before unpacking, require the GitHub Releases API
+asset record to contain a `sha256:` `digest` and verify that digest against the
+downloaded bytes. The manifest intentionally does not duplicate checksums;
+GitHub's asset digest is authoritative.
+
+The manifest's `source_revision` is the full nteract release commit and
+`binding_source_revision` is the short revision compiled into the native
+binding. Packaged hosts should require the latter to match
+`bindingSourceRevision()` and the commit suffix carried by the selected daemon,
+and require the full revision to match any notebook web manifest before opening
+the browser peer. The workflow also loads each native binding on its build
+runner and checks that `bindingSourceRevision()` identifies the release commit
+before it can be attached to a release.
+
 ## Basic Usage
 
 ```js
@@ -265,6 +297,8 @@ The platform packages are implementation details and should normally be
 installed through `@runtimed/node`:
 
 - `@runtimed/node-darwin-arm64`
+- `@runtimed/node-darwin-x64`
 - `@runtimed/node-linux-x64-gnu`
+- `@runtimed/node-win32-x64-msvc`
 
 They contain only the compiled native `.node` binary for their target platform.

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -152,16 +152,14 @@ session API and requires its normal runtime dependencies, including `rxjs`.
 Install the archives through a package manager or supply those declared
 dependencies in the host when using the package root.
 
-The manifest's `source_revision` is the full nteract release commit and
-`binding_source_revision` is the short revision compiled into the native
-binding. Packaged hosts should require the latter to match
-`bindingSourceRevision()` and the commit suffix carried by the selected daemon,
-and require the full revision to match any notebook web manifest before opening
-the browser peer. The `node_api_version` field records the minimum Node-API
-level; a host must check `Number(process.versions.napi)` before loading the
-native package. The workflow also loads each native binding on its build runner
-and checks that `bindingSourceRevision()` identifies the release commit before
-it can be attached to a release.
+The manifest's `source_revision` records release provenance so a downloaded set
+can be audited and reproduced. It is not a runtime compatibility gate: hosts
+must not require it to match the daemon or notebook web bundle. Compatibility is
+established by the relay handshake's protocol number and versioned semantic
+capabilities. The `node_api_version` field records the native package's minimum
+Node-API level; a host must check `Number(process.versions.napi)` before loading
+it. The workflow loads each native binding on its build runner and verifies the
+public relay surface before attaching the archives to a release.
 
 ## Basic Usage
 

--- a/packages/runtimed-node/npm/darwin-x64/README.md
+++ b/packages/runtimed-node/npm/darwin-x64/README.md
@@ -1,0 +1,11 @@
+# @runtimed/node-darwin-x64
+
+Native macOS x64 binding for `@runtimed/node`.
+
+This package contains the compiled N-API `.node` binary used by
+`@runtimed/node` on Intel Macs. Install `@runtimed/node` directly unless you are
+debugging or publishing the platform package itself.
+
+```bash
+npm install @runtimed/node
+```

--- a/packages/runtimed-node/npm/darwin-x64/package.json
+++ b/packages/runtimed-node/npm/darwin-x64/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@runtimed/node-darwin-x64",
+  "version": "0.4.3",
+  "description": "macOS x64 native N-API binding for @runtimed/node.",
+  "type": "commonjs",
+  "main": "./runtimed-node.darwin-x64.node",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nteract/nteract.git",
+    "directory": "packages/runtimed-node/npm/darwin-x64"
+  },
+  "homepage": "https://github.com/nteract/nteract/tree/main/packages/runtimed-node#readme",
+  "bugs": {
+    "url": "https://github.com/nteract/nteract/issues"
+  },
+  "keywords": [
+    "nteract",
+    "runtimed",
+    "notebook",
+    "native",
+    "napi-rs",
+    "darwin",
+    "x64"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "README.md",
+    "runtimed-node.darwin-x64.node"
+  ],
+  "scripts": {
+    "prepack": "node -e \"const fs = require('node:fs'); if (!fs.existsSync('runtimed-node.darwin-x64.node')) { console.error('Run pnpm --dir packages/runtimed-node assemble:platform before packing @runtimed/node-darwin-x64.'); process.exit(1); }\"",
+    "pack:dry-run": "pnpm pack --dry-run"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -64,6 +64,7 @@
     "pack:platform:dry-run": "node scripts/assemble-platform-package.mjs --pack-dry-run",
     "prepack": "node -e \"const fs = require('node:fs'); const files = fs.readdirSync('src'); if (!files.includes('binding.cjs') || !files.includes('binding.d.ts')) { console.error('Run pnpm --dir packages/runtimed-node build before packing @runtimed/node.'); process.exit(1); }\"",
     "pack:dry-run": "pnpm pack --dry-run",
+    "pack:release": "node scripts/release-assets.mjs pack-wrapper",
     "test:release-assets": "node --test scripts/release-assets.test.mjs",
     "smoke": "node -e \"const m = require('./src/index.cjs'); console.log('defaultSocketPath:', m.defaultSocketPath());\"",
     "smoke:relay": "node scripts/smoke-relay.cjs",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -52,6 +52,7 @@
     "binaryName": "runtimed-node",
     "targets": [
       "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
       "x86_64-unknown-linux-gnu",
       "x86_64-pc-windows-msvc"
     ]
@@ -63,6 +64,7 @@
     "pack:platform:dry-run": "node scripts/assemble-platform-package.mjs --pack-dry-run",
     "prepack": "node -e \"const fs = require('node:fs'); const files = fs.readdirSync('src'); if (!files.includes('binding.cjs') || !files.includes('binding.d.ts')) { console.error('Run pnpm --dir packages/runtimed-node build before packing @runtimed/node.'); process.exit(1); }\"",
     "pack:dry-run": "pnpm pack --dry-run",
+    "test:release-assets": "node --test scripts/release-assets.test.mjs",
     "smoke": "node -e \"const m = require('./src/index.cjs'); console.log('defaultSocketPath:', m.defaultSocketPath());\"",
     "smoke:relay": "node scripts/smoke-relay.cjs",
     "smoke:api": "node scripts/smoke-api.cjs"
@@ -72,6 +74,7 @@
   },
   "optionalDependencies": {
     "@runtimed/node-darwin-arm64": "workspace:*",
+    "@runtimed/node-darwin-x64": "workspace:*",
     "@runtimed/node-linux-x64-gnu": "workspace:*",
     "@runtimed/node-win32-x64-msvc": "workspace:*"
   },

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -256,14 +256,26 @@ function archiveCommand(archive, argsBeforeArchive, argsAfterArchive = []) {
   });
 }
 
-function extractArchive(archive, destination) {
-  const result = archiveCommand(
-    archive,
-    ["-xzf"],
-    ["-C", resolve(destination), "--strip-components=1"],
+export function extractArchive(archive, destination) {
+  const resolvedDestination = resolve(destination);
+  mkdirSync(resolvedDestination, { recursive: true });
+  const archiveStagingDirectory = mkdtempSync(
+    join(resolvedDestination, ".runtimed-node-release-archive-"),
   );
-  if (result.status !== 0) {
-    throw new Error(`Could not extract ${archive}: ${result.stderr || result.stdout}`);
+  const stagedArchive = join(archiveStagingDirectory, "package.tgz");
+
+  try {
+    copyFileSync(resolve(archive), stagedArchive);
+    const result = spawnSync(
+      "tar",
+      ["-xzf", basename(stagedArchive), "-C", "..", "--strip-components=1"],
+      { cwd: archiveStagingDirectory, encoding: "utf8" },
+    );
+    if (result.status !== 0) {
+      throw new Error(`Could not extract ${archive}: ${result.stderr || result.stdout}`);
+    }
+  } finally {
+    rmSync(archiveStagingDirectory, { recursive: true, force: true });
   }
 }
 

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -85,6 +85,7 @@ export function buildReleaseManifest({ releaseVersion, sourceRevision, packageVe
     source_revision: sourceRevision,
     binding_source_revision: sourceRevision.slice(0, 7),
     npm_package_version: packageVersion,
+    node_api_version: 9,
     wrapper: {
       package: RELEASE_TARGETS.wrapper.packageName,
       asset: releaseAssetName("wrapper", releaseVersion),

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -13,13 +13,27 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = resolve(SCRIPT_DIRECTORY, "..");
 const WORKSPACE_ROOT = resolve(PACKAGE_ROOT, "../..");
 const NODE_CRATE_MANIFEST = join(WORKSPACE_ROOT, "crates/runtimed-node/Cargo.toml");
+const RELAY_SMOKE_SCRIPT = `"use strict";
+const { writeFileSync } = require("node:fs");
+const relay = require("@runtimed/node/relay");
+if (typeof relay.bindingSourceRevision !== "function") {
+  throw new Error("Extracted @runtimed/node/relay does not expose bindingSourceRevision()");
+}
+const actualRevision = relay.bindingSourceRevision();
+const sourceRevision = process.argv[2];
+if (!sourceRevision.startsWith(actualRevision)) {
+  throw new Error(
+    \`Extracted binding revision \${actualRevision} is not a prefix of \${sourceRevision}\`,
+  );
+}
+writeFileSync(process.argv[3], JSON.stringify({ actualRevision }));
+`;
 
 export const RELEASE_TARGETS = Object.freeze({
   wrapper: Object.freeze({
@@ -230,21 +244,39 @@ export function smokeReleasePair({ wrapperArchive, platformArchive, target, sour
     mkdirSync(platformDirectory, { recursive: true });
     extractArchive(wrapperArchive, wrapperDirectory);
     extractArchive(platformArchive, platformDirectory);
-    const require = createRequire(join(stagingDirectory, "release-asset-smoke.cjs"));
-    const relay = require("@runtimed/node/relay");
-    if (typeof relay.bindingSourceRevision !== "function") {
-      throw new Error("Extracted @runtimed/node/relay does not expose bindingSourceRevision()");
-    }
-    const actualRevision = relay.bindingSourceRevision();
-    if (!sourceRevision.startsWith(actualRevision)) {
-      throw new Error(
-        `Extracted binding revision ${actualRevision} is not a prefix of ${sourceRevision}`,
-      );
-    }
+    const actualRevision = runRelaySmokeChild({ stagingDirectory, sourceRevision });
     console.log(`${target}: loaded @runtimed/node/relay at ${actualRevision}`);
     return actualRevision;
   } finally {
     rmSync(stagingDirectory, { recursive: true, force: true });
+  }
+}
+
+export function runRelaySmokeChild({ stagingDirectory, sourceRevision }) {
+  const resolvedStagingDirectory = resolve(stagingDirectory);
+  const smokeScript = join(resolvedStagingDirectory, "release-asset-smoke.cjs");
+  const smokeResult = join(resolvedStagingDirectory, "release-asset-smoke-result.json");
+  writeFileSync(smokeScript, RELAY_SMOKE_SCRIPT);
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [basename(smokeScript), sourceRevision, basename(smokeResult)],
+      { cwd: resolvedStagingDirectory, encoding: "utf8" },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `Could not load extracted @runtimed/node/relay: ${result.stderr || result.stdout || result.error}`,
+      );
+    }
+    const payload = JSON.parse(readFileSync(smokeResult, "utf8"));
+    if (typeof payload.actualRevision !== "string" || payload.actualRevision.length === 0) {
+      throw new Error("Extracted relay smoke result did not contain a source revision");
+    }
+    return payload.actualRevision;
+  } finally {
+    rmSync(smokeScript, { force: true });
+    rmSync(smokeResult, { force: true });
   }
 }
 

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -225,8 +225,8 @@ export function smokeReleasePair({ wrapperArchive, platformArchive, target, sour
   try {
     mkdirSync(wrapperDirectory, { recursive: true });
     mkdirSync(platformDirectory, { recursive: true });
-    run("tar", ["-xzf", resolve(wrapperArchive), "-C", wrapperDirectory, "--strip-components=1"]);
-    run("tar", ["-xzf", resolve(platformArchive), "-C", platformDirectory, "--strip-components=1"]);
+    extractArchive(wrapperArchive, wrapperDirectory);
+    extractArchive(platformArchive, platformDirectory);
     const require = createRequire(join(stagingDirectory, "release-asset-smoke.cjs"));
     const relay = require("@runtimed/node/relay");
     if (typeof relay.bindingSourceRevision !== "function") {
@@ -245,8 +245,27 @@ export function smokeReleasePair({ wrapperArchive, platformArchive, target, sour
   }
 }
 
+function archiveCommand(archive, argsBeforeArchive, argsAfterArchive = []) {
+  const resolvedArchive = resolve(archive);
+  return spawnSync("tar", [...argsBeforeArchive, basename(resolvedArchive), ...argsAfterArchive], {
+    cwd: dirname(resolvedArchive),
+    encoding: "utf8",
+  });
+}
+
+function extractArchive(archive, destination) {
+  const result = archiveCommand(
+    archive,
+    ["-xzf"],
+    ["-C", resolve(destination), "--strip-components=1"],
+  );
+  if (result.status !== 0) {
+    throw new Error(`Could not extract ${archive}: ${result.stderr || result.stdout}`);
+  }
+}
+
 function tarOutput(archive, args) {
-  const result = spawnSync("tar", [...args, archive], { encoding: "utf8" });
+  const result = archiveCommand(archive, args);
   if (result.status !== 0) {
     throw new Error(`tar ${args.join(" ")} ${archive} failed: ${result.stderr || result.stdout}`);
   }
@@ -254,9 +273,7 @@ function tarOutput(archive, args) {
 }
 
 function readPackageManifest(archive) {
-  const result = spawnSync("tar", ["-xOf", archive, "package/package.json"], {
-    encoding: "utf8",
-  });
+  const result = archiveCommand(archive, ["-xOf"], ["package/package.json"]);
   if (result.status !== 0) {
     throw new Error(
       `Could not read package/package.json from ${archive}: ${result.stderr || result.stdout}`,

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import { copyFileSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const RELEASE_TARGETS = Object.freeze({
+  wrapper: Object.freeze({
+    assetStem: "runtimed-node-wrapper",
+    packageName: "@runtimed/node",
+  }),
+  "darwin-arm64": Object.freeze({
+    assetStem: "runtimed-node-darwin-arm64",
+    packageName: "@runtimed/node-darwin-arm64",
+    os: "darwin",
+    cpu: "arm64",
+    binary: "runtimed-node.darwin-arm64.node",
+  }),
+  "darwin-x64": Object.freeze({
+    assetStem: "runtimed-node-darwin-x64",
+    packageName: "@runtimed/node-darwin-x64",
+    os: "darwin",
+    cpu: "x64",
+    binary: "runtimed-node.darwin-x64.node",
+  }),
+  "linux-x64-gnu": Object.freeze({
+    assetStem: "runtimed-node-linux-x64-gnu",
+    packageName: "@runtimed/node-linux-x64-gnu",
+    os: "linux",
+    cpu: "x64",
+    libc: "glibc",
+    binary: "runtimed-node.linux-x64-gnu.node",
+  }),
+  "win32-x64-msvc": Object.freeze({
+    assetStem: "runtimed-node-win32-x64-msvc",
+    packageName: "@runtimed/node-win32-x64-msvc",
+    os: "win32",
+    cpu: "x64",
+    binary: "runtimed-node.win32-x64-msvc.node",
+  }),
+});
+
+const PLATFORM_TARGETS = Object.keys(RELEASE_TARGETS).filter((target) => target !== "wrapper");
+
+function assertToken(label, value) {
+  if (!value || !/^[0-9A-Za-z][0-9A-Za-z._+-]*$/.test(value)) {
+    throw new Error(
+      `${label} must be a non-empty release-safe token; received ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+function targetConfig(target) {
+  if (!Object.hasOwn(RELEASE_TARGETS, target)) {
+    throw new Error(`Unsupported runtimed-node release target ${JSON.stringify(target)}`);
+  }
+  return RELEASE_TARGETS[target];
+}
+
+export function releaseAssetName(target, releaseVersion) {
+  assertToken("release version", releaseVersion);
+  return `${targetConfig(target).assetStem}-${releaseVersion}.tgz`;
+}
+
+export function releaseManifestName(releaseVersion) {
+  assertToken("release version", releaseVersion);
+  return `runtimed-node-assets-${releaseVersion}.json`;
+}
+
+export function buildReleaseManifest({ releaseVersion, sourceRevision, packageVersion }) {
+  assertToken("release version", releaseVersion);
+  if (!/^[0-9a-f]{40}$/.test(sourceRevision)) {
+    throw new Error(
+      `source revision must be a full lowercase Git commit SHA; received ${sourceRevision}`,
+    );
+  }
+  if (!packageVersion) {
+    throw new Error("package version is required");
+  }
+
+  return {
+    schema_version: 1,
+    release_version: releaseVersion,
+    source_revision: sourceRevision,
+    binding_source_revision: sourceRevision.slice(0, 7),
+    npm_package_version: packageVersion,
+    wrapper: {
+      package: RELEASE_TARGETS.wrapper.packageName,
+      asset: releaseAssetName("wrapper", releaseVersion),
+    },
+    platforms: Object.fromEntries(
+      PLATFORM_TARGETS.map((target) => {
+        const config = RELEASE_TARGETS[target];
+        return [
+          target,
+          {
+            package: config.packageName,
+            asset: releaseAssetName(target, releaseVersion),
+            os: config.os,
+            cpu: config.cpu,
+            ...(config.libc ? { libc: config.libc } : {}),
+          },
+        ];
+      }),
+    ),
+  };
+}
+
+function tarOutput(archive, args) {
+  const result = spawnSync("tar", [...args, archive], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`tar ${args.join(" ")} ${archive} failed: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+function readPackageManifest(archive) {
+  const result = spawnSync("tar", ["-xOf", archive, "package/package.json"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Could not read package/package.json from ${archive}: ${result.stderr || result.stdout}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function listArchiveFiles(archive) {
+  return tarOutput(archive, ["-tzf"])
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((file) => file.replace(/^\.\//, ""));
+}
+
+function assertPackage(target, archive, expectedVersion) {
+  const config = targetConfig(target);
+  const manifest = readPackageManifest(archive);
+  if (manifest.name !== config.packageName) {
+    throw new Error(
+      `${basename(archive)} contains ${manifest.name}; expected ${config.packageName}`,
+    );
+  }
+  if (expectedVersion && manifest.version !== expectedVersion) {
+    throw new Error(
+      `${basename(archive)} contains package version ${manifest.version}; expected ${expectedVersion}`,
+    );
+  }
+
+  if (target === "wrapper") {
+    const optionalDependencies = manifest.optionalDependencies ?? {};
+    const expectedPackages = PLATFORM_TARGETS.map(
+      (platform) => RELEASE_TARGETS[platform].packageName,
+    );
+    const actualPackages = Object.keys(optionalDependencies).sort();
+    if (JSON.stringify(actualPackages) !== JSON.stringify(expectedPackages.sort())) {
+      throw new Error(
+        `Wrapper optional dependencies are ${actualPackages.join(", ")}; expected ${expectedPackages.join(", ")}`,
+      );
+    }
+    for (const [name, version] of Object.entries(optionalDependencies)) {
+      if (version !== manifest.version) {
+        throw new Error(
+          `Wrapper optional dependency ${name} is ${version}; expected ${manifest.version}`,
+        );
+      }
+    }
+    for (const [section, entries] of Object.entries({
+      dependencies: manifest.dependencies ?? {},
+      optionalDependencies,
+    })) {
+      for (const [name, version] of Object.entries(entries)) {
+        if (String(version).startsWith("workspace:")) {
+          throw new Error(`${section}.${name} still uses the workspace protocol`);
+        }
+      }
+    }
+  } else {
+    if (!manifest.os?.includes(config.os) || !manifest.cpu?.includes(config.cpu)) {
+      throw new Error(
+        `${basename(archive)} has platform ${JSON.stringify({ os: manifest.os, cpu: manifest.cpu })}; expected ${config.os}/${config.cpu}`,
+      );
+    }
+    if (config.libc && !manifest.libc?.includes(config.libc)) {
+      throw new Error(`${basename(archive)} does not declare libc ${config.libc}`);
+    }
+    const files = listArchiveFiles(archive);
+    if (!files.includes(`package/${config.binary}`)) {
+      throw new Error(`${basename(archive)} does not contain package/${config.binary}`);
+    }
+  }
+
+  return manifest;
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const values = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`Expected --key value arguments; received ${rest.join(" ")}`);
+    }
+    values[key.slice(2)] = value;
+  }
+  return { command, values };
+}
+
+function requireArg(values, name) {
+  const value = values[name];
+  if (!value) {
+    throw new Error(`Missing required --${name} argument`);
+  }
+  return value;
+}
+
+function renameAsset(values) {
+  const releaseVersion = requireArg(values, "release-version");
+  const target = requireArg(values, "target");
+  const inputDir = resolve(requireArg(values, "input-dir"));
+  const outputDir = resolve(requireArg(values, "output-dir"));
+  const archives = readdirSync(inputDir).filter((file) => file.endsWith(".tgz"));
+  if (archives.length !== 1) {
+    throw new Error(`Expected exactly one .tgz in ${inputDir}; found ${archives.join(", ")}`);
+  }
+  const input = join(inputDir, archives[0]);
+  assertPackage(target, input);
+  mkdirSync(outputDir, { recursive: true });
+  const output = join(outputDir, releaseAssetName(target, releaseVersion));
+  copyFileSync(input, output);
+  console.log(output);
+}
+
+function writeManifest(values) {
+  const releaseVersion = requireArg(values, "release-version");
+  const sourceRevision = requireArg(values, "source-revision");
+  const assetsDir = resolve(requireArg(values, "assets-dir"));
+  const output = resolve(requireArg(values, "output"));
+  const expectedManifestName = releaseManifestName(releaseVersion);
+  if (basename(output) !== expectedManifestName) {
+    throw new Error(
+      `Release manifest must be named ${expectedManifestName}; received ${basename(output)}`,
+    );
+  }
+
+  const expectedArchives = Object.keys(RELEASE_TARGETS)
+    .map((target) => releaseAssetName(target, releaseVersion))
+    .sort();
+  const actualArchives = readdirSync(assetsDir)
+    .filter((file) => file.endsWith(".tgz"))
+    .sort();
+  if (JSON.stringify(actualArchives) !== JSON.stringify(expectedArchives)) {
+    throw new Error(
+      `Release archive set is ${actualArchives.join(", ")}; expected ${expectedArchives.join(", ")}`,
+    );
+  }
+
+  const wrapperArchive = join(assetsDir, releaseAssetName("wrapper", releaseVersion));
+  const wrapper = assertPackage("wrapper", wrapperArchive);
+  for (const target of PLATFORM_TARGETS) {
+    assertPackage(
+      target,
+      join(assetsDir, releaseAssetName(target, releaseVersion)),
+      wrapper.version,
+    );
+  }
+
+  const manifest = buildReleaseManifest({
+    releaseVersion,
+    sourceRevision,
+    packageVersion: wrapper.version,
+  });
+  writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(output);
+}
+
+function main() {
+  const { command, values } = parseArgs(process.argv.slice(2));
+  if (command === "rename") {
+    renameAsset(values);
+    return;
+  }
+  if (command === "manifest") {
+    writeManifest(values);
+    return;
+  }
+  throw new Error(`Usage: ${basename(process.argv[1])} <rename|manifest> --key value ...`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -1,9 +1,25 @@
 #!/usr/bin/env node
 
-import { copyFileSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import {
+  copyFileSync,
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(SCRIPT_DIRECTORY, "..");
+const WORKSPACE_ROOT = resolve(PACKAGE_ROOT, "../..");
+const NODE_CRATE_MANIFEST = join(WORKSPACE_ROOT, "crates/runtimed-node/Cargo.toml");
 
 export const RELEASE_TARGETS = Object.freeze({
   wrapper: Object.freeze({
@@ -68,6 +84,21 @@ export function releaseManifestName(releaseVersion) {
   return `runtimed-node-assets-${releaseVersion}.json`;
 }
 
+export function nodeApiVersionFromCargoManifest(manifestPath = NODE_CRATE_MANIFEST) {
+  const manifest = readFileSync(manifestPath, "utf8");
+  const napiDependency = /^napi\s*=\s*\{([^}]*)\}\s*$/m.exec(manifest)?.[1];
+  const features = /features\s*=\s*\[([^\]]*)\]/.exec(napiDependency ?? "")?.[1];
+  const versions = [...(features ?? "").matchAll(/"napi([0-9]+)"/g)].map((match) =>
+    Number(match[1]),
+  );
+  if (versions.length !== 1 || !Number.isInteger(versions[0])) {
+    throw new Error(
+      `${manifestPath} must configure exactly one napiN feature; found ${versions.join(", ") || "none"}`,
+    );
+  }
+  return versions[0];
+}
+
 export function buildReleaseManifest({ releaseVersion, sourceRevision, packageVersion }) {
   assertToken("release version", releaseVersion);
   if (!/^[0-9a-f]{40}$/.test(sourceRevision)) {
@@ -85,7 +116,7 @@ export function buildReleaseManifest({ releaseVersion, sourceRevision, packageVe
     source_revision: sourceRevision,
     binding_source_revision: sourceRevision.slice(0, 7),
     npm_package_version: packageVersion,
-    node_api_version: 9,
+    node_api_version: nodeApiVersionFromCargoManifest(),
     wrapper: {
       package: RELEASE_TARGETS.wrapper.packageName,
       asset: releaseAssetName("wrapper", releaseVersion),
@@ -106,6 +137,112 @@ export function buildReleaseManifest({ releaseVersion, sourceRevision, packageVe
       }),
     ),
   };
+}
+
+function commandName(name) {
+  return process.platform === "win32" ? `${name}.cmd` : name;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed: ${result.stderr || result.stdout || result.error}`,
+    );
+  }
+  return result.stdout;
+}
+
+export function packWrapperReleaseAsset({ packageRoot = PACKAGE_ROOT, outputDir }) {
+  const resolvedPackageRoot = resolve(packageRoot);
+  const resolvedOutputDir = resolve(outputDir);
+  const manifest = JSON.parse(readFileSync(join(resolvedPackageRoot, "package.json"), "utf8"));
+  const optionalDependencies = Object.fromEntries(
+    Object.entries(manifest.optionalDependencies ?? {})
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([name, version]) => {
+        if (version !== "workspace:*") {
+          throw new Error(
+            `Expected optionalDependencies.${name} to use workspace:*; received ${version}`,
+          );
+        }
+        return [name, manifest.version];
+      }),
+  );
+  const stagedManifest = { ...manifest, optionalDependencies };
+  const stagingDirectory = mkdtempSync(join(tmpdir(), "runtimed-node-wrapper-pack-"));
+
+  try {
+    for (const relativePath of manifest.files ?? []) {
+      const source = join(resolvedPackageRoot, relativePath);
+      const destination = join(stagingDirectory, relativePath);
+      mkdirSync(dirname(destination), { recursive: true });
+      cpSync(source, destination, { recursive: true });
+    }
+    copyFileSync(join(WORKSPACE_ROOT, "LICENSE"), join(stagingDirectory, "LICENSE"));
+    writeFileSync(
+      join(stagingDirectory, "package.json"),
+      `${JSON.stringify(stagedManifest, null, 2)}\n`,
+    );
+    mkdirSync(resolvedOutputDir, { recursive: true });
+    const existingArchives = readdirSync(resolvedOutputDir).filter((file) => file.endsWith(".tgz"));
+    if (existingArchives.length !== 0) {
+      throw new Error(
+        `Wrapper output directory ${resolvedOutputDir} must contain no .tgz files; found ${existingArchives.join(", ")}`,
+      );
+    }
+    run(
+      commandName("npm"),
+      ["pack", "--ignore-scripts", "--pack-destination", resolvedOutputDir, stagingDirectory],
+      { cwd: resolvedPackageRoot },
+    );
+    const archives = readdirSync(resolvedOutputDir).filter((file) => file.endsWith(".tgz"));
+    if (archives.length !== 1) {
+      throw new Error(
+        `Expected exactly one wrapper .tgz in ${resolvedOutputDir}; found ${archives.join(", ")}`,
+      );
+    }
+    const archive = join(resolvedOutputDir, archives[0]);
+    assertPackage("wrapper", archive, manifest.version);
+    console.log(archive);
+    return archive;
+  } finally {
+    rmSync(stagingDirectory, { recursive: true, force: true });
+  }
+}
+
+export function smokeReleasePair({ wrapperArchive, platformArchive, target, sourceRevision }) {
+  const wrapper = assertPackage("wrapper", wrapperArchive);
+  assertPackage(target, platformArchive, wrapper.version);
+  const stagingDirectory = mkdtempSync(join(tmpdir(), "runtimed-node-release-smoke-"));
+  const nodeModulesRoot = join(stagingDirectory, "node_modules");
+  const wrapperDirectory = join(nodeModulesRoot, "@runtimed/node");
+  const platformDirectory = join(nodeModulesRoot, targetConfig(target).packageName);
+
+  try {
+    mkdirSync(wrapperDirectory, { recursive: true });
+    mkdirSync(platformDirectory, { recursive: true });
+    run("tar", ["-xzf", resolve(wrapperArchive), "-C", wrapperDirectory, "--strip-components=1"]);
+    run("tar", ["-xzf", resolve(platformArchive), "-C", platformDirectory, "--strip-components=1"]);
+    const require = createRequire(join(stagingDirectory, "release-asset-smoke.cjs"));
+    const relay = require("@runtimed/node/relay");
+    if (typeof relay.bindingSourceRevision !== "function") {
+      throw new Error("Extracted @runtimed/node/relay does not expose bindingSourceRevision()");
+    }
+    const actualRevision = relay.bindingSourceRevision();
+    if (!sourceRevision.startsWith(actualRevision)) {
+      throw new Error(
+        `Extracted binding revision ${actualRevision} is not a prefix of ${sourceRevision}`,
+      );
+    }
+    console.log(`${target}: loaded @runtimed/node/relay at ${actualRevision}`);
+    return actualRevision;
+  } finally {
+    rmSync(stagingDirectory, { recursive: true, force: true });
+  }
 }
 
 function tarOutput(archive, args) {
@@ -196,7 +333,8 @@ function assertPackage(target, archive, expectedVersion) {
 }
 
 function parseArgs(argv) {
-  const [command, ...rest] = argv;
+  const [command, ...rawArgs] = argv;
+  const rest = rawArgs.filter((argument) => argument !== "--");
   const values = {};
   for (let index = 0; index < rest.length; index += 2) {
     const key = rest[index];
@@ -279,6 +417,10 @@ function writeManifest(values) {
 
 function main() {
   const { command, values } = parseArgs(process.argv.slice(2));
+  if (command === "pack-wrapper") {
+    packWrapperReleaseAsset({ outputDir: requireArg(values, "output-dir") });
+    return;
+  }
   if (command === "rename") {
     renameAsset(values);
     return;
@@ -287,7 +429,18 @@ function main() {
     writeManifest(values);
     return;
   }
-  throw new Error(`Usage: ${basename(process.argv[1])} <rename|manifest> --key value ...`);
+  if (command === "smoke") {
+    smokeReleasePair({
+      wrapperArchive: requireArg(values, "wrapper"),
+      platformArchive: requireArg(values, "platform"),
+      target: requireArg(values, "target"),
+      sourceRevision: requireArg(values, "source-revision"),
+    });
+    return;
+  }
+  throw new Error(
+    `Usage: ${basename(process.argv[1])} <pack-wrapper|rename|manifest|smoke> --key value ...`,
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -22,17 +22,24 @@ const NODE_CRATE_MANIFEST = join(WORKSPACE_ROOT, "crates/runtimed-node/Cargo.tom
 const RELAY_SMOKE_SCRIPT = `"use strict";
 const { writeFileSync } = require("node:fs");
 const relay = require("@runtimed/node/relay");
-if (typeof relay.bindingSourceRevision !== "function") {
-  throw new Error("Extracted @runtimed/node/relay does not expose bindingSourceRevision()");
+for (const name of [
+  "createRelay",
+  "openRelayPath",
+  "connectRelay",
+  "queryDaemonInfo",
+  "defaultSocketPath",
+  "socketPathForChannel",
+]) {
+  if (typeof relay[name] !== "function") {
+    throw new Error(\`Extracted @runtimed/node/relay does not expose \${name}()\`);
+  }
 }
-const actualRevision = relay.bindingSourceRevision();
-const sourceRevision = process.argv[2];
-if (!sourceRevision.startsWith(actualRevision)) {
-  throw new Error(
-    \`Extracted binding revision \${actualRevision} is not a prefix of \${sourceRevision}\`,
-  );
+const defaultPath = relay.defaultSocketPath();
+const stablePath = relay.socketPathForChannel("stable");
+if (typeof defaultPath !== "string" || !defaultPath || typeof stablePath !== "string" || !stablePath) {
+  throw new Error("Extracted relay socket discovery did not return usable paths");
 }
-writeFileSync(process.argv[3], JSON.stringify({ actualRevision }));
+writeFileSync(process.argv[2], JSON.stringify({ loaded: true }));
 `;
 
 export const RELEASE_TARGETS = Object.freeze({
@@ -128,7 +135,6 @@ export function buildReleaseManifest({ releaseVersion, sourceRevision, packageVe
     schema_version: 1,
     release_version: releaseVersion,
     source_revision: sourceRevision,
-    binding_source_revision: sourceRevision.slice(0, 7),
     npm_package_version: packageVersion,
     node_api_version: nodeApiVersionFromCargoManifest(),
     wrapper: {
@@ -231,7 +237,7 @@ export function packWrapperReleaseAsset({ packageRoot = PACKAGE_ROOT, outputDir 
   }
 }
 
-export function smokeReleasePair({ wrapperArchive, platformArchive, target, sourceRevision }) {
+export function smokeReleasePair({ wrapperArchive, platformArchive, target }) {
   const wrapper = assertPackage("wrapper", wrapperArchive);
   assertPackage(target, platformArchive, wrapper.version);
   const stagingDirectory = mkdtempSync(join(tmpdir(), "runtimed-node-release-smoke-"));
@@ -244,36 +250,33 @@ export function smokeReleasePair({ wrapperArchive, platformArchive, target, sour
     mkdirSync(platformDirectory, { recursive: true });
     extractArchive(wrapperArchive, wrapperDirectory);
     extractArchive(platformArchive, platformDirectory);
-    const actualRevision = runRelaySmokeChild({ stagingDirectory, sourceRevision });
-    console.log(`${target}: loaded @runtimed/node/relay at ${actualRevision}`);
-    return actualRevision;
+    runRelaySmokeChild({ stagingDirectory });
+    console.log(`${target}: loaded @runtimed/node/relay`);
   } finally {
     rmSync(stagingDirectory, { recursive: true, force: true });
   }
 }
 
-export function runRelaySmokeChild({ stagingDirectory, sourceRevision }) {
+export function runRelaySmokeChild({ stagingDirectory }) {
   const resolvedStagingDirectory = resolve(stagingDirectory);
   const smokeScript = join(resolvedStagingDirectory, "release-asset-smoke.cjs");
   const smokeResult = join(resolvedStagingDirectory, "release-asset-smoke-result.json");
   writeFileSync(smokeScript, RELAY_SMOKE_SCRIPT);
 
   try {
-    const result = spawnSync(
-      process.execPath,
-      [basename(smokeScript), sourceRevision, basename(smokeResult)],
-      { cwd: resolvedStagingDirectory, encoding: "utf8" },
-    );
+    const result = spawnSync(process.execPath, [basename(smokeScript), basename(smokeResult)], {
+      cwd: resolvedStagingDirectory,
+      encoding: "utf8",
+    });
     if (result.status !== 0) {
       throw new Error(
         `Could not load extracted @runtimed/node/relay: ${result.stderr || result.stdout || result.error}`,
       );
     }
     const payload = JSON.parse(readFileSync(smokeResult, "utf8"));
-    if (typeof payload.actualRevision !== "string" || payload.actualRevision.length === 0) {
-      throw new Error("Extracted relay smoke result did not contain a source revision");
+    if (payload.loaded !== true) {
+      throw new Error("Extracted relay smoke result did not confirm a successful load");
     }
-    return payload.actualRevision;
   } finally {
     rmSync(smokeScript, { force: true });
     rmSync(smokeResult, { force: true });
@@ -498,7 +501,6 @@ function main() {
       wrapperArchive: requireArg(values, "wrapper"),
       platformArchive: requireArg(values, "platform"),
       target: requireArg(values, "target"),
-      sourceRevision: requireArg(values, "source-revision"),
     });
     return;
   }

--- a/packages/runtimed-node/scripts/release-assets.mjs
+++ b/packages/runtimed-node/scripts/release-assets.mjs
@@ -146,6 +146,9 @@ function commandName(name) {
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     encoding: "utf8",
+    // Windows cannot execute npm.cmd directly through CreateProcess. The
+    // command and every argument here are locally generated release paths.
+    shell: process.platform === "win32",
     ...options,
   });
   if (result.status !== 0) {

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -46,6 +46,23 @@ test("release manifest carries source and npm package identities", () => {
   );
 });
 
+test("a Node host can consume the manifest compatibility fields", () => {
+  const manifest = JSON.parse(
+    JSON.stringify(
+      buildReleaseManifest({
+        releaseVersion,
+        sourceRevision,
+        packageVersion: "0.4.3",
+      }),
+    ),
+  );
+  const hostNodeApiVersion = Number(process.versions.napi);
+
+  assert.ok(Number.isInteger(hostNodeApiVersion));
+  assert.ok(hostNodeApiVersion >= manifest.node_api_version);
+  assert.equal(manifest.binding_source_revision, manifest.source_revision.slice(0, 7));
+});
+
 test("release version and source revision are validated", () => {
   assert.throws(() => releaseAssetName("wrapper", "../unsafe"), /release-safe token/);
   assert.throws(

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -13,6 +13,7 @@ import {
   packWrapperReleaseAsset,
   releaseAssetName,
   releaseManifestName,
+  runRelaySmokeChild,
 } from "./release-assets.mjs";
 
 const releaseVersion = "2.6.3-nightly.202608110900";
@@ -137,6 +138,49 @@ test("archives extract through relative paths when directories contain spaces", 
     extractArchive(archive, destination);
 
     assert.equal(readFileSync(join(destination, "fixture.txt"), "utf8"), "release fixture\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeRelayFixture(root, revision) {
+  const packageDirectory = join(root, "node_modules", "@runtimed", "node");
+  mkdirSync(packageDirectory, { recursive: true });
+  writeFileSync(
+    join(packageDirectory, "package.json"),
+    `${JSON.stringify({
+      name: "@runtimed/node",
+      exports: { "./relay": "./relay.cjs" },
+    })}\n`,
+  );
+  writeFileSync(
+    join(packageDirectory, "relay.cjs"),
+    `module.exports.bindingSourceRevision = () => ${JSON.stringify(revision)};\n`,
+  );
+}
+
+test("relay smoke child exits before its extracted package is cleaned up", () => {
+  const root = mkdtempSync(join(tmpdir(), "runtimed node child smoke "));
+  writeRelayFixture(root, sourceRevision.slice(0, 7));
+
+  assert.equal(runRelaySmokeChild({ stagingDirectory: root, sourceRevision }), "0123456");
+  assert.equal(existsSync(join(root, "release-asset-smoke.cjs")), false);
+  assert.equal(existsSync(join(root, "release-asset-smoke-result.json")), false);
+  rmSync(root, { recursive: true, force: true });
+  assert.equal(existsSync(root), false);
+});
+
+test("relay smoke child propagates revision failures and removes its files", () => {
+  const root = mkdtempSync(join(tmpdir(), "runtimed node child failure "));
+  try {
+    writeRelayFixture(root, "deadbee");
+
+    assert.throws(
+      () => runRelaySmokeChild({ stagingDirectory: root, sourceRevision }),
+      /Extracted binding revision deadbee is not a prefix/,
+    );
+    assert.equal(existsSync(join(root, "release-asset-smoke.cjs")), false);
+    assert.equal(existsSync(join(root, "release-asset-smoke-result.json")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -33,6 +33,7 @@ test("release manifest carries source and npm package identities", () => {
   assert.equal(manifest.source_revision, sourceRevision);
   assert.equal(manifest.binding_source_revision, sourceRevision.slice(0, 7));
   assert.equal(manifest.npm_package_version, "0.4.3");
+  assert.equal(manifest.node_api_version, 9);
   assert.deepEqual(Object.keys(manifest.platforms), [
     "darwin-arm64",
     "darwin-x64",

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -7,6 +8,7 @@ import test from "node:test";
 
 import {
   buildReleaseManifest,
+  extractArchive,
   nodeApiVersionFromCargoManifest,
   packWrapperReleaseAsset,
   releaseAssetName,
@@ -113,6 +115,28 @@ test("wrapper release archives are byte reproducible", () => {
     const second = packWrapperReleaseAsset({ outputDir: secondDirectory });
     const digest = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
     assert.equal(digest(first), digest(second));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("archives extract through relative paths when directories contain spaces", () => {
+  const root = mkdtempSync(join(tmpdir(), "runtimed node archive paths "));
+  try {
+    const packageDirectory = join(root, "source", "package");
+    const archive = join(root, "release archive.tgz");
+    const destination = join(root, "destination with spaces");
+    mkdirSync(packageDirectory, { recursive: true });
+    writeFileSync(join(packageDirectory, "fixture.txt"), "release fixture\n");
+    const packed = spawnSync("tar", ["-czf", "release archive.tgz", "-C", "source", "package"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.equal(packed.status, 0, packed.stderr || packed.stdout);
+
+    extractArchive(archive, destination);
+
+    assert.equal(readFileSync(join(destination, "fixture.txt"), "utf8"), "release fixture\n");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildReleaseManifest, releaseAssetName, releaseManifestName } from "./release-assets.mjs";
+
+const releaseVersion = "2.6.3-nightly.202608110900";
+const sourceRevision = "0123456789abcdef0123456789abcdef01234567";
+
+test("release asset names use the nteract release version", () => {
+  assert.equal(
+    releaseAssetName("wrapper", releaseVersion),
+    "runtimed-node-wrapper-2.6.3-nightly.202608110900.tgz",
+  );
+  assert.equal(
+    releaseAssetName("darwin-x64", releaseVersion),
+    "runtimed-node-darwin-x64-2.6.3-nightly.202608110900.tgz",
+  );
+  assert.equal(
+    releaseManifestName(releaseVersion),
+    "runtimed-node-assets-2.6.3-nightly.202608110900.json",
+  );
+});
+
+test("release manifest carries source and npm package identities", () => {
+  const manifest = buildReleaseManifest({
+    releaseVersion,
+    sourceRevision,
+    packageVersion: "0.4.3",
+  });
+
+  assert.equal(manifest.schema_version, 1);
+  assert.equal(manifest.release_version, releaseVersion);
+  assert.equal(manifest.source_revision, sourceRevision);
+  assert.equal(manifest.binding_source_revision, sourceRevision.slice(0, 7));
+  assert.equal(manifest.npm_package_version, "0.4.3");
+  assert.deepEqual(Object.keys(manifest.platforms), [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-x64-gnu",
+    "win32-x64-msvc",
+  ]);
+  assert.equal(
+    manifest.platforms["win32-x64-msvc"].asset,
+    `runtimed-node-win32-x64-msvc-${releaseVersion}.tgz`,
+  );
+});
+
+test("release version and source revision are validated", () => {
+  assert.throws(() => releaseAssetName("wrapper", "../unsafe"), /release-safe token/);
+  assert.throws(
+    () =>
+      buildReleaseManifest({
+        releaseVersion,
+        sourceRevision: "short",
+        packageVersion: "0.4.3",
+      }),
+    /full lowercase Git commit SHA/,
+  );
+});

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -34,7 +34,7 @@ test("release asset names use the nteract release version", () => {
   );
 });
 
-test("release manifest carries source and npm package identities", () => {
+test("release manifest carries source provenance and npm package identity", () => {
   const manifest = buildReleaseManifest({
     releaseVersion,
     sourceRevision,
@@ -44,7 +44,6 @@ test("release manifest carries source and npm package identities", () => {
   assert.equal(manifest.schema_version, 1);
   assert.equal(manifest.release_version, releaseVersion);
   assert.equal(manifest.source_revision, sourceRevision);
-  assert.equal(manifest.binding_source_revision, sourceRevision.slice(0, 7));
   assert.equal(manifest.npm_package_version, "0.4.3");
   assert.equal(manifest.node_api_version, 9);
   assert.deepEqual(Object.keys(manifest.platforms), [
@@ -59,7 +58,7 @@ test("release manifest carries source and npm package identities", () => {
   );
 });
 
-test("a Node host can consume the manifest compatibility fields", () => {
+test("a Node host can consume the manifest Node-API compatibility field", () => {
   const manifest = JSON.parse(
     JSON.stringify(
       buildReleaseManifest({
@@ -73,7 +72,6 @@ test("a Node host can consume the manifest compatibility fields", () => {
 
   assert.ok(Number.isInteger(hostNodeApiVersion));
   assert.ok(hostNodeApiVersion >= manifest.node_api_version);
-  assert.equal(manifest.binding_source_revision, manifest.source_revision.slice(0, 7));
 });
 
 test("release version and source revision are validated", () => {
@@ -143,7 +141,7 @@ test("archives extract through relative paths when directories contain spaces", 
   }
 });
 
-function writeRelayFixture(root, revision) {
+function writeRelayFixture(root, { usablePaths = true } = {}) {
   const packageDirectory = join(root, "node_modules", "@runtimed", "node");
   mkdirSync(packageDirectory, { recursive: true });
   writeFileSync(
@@ -155,29 +153,36 @@ function writeRelayFixture(root, revision) {
   );
   writeFileSync(
     join(packageDirectory, "relay.cjs"),
-    `module.exports.bindingSourceRevision = () => ${JSON.stringify(revision)};\n`,
+    `module.exports = {
+      createRelay() {},
+      openRelayPath() {},
+      connectRelay() {},
+      queryDaemonInfo() {},
+      defaultSocketPath: () => ${usablePaths ? '"/tmp/runtimed.sock"' : '""'},
+      socketPathForChannel: () => ${usablePaths ? '"/tmp/runtimed.sock"' : '""'},
+    };\n`,
   );
 }
 
 test("relay smoke child exits before its extracted package is cleaned up", () => {
   const root = mkdtempSync(join(tmpdir(), "runtimed node child smoke "));
-  writeRelayFixture(root, sourceRevision.slice(0, 7));
+  writeRelayFixture(root);
 
-  assert.equal(runRelaySmokeChild({ stagingDirectory: root, sourceRevision }), "0123456");
+  runRelaySmokeChild({ stagingDirectory: root });
   assert.equal(existsSync(join(root, "release-asset-smoke.cjs")), false);
   assert.equal(existsSync(join(root, "release-asset-smoke-result.json")), false);
   rmSync(root, { recursive: true, force: true });
   assert.equal(existsSync(root), false);
 });
 
-test("relay smoke child propagates revision failures and removes its files", () => {
+test("relay smoke child propagates native API failures and removes its files", () => {
   const root = mkdtempSync(join(tmpdir(), "runtimed node child failure "));
   try {
-    writeRelayFixture(root, "deadbee");
+    writeRelayFixture(root, { usablePaths: false });
 
     assert.throws(
-      () => runRelaySmokeChild({ stagingDirectory: root, sourceRevision }),
-      /Extracted binding revision deadbee is not a prefix/,
+      () => runRelaySmokeChild({ stagingDirectory: root }),
+      /socket discovery did not return usable paths/,
     );
     assert.equal(existsSync(join(root, "release-asset-smoke.cjs")), false);
     assert.equal(existsSync(join(root, "release-asset-smoke-result.json")), false);

--- a/packages/runtimed-node/scripts/release-assets.test.mjs
+++ b/packages/runtimed-node/scripts/release-assets.test.mjs
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
-import { buildReleaseManifest, releaseAssetName, releaseManifestName } from "./release-assets.mjs";
+import {
+  buildReleaseManifest,
+  nodeApiVersionFromCargoManifest,
+  packWrapperReleaseAsset,
+  releaseAssetName,
+  releaseManifestName,
+} from "./release-assets.mjs";
 
 const releaseVersion = "2.6.3-nightly.202608110900";
 const sourceRevision = "0123456789abcdef0123456789abcdef01234567";
@@ -74,4 +84,36 @@ test("release version and source revision are validated", () => {
       }),
     /full lowercase Git commit SHA/,
   );
+});
+
+test("manifest Node-API minimum follows the native crate feature", () => {
+  const root = mkdtempSync(join(tmpdir(), "runtimed-node-api-version-"));
+  try {
+    const manifest = join(root, "Cargo.toml");
+    writeFileSync(
+      manifest,
+      'napi = { version = "3", default-features = false, features = ["napi9", "async"] }\n',
+    );
+    assert.equal(nodeApiVersionFromCargoManifest(manifest), 9);
+    writeFileSync(manifest, 'napi = { version = "3", features = ["async"] }\n');
+    assert.throws(() => nodeApiVersionFromCargoManifest(manifest), /exactly one napiN feature/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wrapper release archives are byte reproducible", () => {
+  const root = mkdtempSync(join(tmpdir(), "runtimed-node-wrapper-reproducibility-"));
+  try {
+    const firstDirectory = join(root, "first");
+    const secondDirectory = join(root, "second");
+    mkdirSync(firstDirectory);
+    mkdirSync(secondDirectory);
+    const first = packWrapperReleaseAsset({ outputDir: firstDirectory });
+    const second = packWrapperReleaseAsset({ outputDir: secondDirectory });
+    const digest = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
+    assert.equal(digest(first), digest(second));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,9 @@ importers:
       '@runtimed/node-darwin-arm64':
         specifier: workspace:*
         version: link:npm/darwin-arm64
+      '@runtimed/node-darwin-x64':
+        specifier: workspace:*
+        version: link:npm/darwin-x64
       '@runtimed/node-linux-x64-gnu':
         specifier: workspace:*
         version: link:npm/linux-x64-gnu
@@ -758,6 +761,8 @@ importers:
         version: link:npm/win32-x64-msvc
 
   packages/runtimed-node/npm/darwin-arm64: {}
+
+  packages/runtimed-node/npm/darwin-x64: {}
 
   packages/runtimed-node/npm/linux-x64-gnu: {}
 


### PR DESCRIPTION
## Summary

- publish deterministic `@runtimed/node` wrapper and native package archives with each nteract release
- cover macOS arm64, macOS x64, Linux x64 glibc, and Windows x64 MSVC
- add a machine-readable asset manifest carrying release provenance, npm package version, Node-API minimum, and target/package mapping
- add the missing macOS x64 npm package surface and release/publish matrix coverage
- load every platform archive on its native runner in both PR and release workflows

## Motivation

Embedding hosts often acquire the notebook web bundle and daemon from one immutable nteract release rather than installing npm packages dynamically at runtime. The native relay should be available through the same release boundary so a host can select and verify a wrapper/native asset set without compiling Rust or reaching a package registry during packaging.

## Release contract

Each release adds:

- `runtimed-node-wrapper-${releaseVersion}.tgz`
- `runtimed-node-darwin-arm64-${releaseVersion}.tgz`
- `runtimed-node-darwin-x64-${releaseVersion}.tgz`
- `runtimed-node-linux-x64-gnu-${releaseVersion}.tgz`
- `runtimed-node-win32-x64-msvc-${releaseVersion}.tgz`
- `runtimed-node-assets-${releaseVersion}.json`

The GitHub Releases API `sha256:` digest remains the archive authenticity source. The manifest describes provenance, Node-API compatibility, and package placement; it intentionally does not duplicate archive checksums. A host installs the wrapper plus exactly one platform package and verifies Node-API support before loading.

`source_revision` records the release commit for audit and reproduction. It is not a runtime admission check and hosts must not require it to equal the daemon or notebook web revision. Runtime compatibility is negotiated by protocol number and versioned semantic capabilities on the relay connection.

Directly extracting the wrapper and native archive self-contains the `@runtimed/node/relay` surface. The higher-level package root still requires its declared runtime dependencies, including `rxjs`, supplied by a package manager or embedding host.

The workflows assert the actual Node architecture and Rust host tuple before building each native target, so runner-label drift fails explicitly rather than publishing a mislabeled archive. Each extracted archive pair must load the public relay API and exercise native socket discovery before release. The PR matrix is conservatively triggered by any local Rust crate change, and release build jobs run with read-only repository permissions.

## Verification

- `cargo xtask lint --fix`
- 45 xtask tests
- 9 release-asset contract/reproducibility tests
- frozen lockfile install
- deterministic wrapper packing
- isolated wrapper + native `/relay` extraction and load on macOS arm64
- real wrapper and arm64 platform package dry-runs
- deterministic archive rename and manifest generation checks
- workflow lint

The four-platform native package/load matrix is a required check on this draft's pushed head; signed/notarized application smoke remains outside this package PR.

## Stack

- base: #4134
