### PR TITLE
fix(node): wrap path-opened notebook sessions

### DIFF
--- a/packages/runtimed-node/src/index.cjs
+++ b/packages/runtimed-node/src/index.cjs
@@ -18,10 +18,15 @@ async function openNotebook(notebookId, options) {
   return new Session(await binding.openNotebook(notebookId, options));
 }
 
+async function openNotebookPath(path, options) {
+  return new Session(await binding.openNotebookPath(path, options));
+}
+
 module.exports = {
   ...binding,
   createNotebook,
   openNotebook,
+  openNotebookPath,
   NativeSession: binding.Session,
   Session,
 };

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -267,6 +267,7 @@ export function defaultSocketPath(): string;
 export function socketPathForChannel(channel: "stable" | "nightly"): string;
 export function createNotebook(options?: CreateNotebookOptions): Promise<Session>;
 export function openNotebook(notebookId: string, options?: OpenNotebookOptions): Promise<Session>;
+export function openNotebookPath(path: string, options?: OpenNotebookOptions): Promise<Session>;
 export function getExecutionResult(
   executionId: string,
   options?: { socketPath?: string },

--- a/packages/runtimed-node/tests/index.test.ts
+++ b/packages/runtimed-node/tests/index.test.ts
@@ -18,7 +18,9 @@ describe("@runtimed/node root wrapper", () => {
   it("wraps path-opened native sessions in the high-level Session API", async () => {
     const fixture = fs.mkdtempSync(path.join(packageRoot, ".index-test-"));
     temporaryDirectories.push(fixture);
-    for (const file of ["index.cjs", "session.cjs", "napi-observables.cjs"]) {
+    for (const file of fs
+      .readdirSync(path.join(packageRoot, "src"))
+      .filter((name) => name.endsWith(".cjs") && name !== "binding.cjs")) {
       fs.copyFileSync(path.join(packageRoot, "src", file), path.join(fixture, file));
     }
     fs.writeFileSync(

--- a/packages/runtimed-node/tests/index.test.ts
+++ b/packages/runtimed-node/tests/index.test.ts
@@ -1,0 +1,57 @@
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+const require = createRequire(import.meta.url);
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("@runtimed/node root wrapper", () => {
+  it("wraps path-opened native sessions in the high-level Session API", async () => {
+    const fixture = fs.mkdtempSync(path.join(packageRoot, ".index-test-"));
+    temporaryDirectories.push(fixture);
+    for (const file of ["index.cjs", "session.cjs", "napi-observables.cjs"]) {
+      fs.copyFileSync(path.join(packageRoot, "src", file), path.join(fixture, file));
+    }
+    fs.writeFileSync(
+      path.join(fixture, "binding.cjs"),
+      `
+const calls = [];
+class NativeSession {}
+module.exports = {
+  calls,
+  Session: NativeSession,
+  openNotebookPath: async (notebookPath, options) => {
+    calls.push({ notebookPath, options });
+    return { notebookId: "notebook-from-path" };
+  },
+};
+`,
+    );
+
+    const api = require(path.join(fixture, "index.cjs")) as {
+      calls: Array<{ notebookPath: string; options: unknown }>;
+      NativeSession: new () => unknown;
+      Session: new (native: unknown) => { notebookId: string };
+      openNotebookPath(
+        notebookPath: string,
+        options?: { socketPath?: string; peerLabel?: string },
+      ): Promise<{ notebookId: string }>;
+    };
+    const options = { socketPath: "/tmp/runtimed.sock", peerLabel: "host" };
+    const session = await api.openNotebookPath("/tmp/analysis.ipynb", options);
+
+    expect(session).toBeInstanceOf(api.Session);
+    expect(session).not.toBeInstanceOf(api.NativeSession);
+    expect(session.notebookId).toBe("notebook-from-path");
+    expect(api.calls).toEqual([{ notebookPath: "/tmp/analysis.ipynb", options }]);
+  });
+});


### PR DESCRIPTION
## Summary

- expose `openNotebookPath(path, options)` from the high-level `@runtimed/node` wrapper
- wrap the native session in the same observable `Session` API returned by `createNotebook()` and `openNotebook()`
- declare the API in the package TypeScript surface and add a regression test for the wrapper boundary

## Why

The native binding already implements path-based notebook opening, and the package README already documents it. The root CommonJS wrapper currently leaks the raw native session for that one function through `...binding`, while the declaration file omits the function entirely. Consumers therefore lose the high-level session methods and cannot call the documented API from TypeScript.

## Verification

- `pnpm test:run packages/runtimed-node/tests` (6 passed, 3 native-integration tests skipped)
- `cargo xtask lint --fix`

