### PR TITLE
build(web): add artifact compliance metadata

### DIFF
--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -17,6 +17,7 @@
  */
 
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { build, type Plugin } from "vite-plus";
@@ -32,6 +33,7 @@ const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
 // Without this, importing the core IIFE would also pull in all plugin strings.
 const VIRTUAL_PLUGIN_PREFIX = "virtual:renderer-plugin/";
 const RESOLVED_PLUGIN_PREFIX = "\0virtual:renderer-plugin/";
+const BUILD_PROVENANCE_FILE = "notebook-web-build-provenance.json";
 
 /** Directory containing pre-built renderer plugin artifacts. */
 const PREBUILT_DIR = path.resolve(__dirname, "../notebook/src/renderer-plugins");
@@ -280,6 +282,51 @@ export const css = ${JSON.stringify(css)};
 `;
         }
       }
+    },
+
+    generateBundle(_outputOptions, bundle) {
+      const sourceModules = [
+        ["isolated-renderer.js", RESOLVED_VIRTUAL_MODULE_ID],
+        ["isolated-renderer.css", RESOLVED_VIRTUAL_MODULE_ID],
+        ...prebuiltPluginNames.flatMap((name) => {
+          const moduleId = `${RESOLVED_PLUGIN_PREFIX}${name}`;
+          return PLUGIN_CSS_NAMES.has(name)
+            ? [
+                [`${name}.js`, moduleId],
+                [`${name}.css`, moduleId],
+              ]
+            : [[`${name}.js`, moduleId]];
+        }),
+      ] as const;
+      const inputs = sourceModules.map(([filename, moduleId]) => {
+        const sourcePath = path.join(PREBUILT_DIR, filename);
+        const source = fs.readFileSync(sourcePath);
+        const outputs = Object.values(bundle)
+          .flatMap((output) =>
+            output.type === "chunk" && Object.hasOwn(output.modules, moduleId)
+              ? [
+                  {
+                    path: output.fileName,
+                    sha256: createHash("sha256").update(output.code).digest("hex"),
+                  },
+                ]
+              : [],
+          )
+          .sort((left, right) => left.path.localeCompare(right.path));
+        if (outputs.length === 0) {
+          throw new Error(`Opaque renderer input ${filename} has no generated output chunk`);
+        }
+        return {
+          path: `apps/notebook/src/renderer-plugins/${filename}`,
+          sha256: createHash("sha256").update(source).digest("hex"),
+          outputs,
+        };
+      });
+      this.emitFile({
+        type: "asset",
+        fileName: BUILD_PROVENANCE_FILE,
+        source: `${JSON.stringify({ schemaVersion: 1, inputs }, null, 2)}\n`,
+      });
     },
 
     // Dev server: build from source for live development

--- a/crates/nteract-markdown-engine/Cargo.toml
+++ b/crates/nteract-markdown-engine/Cargo.toml
@@ -3,6 +3,7 @@ name = "nteract-markdown-engine"
 version = "0.2.3"
 edition = "2021"
 publish = false
+license.workspace = true
 
 [dependencies]
 markdown = "1"

--- a/crates/nteract-markdown-wasm/Cargo.toml
+++ b/crates/nteract-markdown-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "nteract-markdown-wasm"
 version = "0.2.3"
 edition = "2021"
 publish = false
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/docs/memos/host-neutral-notebook-web-artifacts.md
+++ b/docs/memos/host-neutral-notebook-web-artifacts.md
@@ -38,8 +38,11 @@ package it as a separate release asset. The archive carries:
 - `index.html` and all content-hashed frontend assets;
 - generated runtime WASM;
 - the repository `LICENSE`, deterministic `THIRD_PARTY_NOTICES.txt`, and an
-  SPDX 2.3 inventory of shipped JavaScript/WASM, npm and Cargo dependencies,
-  and opaque renderer build inputs;
+  SPDX 2.3 inventory of every regular payload file, the notebook UI's npm
+  runtime dependencies, WASM Cargo dependencies, CSS/font provenance, and
+  opaque renderer build inputs;
+- build provenance that binds each opaque renderer source hash to its emitted,
+  content-hashed output chunk;
 - `notebook-web-manifest.json`, naming the nteract source revision and runtime
   compatibility contract;
 - `SHA256SUMS`, covering the payload and manifest.
@@ -56,7 +59,8 @@ creates a versioned `nteract-notebook-web-<version>.tar.gz` and adjacent archive
 checksum from the same commit as the standalone daemon binaries.
 
 The manifest schema starts at version 1. Consumers must reject unknown schema
-versions, missing runtime WASM, unsafe file paths, and payload checksum drift.
+versions, missing runtime WASM, unsafe file paths, non-regular filesystem
+entries, stale renderer provenance, and payload checksum drift.
 They may allow an unstamped local development daemon, but a stamped source
 revision mismatch fails closed before notebook traffic is relayed.
 

--- a/docs/memos/host-neutral-notebook-web-artifacts.md
+++ b/docs/memos/host-neutral-notebook-web-artifacts.md
@@ -38,9 +38,10 @@ package it as a separate release asset. The archive carries:
 - `index.html` and all content-hashed frontend assets;
 - generated runtime WASM;
 - the repository `LICENSE`, deterministic `THIRD_PARTY_NOTICES.txt`, and an
-  SPDX 2.3 inventory of every regular payload file, the notebook UI's npm
-  runtime dependencies, WASM Cargo dependencies, CSS/font provenance, and
-  opaque renderer build inputs;
+  SPDX 2.3 inventory of every regular payload file; the deterministic union of
+  notebook UI, shared-source, embedded-renderer, and workspace npm runtime
+  dependencies; WASM Cargo dependencies; CSS/font provenance; and opaque
+  renderer build inputs;
 - build provenance that binds each opaque renderer source hash to its emitted,
   content-hashed output chunk;
 - `notebook-web-manifest.json`, naming the nteract source revision and runtime

--- a/docs/memos/host-neutral-notebook-web-artifacts.md
+++ b/docs/memos/host-neutral-notebook-web-artifacts.md
@@ -37,6 +37,9 @@ package it as a separate release asset. The archive carries:
 
 - `index.html` and all content-hashed frontend assets;
 - generated runtime WASM;
+- the repository `LICENSE`, deterministic `THIRD_PARTY_NOTICES.txt`, and an
+  SPDX 2.3 inventory of shipped JavaScript/WASM, npm and Cargo dependencies,
+  and opaque renderer build inputs;
 - `notebook-web-manifest.json`, naming the nteract source revision and runtime
   compatibility contract;
 - `SHA256SUMS`, covering the payload and manifest.
@@ -74,6 +77,3 @@ revision mismatch fails closed before notebook traffic is relayed.
 - Whether a smaller notebook-only Vite entry should exclude settings, gallery,
   and other desktop sub-apps; the first archive deliberately packages the
   already-tested production output.
-- Whether the archive should carry a machine-readable third-party notice or
-  SBOM alongside the integrity manifest so embedding hosts can feed their own
-  release-compliance pipelines without reconstructing the Vite dependency graph.

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@wdio/types": "^8.40.0",
     "jsdom": "^26.0.0",
     "rollup-plugin-visualizer": "^5.14.0",
+    "spdx-expression-parse": "3.0.1",
     "tailwindcss": "^4.1.8",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm --dir apps/notebook build",
     "notebook:build": "pnpm --dir apps/notebook build",
     "notebook-web:package": "cargo xtask notebook-web",
-    "notebook-web:test": "node --experimental-strip-types --test scripts/package-notebook-web.test.ts",
+    "notebook-web:test": "node --experimental-strip-types --test scripts/package-notebook-web.test.ts scripts/notebook-web-compliance.test.ts",
     "notebook:dev": "pnpm --dir apps/notebook dev",
     "test": "vp test",
     "test:run": "vp test run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^5.14.0
         version: 5.14.0(rolldown@1.0.0-rc.13)(rollup@4.59.0)
+      spdx-expression-parse:
+        specifier: 3.0.1
+        version: 3.0.1
       tailwindcss:
         specifier: ^4.1.8
         version: 4.2.2

--- a/scripts/license-overrides/ansi-to-react-BSD-3-Clause.txt
+++ b/scripts/license-overrides/ansi-to-react-BSD-3-Clause.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) nteract contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/scripts/license-overrides/katex-fonts-OFL-1.1.txt
+++ b/scripts/license-overrides/katex-fonts-OFL-1.1.txt
@@ -1,0 +1,43 @@
+SIL OPEN FONT LICENSE
+
+Version 1.1 - 26 February 2007
+
+PREAMBLE
+
+The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting — in part or in whole — any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+TERMINATION
+
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/scripts/license-overrides/remark-math-MIT.txt
+++ b/scripts/license-overrides/remark-math-MIT.txt
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2017 Junyoung Choi <fluke8259@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/scripts/license-overrides/uiwjs-react-json-view-MIT.txt
+++ b/scripts/license-overrides/uiwjs-react-json-view-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 uiwjs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/notebook-web-compliance.test.ts
+++ b/scripts/notebook-web-compliance.test.ts
@@ -12,7 +12,7 @@ import {
   collectOpaqueRendererAssets,
   NOTEBOOK_WEB_BUILD_PROVENANCE,
   opaqueRendererAssetNames,
-  pnpmExecutable,
+  pnpmInvocation,
   requiredNotebookNpmComponents,
   validateLicenseExpression,
   type ComplianceComponent,
@@ -143,7 +143,20 @@ test("fails closed when any required notebook or renderer component is omitted",
   }
 });
 
-test("uses the Windows pnpm command shim when required", () => {
-  assert.equal(pnpmExecutable("win32"), "pnpm.cmd");
-  assert.equal(pnpmExecutable("darwin"), "pnpm");
+test("constructs a safe platform-specific pnpm launch", () => {
+  const args = ["--filter", "notebook-ui", "licenses", "list", "--prod", "--json", "--long"];
+  assert.deepEqual(pnpmInvocation(args, "darwin"), { file: "pnpm", args });
+  assert.deepEqual(pnpmInvocation(args, "win32"), {
+    file: "cmd.exe",
+    args: [
+      "/d",
+      "/s",
+      "/c",
+      '""pnpm.cmd" "--filter" "notebook-ui" "licenses" "list" "--prod" "--json" "--long""',
+    ],
+  });
+  assert.throws(
+    () => pnpmInvocation(["--filter", "notebook-ui & whoami"], "win32"),
+    /Unsafe pnpm argument/,
+  );
 });

--- a/scripts/notebook-web-compliance.test.ts
+++ b/scripts/notebook-web-compliance.test.ts
@@ -6,11 +6,14 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  assertRequiredNotebookNpmComponents,
   buildSpdxDocument,
   buildThirdPartyNotices,
   collectOpaqueRendererAssets,
   NOTEBOOK_WEB_BUILD_PROVENANCE,
   opaqueRendererAssetNames,
+  pnpmExecutable,
+  requiredNotebookNpmComponents,
   validateLicenseExpression,
   type ComplianceComponent,
 } from "./notebook-web-compliance.ts";
@@ -111,6 +114,9 @@ test("builds deterministic SPDX and notice documents with renderer provenance", 
 
 test("rejects unknown licenses and incomplete opaque renderer provenance", async () => {
   assert.throws(() => validateLicenseExpression("GPL-3.0-only"), /unknown license expression/);
+  for (const malformed of ["MIT OR", "MIT AND", "MIT OR OR Apache-2.0", "(MIT OR Apache-2.0"]) {
+    assert.throws(() => validateLicenseExpression(malformed), /Invalid SPDX license expression/);
+  }
 
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "nteract-compliance-missing-"));
   const outputDir = path.join(repoRoot, "dist");
@@ -124,4 +130,20 @@ test("rejects unknown licenses and incomplete opaque renderer provenance", async
     collectOpaqueRendererAssets(repoRoot, outputDir),
     /Missing opaque renderer asset/,
   );
+});
+
+test("fails closed when any required notebook or renderer component is omitted", () => {
+  const required = [...requiredNotebookNpmComponents()];
+  assert.doesNotThrow(() => assertRequiredNotebookNpmComponents(required));
+  for (const omitted of required) {
+    assert.throws(
+      () => assertRequiredNotebookNpmComponents(required.filter((name) => name !== omitted)),
+      (error: unknown) => error instanceof Error && error.message.includes(omitted),
+    );
+  }
+});
+
+test("uses the Windows pnpm command shim when required", () => {
+  assert.equal(pnpmExecutable("win32"), "pnpm.cmd");
+  assert.equal(pnpmExecutable("darwin"), "pnpm");
 });

--- a/scripts/notebook-web-compliance.test.ts
+++ b/scripts/notebook-web-compliance.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,7 @@ import {
   buildSpdxDocument,
   buildThirdPartyNotices,
   collectOpaqueRendererAssets,
+  NOTEBOOK_WEB_BUILD_PROVENANCE,
   opaqueRendererAssetNames,
   validateLicenseExpression,
   type ComplianceComponent,
@@ -15,6 +17,7 @@ import {
 
 const COMPONENT: ComplianceComponent = {
   ecosystem: "cargo",
+  scope: "runtime",
   name: "fixture-crate",
   version: "1.2.3",
   licenseDeclared: "MIT OR Apache-2.0",
@@ -29,14 +32,33 @@ const COMPONENT: ComplianceComponent = {
 test("builds deterministic SPDX and notice documents with renderer provenance", async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "nteract-compliance-"));
   const rendererRoot = path.join(repoRoot, "apps/notebook/src/renderer-plugins");
+  const outputDir = path.join(repoRoot, "dist");
   await mkdir(rendererRoot, { recursive: true });
+  await mkdir(path.join(outputDir, "assets"), { recursive: true });
   await Promise.all(
     opaqueRendererAssetNames().map((name) =>
       writeFile(path.join(rendererRoot, name), `release payload for ${name}`),
     ),
   );
+  const outputPayload = "generated renderer chunk";
+  const outputSha256 = createHash("sha256").update(outputPayload).digest("hex");
+  await writeFile(path.join(outputDir, "assets/renderer-fixture.js"), outputPayload);
+  await writeFile(
+    path.join(outputDir, NOTEBOOK_WEB_BUILD_PROVENANCE),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      inputs: opaqueRendererAssetNames().map((name) => {
+        const source = `release payload for ${name}`;
+        return {
+          path: `apps/notebook/src/renderer-plugins/${name}`,
+          sha256: createHash("sha256").update(source).digest("hex"),
+          outputs: [{ path: "assets/renderer-fixture.js", sha256: outputSha256 }],
+        };
+      }),
+    })}\n`,
+  );
 
-  const assets = await collectOpaqueRendererAssets(repoRoot);
+  const assets = await collectOpaqueRendererAssets(repoRoot, outputDir);
   const first = buildSpdxDocument({
     components: [COMPONENT],
     opaqueRendererAssets: assets,
@@ -73,12 +95,33 @@ test("builds deterministic SPDX and notice documents with renderer provenance", 
   assert.equal(first.files.length, 2);
   assert.match(first.annotations[0]?.comment ?? "", /plotly\.js/);
   assert.match(buildThirdPartyNotices([COMPONENT], assets), /fixture-crate@1\.2\.3/);
+
+  await writeFile(path.join(rendererRoot, "plotly.js"), "stale renderer source");
+  await assert.rejects(
+    collectOpaqueRendererAssets(repoRoot, outputDir),
+    /renderer build provenance is stale or missing/,
+  );
+  await writeFile(path.join(rendererRoot, "plotly.js"), "release payload for plotly.js");
+  await writeFile(path.join(outputDir, "assets/renderer-fixture.js"), "stale renderer chunk");
+  await assert.rejects(
+    collectOpaqueRendererAssets(repoRoot, outputDir),
+    /renderer output provenance is stale/,
+  );
 });
 
 test("rejects unknown licenses and incomplete opaque renderer provenance", async () => {
   assert.throws(() => validateLicenseExpression("GPL-3.0-only"), /unknown license expression/);
 
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "nteract-compliance-missing-"));
+  const outputDir = path.join(repoRoot, "dist");
   await mkdir(path.join(repoRoot, "apps/notebook/src/renderer-plugins"), { recursive: true });
-  await assert.rejects(collectOpaqueRendererAssets(repoRoot), /Missing opaque renderer asset/);
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, NOTEBOOK_WEB_BUILD_PROVENANCE),
+    '{"schemaVersion":1,"inputs":[]}',
+  );
+  await assert.rejects(
+    collectOpaqueRendererAssets(repoRoot, outputDir),
+    /Missing opaque renderer asset/,
+  );
 });

--- a/scripts/notebook-web-compliance.test.ts
+++ b/scripts/notebook-web-compliance.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildSpdxDocument,
+  buildThirdPartyNotices,
+  collectOpaqueRendererAssets,
+  opaqueRendererAssetNames,
+  validateLicenseExpression,
+  type ComplianceComponent,
+} from "./notebook-web-compliance.ts";
+
+const COMPONENT: ComplianceComponent = {
+  ecosystem: "cargo",
+  name: "fixture-crate",
+  version: "1.2.3",
+  licenseDeclared: "MIT OR Apache-2.0",
+  licenseTexts: [
+    {
+      name: "LICENSE-MIT",
+      text: "MIT License\nCopyright (c) Fixture",
+    },
+  ],
+};
+
+test("builds deterministic SPDX and notice documents with renderer provenance", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "nteract-compliance-"));
+  const rendererRoot = path.join(repoRoot, "apps/notebook/src/renderer-plugins");
+  await mkdir(rendererRoot, { recursive: true });
+  await Promise.all(
+    opaqueRendererAssetNames().map((name) =>
+      writeFile(path.join(rendererRoot, name), `release payload for ${name}`),
+    ),
+  );
+
+  const assets = await collectOpaqueRendererAssets(repoRoot);
+  const first = buildSpdxDocument({
+    components: [COMPONENT],
+    opaqueRendererAssets: assets,
+    shippedWebFiles: [
+      { path: "assets/main-fixture.js", bytes: 7, sha1: "0".repeat(40), sha256: "0".repeat(64) },
+      {
+        path: "assets/runtime-fixture.wasm",
+        bytes: 8,
+        sha1: "1".repeat(40),
+        sha256: "1".repeat(64),
+      },
+    ],
+    sourceRevision: "abc1234",
+    version: "1.0.0",
+  });
+  const second = buildSpdxDocument({
+    components: [COMPONENT],
+    opaqueRendererAssets: assets,
+    shippedWebFiles: [
+      { path: "assets/main-fixture.js", bytes: 7, sha1: "0".repeat(40), sha256: "0".repeat(64) },
+      {
+        path: "assets/runtime-fixture.wasm",
+        bytes: 8,
+        sha1: "1".repeat(40),
+        sha256: "1".repeat(64),
+      },
+    ],
+    sourceRevision: "abc1234",
+    version: "1.0.0",
+  });
+
+  assert.deepEqual(first, second);
+  assert.equal(first.packages[1]?.licenseDeclared, "MIT OR Apache-2.0");
+  assert.equal(first.files.length, 2);
+  assert.match(first.annotations[0]?.comment ?? "", /plotly\.js/);
+  assert.match(buildThirdPartyNotices([COMPONENT], assets), /fixture-crate@1\.2\.3/);
+});
+
+test("rejects unknown licenses and incomplete opaque renderer provenance", async () => {
+  assert.throws(() => validateLicenseExpression("GPL-3.0-only"), /unknown license expression/);
+
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "nteract-compliance-missing-"));
+  await mkdir(path.join(repoRoot, "apps/notebook/src/renderer-plugins"), { recursive: true });
+  await assert.rejects(collectOpaqueRendererAssets(repoRoot), /Missing opaque renderer asset/);
+});

--- a/scripts/notebook-web-compliance.ts
+++ b/scripts/notebook-web-compliance.ts
@@ -1,0 +1,635 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const NOTEBOOK_WEB_LICENSE = "LICENSE";
+export const NOTEBOOK_WEB_NOTICES = "THIRD_PARTY_NOTICES.txt";
+export const NOTEBOOK_WEB_SBOM = "notebook-web.spdx.json";
+
+const APPROVED_LICENSE_IDS = new Set([
+  "0BSD",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "MIT",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+]);
+
+const OPAQUE_RENDERER_COMPONENTS: Record<string, readonly string[]> = {
+  "isolated-renderer.css": ["nteract"],
+  "isolated-renderer.js": ["nteract"],
+  "markdown.css": ["nteract", "katex", "react-markdown"],
+  "markdown.js": ["nteract", "katex", "react-markdown"],
+  "plotly.js": ["nteract", "plotly.js-dist-min"],
+  "bokeh.js": ["nteract"],
+  "panel.js": ["nteract"],
+  "vega.js": ["nteract", "vega", "vega-embed", "vega-lite"],
+  "leaflet.css": ["nteract", "leaflet"],
+  "leaflet.js": ["nteract", "leaflet"],
+  "sift.css": ["nteract", "@nteract/sift"],
+  "sift.js": ["nteract", "@nteract/sift"],
+};
+
+export function opaqueRendererAssetNames(): string[] {
+  return Object.keys(OPAQUE_RENDERER_COMPONENTS).sort();
+}
+
+const LICENSE_SOURCE_PACKAGE_OVERRIDES: Record<string, string> = {
+  "react-remove-scroll-bar": "react-remove-scroll",
+  "vega-functions": "vega",
+  "vega-interpreter": "vega",
+  "vega-selections": "vega",
+};
+
+const LICENSE_FILE_OVERRIDES: Record<string, string> = {
+  "@uiw/react-json-view": "uiwjs-react-json-view-MIT.txt",
+  "ansi-to-react": "ansi-to-react-BSD-3-Clause.txt",
+  "rehype-katex": "remark-math-MIT.txt",
+  "remark-math": "remark-math-MIT.txt",
+};
+
+type LicenseText = { name: string; text: string };
+
+export type ComplianceComponent = {
+  ecosystem: "cargo" | "npm";
+  name: string;
+  version: string;
+  licenseDeclared: string;
+  licenseTexts: LicenseText[];
+  homepage?: string;
+};
+
+export type OpaqueRendererAsset = {
+  path: string;
+  bytes: number;
+  sha256: string;
+  components: readonly string[];
+};
+
+export type ShippedWebFile = {
+  path: string;
+  bytes: number;
+  sha1: string;
+  sha256: string;
+};
+
+type PnpmLicenseRecord = {
+  name: string;
+  versions: string[];
+  paths: string[];
+  license?: string;
+  homepage?: string;
+};
+
+type CargoMetadata = {
+  packages: Array<{
+    id: string;
+    name: string;
+    version: string;
+    license: string | null;
+    homepage: string | null;
+    repository: string | null;
+    manifest_path: string;
+  }>;
+  resolve: {
+    nodes: Array<{
+      id: string;
+      deps: Array<{ pkg: string; dep_kinds: Array<{ kind: string | null }> }>;
+    }>;
+  };
+};
+
+type SpdxPackage = {
+  SPDXID: string;
+  name: string;
+  versionInfo: string;
+  downloadLocation: "NOASSERTION";
+  filesAnalyzed: boolean;
+  packageVerificationCode?: { packageVerificationCodeValue: string };
+  licenseConcluded: string;
+  licenseDeclared: string;
+  copyrightText: string;
+  externalRefs: Array<{
+    referenceCategory: "PACKAGE-MANAGER";
+    referenceType: "purl";
+    referenceLocator: string;
+  }>;
+};
+
+type SpdxFile = {
+  SPDXID: string;
+  fileName: string;
+  checksums: [
+    { algorithm: "SHA1"; checksumValue: string },
+    { algorithm: "SHA256"; checksumValue: string },
+  ];
+  licenseConcluded: "NOASSERTION";
+  copyrightText: "NOASSERTION";
+};
+
+export type NotebookWebSpdxDocument = {
+  spdxVersion: "SPDX-2.3";
+  dataLicense: "CC0-1.0";
+  SPDXID: "SPDXRef-DOCUMENT";
+  name: string;
+  documentNamespace: string;
+  creationInfo: {
+    created: string;
+    creators: ["Tool: nteract-notebook-web-compliance"];
+  };
+  documentDescribes: ["SPDXRef-Package-notebook-web"];
+  packages: SpdxPackage[];
+  files: SpdxFile[];
+  relationships: Array<{
+    spdxElementId: string;
+    relationshipType: "CONTAINS" | "DEPENDS_ON";
+    relatedSpdxElement: string;
+  }>;
+  annotations: Array<{
+    annotationDate: string;
+    annotationType: "OTHER";
+    annotator: "Tool: nteract-notebook-web-compliance";
+    comment: string;
+  }>;
+};
+
+function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sha1(value: string | Uint8Array): string {
+  return createHash("sha1").update(value).digest("hex");
+}
+
+function normalizedLicenseExpression(expression: string): string {
+  return expression
+    .replaceAll("Apache-2.0/MIT", "Apache-2.0 OR MIT")
+    .replaceAll("MIT/Apache-2.0", "MIT OR Apache-2.0")
+    .trim();
+}
+
+export function validateLicenseExpression(expression: string): string {
+  const normalized = normalizedLicenseExpression(expression);
+  const identifiers = normalized.match(/[A-Za-z0-9.-]+/g) ?? [];
+  const unknown = identifiers.filter(
+    (identifier) => identifier !== "AND" && identifier !== "OR" && !APPROVED_LICENSE_IDS.has(identifier),
+  );
+  if (identifiers.length === 0 || unknown.length > 0) {
+    throw new Error(
+      `Unapproved or unknown license expression ${JSON.stringify(expression)}${
+        unknown.length > 0 ? ` (${unknown.join(", ")})` : ""
+      }`,
+    );
+  }
+  return normalized;
+}
+
+async function licenseFilesBelow(packageRoot: string): Promise<LicenseText[]> {
+  const entries = await readdir(packageRoot, { withFileTypes: true });
+  const filenames = entries
+    .filter(
+      (entry) =>
+        entry.isFile() && /^(?:licen[cs]e|copying|notice|unlicense)/i.test(entry.name),
+    )
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+  return Promise.all(
+    filenames.map(async (name) => ({
+      name,
+      text: (await readFile(path.join(packageRoot, name), "utf8")).trim(),
+    })),
+  );
+}
+
+async function npmLicenseTexts(
+  component: { name: string; packageRoot: string },
+  packageRoots: ReadonlyMap<string, string>,
+  repoRoot: string,
+): Promise<LicenseText[]> {
+  let texts = await licenseFilesBelow(component.packageRoot);
+  if (texts.length > 0) return texts;
+
+  const sourceName = component.name.startsWith("@radix-ui/")
+    ? "@radix-ui/react-accordion"
+    : LICENSE_SOURCE_PACKAGE_OVERRIDES[component.name];
+  if (sourceName) {
+    const sourceRoot = packageRoots.get(sourceName);
+    if (!sourceRoot) {
+      throw new Error(`License source package ${sourceName} is unavailable for ${component.name}`);
+    }
+    texts = await licenseFilesBelow(sourceRoot);
+    if (texts.length > 0) {
+      return texts.map((license) => ({ ...license, name: `${license.name} (from ${sourceName})` }));
+    }
+  }
+
+  const override = LICENSE_FILE_OVERRIDES[component.name];
+  if (override) {
+    const text = await readFile(path.join(repoRoot, "scripts/license-overrides", override), "utf8");
+    return [{ name: `${override} (reviewed override)`, text: text.trim() }];
+  }
+
+  throw new Error(`No license text or reviewed override for npm package ${component.name}`);
+}
+
+async function collectNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
+  const output = execFileSync(
+    "pnpm",
+    ["--filter", ".", "licenses", "list", "--prod", "--json", "--long"],
+    { cwd: repoRoot, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  const grouped = JSON.parse(output) as Record<string, PnpmLicenseRecord[]>;
+  const records = Object.entries(grouped).flatMap(([license, packages]) =>
+    packages.flatMap((entry) => entry.paths.map((packageRoot) => ({ ...entry, packageRoot, license }))),
+  );
+
+  const packageRoots = new Map<string, string>();
+  const packageRecords = new Map<
+    string,
+    { name: string; version: string; license: string; homepage?: string; packageRoot: string }
+  >();
+  for (const record of records) {
+    const packageJson = JSON.parse(
+      await readFile(path.join(record.packageRoot, "package.json"), "utf8"),
+    ) as { name?: string; version?: string; license?: string; homepage?: string };
+    if (!packageJson.name || !packageJson.version) {
+      throw new Error(`Invalid package metadata under ${record.packageRoot}`);
+    }
+    const license = packageJson.license ?? record.license;
+    validateLicenseExpression(license);
+    packageRoots.set(packageJson.name, record.packageRoot);
+    packageRecords.set(`${packageJson.name}@${packageJson.version}`, {
+      name: packageJson.name,
+      version: packageJson.version,
+      license,
+      homepage: packageJson.homepage ?? record.homepage,
+      packageRoot: record.packageRoot,
+    });
+  }
+
+  return Promise.all(
+    [...packageRecords.values()]
+      .sort((left, right) =>
+        left.name.localeCompare(right.name) || left.version.localeCompare(right.version),
+      )
+      .map(async (record) => ({
+        ecosystem: "npm" as const,
+        name: record.name,
+        version: record.version,
+        licenseDeclared: validateLicenseExpression(record.license),
+        licenseTexts: await npmLicenseTexts(record, packageRoots, repoRoot),
+        homepage: record.homepage,
+      })),
+  );
+}
+
+async function cargoLicenseTexts(
+  manifestPath: string,
+  repoRoot: string,
+): Promise<LicenseText[]> {
+  const packageRoot = path.dirname(manifestPath);
+  let texts = await licenseFilesBelow(packageRoot);
+  if (texts.length > 0) return texts;
+
+  if (packageRoot === repoRoot || packageRoot.startsWith(`${repoRoot}${path.sep}`)) {
+    const text = await readFile(path.join(repoRoot, "LICENSE"), "utf8");
+    return [{ name: "LICENSE (workspace root)", text: text.trim() }];
+  }
+
+  let candidate = path.dirname(packageRoot);
+  for (let depth = 0; depth < 5; depth += 1) {
+    texts = await licenseFilesBelow(candidate);
+    if (texts.length > 0) {
+      return texts.map((license) => ({ ...license, name: `${license.name} (source root)` }));
+    }
+    const parent = path.dirname(candidate);
+    if (parent === candidate) break;
+    candidate = parent;
+  }
+  throw new Error(`No license text available for Cargo package at ${manifestPath}`);
+}
+
+async function collectCargoComponents(repoRoot: string): Promise<ComplianceComponent[]> {
+  const output = execFileSync(
+    "cargo",
+    ["metadata", "--format-version", "1", "--locked", "--filter-platform", "wasm32-unknown-unknown"],
+    { cwd: repoRoot, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+  );
+  const metadata = JSON.parse(output) as CargoMetadata;
+  const packages = new Map(metadata.packages.map((pkg) => [pkg.id, pkg]));
+  const nodes = new Map(metadata.resolve.nodes.map((node) => [node.id, node]));
+  const root = metadata.packages.find((pkg) => pkg.name === "runtimed-wasm");
+  if (!root) throw new Error("Cargo metadata has no runtimed-wasm package");
+
+  const seen = new Set<string>();
+  const pending = [root.id];
+  while (pending.length > 0) {
+    const id = pending.pop() as string;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    for (const dependency of nodes.get(id)?.deps ?? []) {
+      if (dependency.dep_kinds.some((kind) => kind.kind !== "dev")) pending.push(dependency.pkg);
+    }
+  }
+
+  return Promise.all(
+    [...seen]
+      .map((id) => packages.get(id))
+      .filter((pkg): pkg is NonNullable<typeof pkg> => pkg !== undefined)
+      .sort((left, right) =>
+        left.name.localeCompare(right.name) || left.version.localeCompare(right.version),
+      )
+      .map(async (pkg) => {
+        if (!pkg.license) throw new Error(`Cargo package ${pkg.name}@${pkg.version} has no license metadata`);
+        return {
+          ecosystem: "cargo" as const,
+          name: pkg.name,
+          version: pkg.version,
+          licenseDeclared: validateLicenseExpression(pkg.license),
+          licenseTexts: await cargoLicenseTexts(pkg.manifest_path, repoRoot),
+          homepage: pkg.homepage ?? pkg.repository ?? undefined,
+        };
+      }),
+  );
+}
+
+export async function collectOpaqueRendererAssets(repoRoot: string): Promise<OpaqueRendererAsset[]> {
+  const rendererRoot = path.join(repoRoot, "apps/notebook/src/renderer-plugins");
+  return Promise.all(
+    Object.entries(OPAQUE_RENDERER_COMPONENTS)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(async ([filename, components]) => {
+        const absolute = path.join(rendererRoot, filename);
+        let bytes: Uint8Array;
+        try {
+          bytes = await readFile(absolute);
+        } catch (error) {
+          throw new Error(`Missing opaque renderer asset ${filename}`, { cause: error });
+        }
+        if (bytes.byteLength === 0 || new TextDecoder().decode(bytes.subarray(0, 80)).startsWith("version https://git-lfs.github.com/spec/")) {
+          throw new Error(`Opaque renderer asset ${filename} has no release payload`);
+        }
+        return {
+          path: `apps/notebook/src/renderer-plugins/${filename}`,
+          bytes: bytes.byteLength,
+          sha256: sha256(bytes),
+          components,
+        };
+      }),
+  );
+}
+
+async function filesBelow(root: string, current = root): Promise<string[]> {
+  const entries = await readdir(current, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const absolute = path.join(current, entry.name);
+    if (entry.isDirectory()) files.push(...(await filesBelow(root, absolute)));
+    else if (entry.isFile()) files.push(path.relative(root, absolute).split(path.sep).join("/"));
+  }
+  return files;
+}
+
+export async function collectShippedWebFiles(outputDir: string): Promise<ShippedWebFile[]> {
+  const paths = (await filesBelow(outputDir)).filter((filename) => /\.(?:js|wasm)$/.test(filename));
+  return Promise.all(
+    paths.map(async (filename) => {
+      const absolute = path.join(outputDir, ...filename.split("/"));
+      const [bytes, info] = await Promise.all([readFile(absolute), stat(absolute)]);
+      return { path: filename, bytes: info.size, sha1: sha1(bytes), sha256: sha256(bytes) };
+    }),
+  );
+}
+
+function componentId(component: ComplianceComponent): string {
+  const key = `${component.ecosystem}:${component.name}@${component.version}`;
+  return `SPDXRef-Package-${component.ecosystem}-${sha256(key).slice(0, 16)}`;
+}
+
+function fileId(file: ShippedWebFile): string {
+  return `SPDXRef-File-${sha256(file.path).slice(0, 16)}`;
+}
+
+function packageUrl(component: ComplianceComponent): string {
+  if (component.ecosystem === "cargo") {
+    return `pkg:cargo/${encodeURIComponent(component.name)}@${encodeURIComponent(component.version)}`;
+  }
+  const npmName = component.name.startsWith("@")
+    ? `%40${component.name.slice(1).split("/").map(encodeURIComponent).join("/")}`
+    : encodeURIComponent(component.name);
+  return `pkg:npm/${npmName}@${encodeURIComponent(component.version)}`;
+}
+
+function copyrightText(component: ComplianceComponent): string {
+  const lines = component.licenseTexts.flatMap((license) =>
+    license.text
+      .split(/\r?\n/)
+      .filter((line) => /copyright|all rights reserved/i.test(line.trim())),
+  );
+  return [...new Set(lines)].join("\n") || "NOASSERTION";
+}
+
+function creationDate(): string {
+  const seconds = Number.parseInt(process.env.SOURCE_DATE_EPOCH ?? "0", 10);
+  return new Date(Number.isFinite(seconds) ? seconds * 1000 : 0).toISOString().replace(".000Z", "Z");
+}
+
+export function buildSpdxDocument(options: {
+  components: ComplianceComponent[];
+  opaqueRendererAssets: OpaqueRendererAsset[];
+  shippedWebFiles: ShippedWebFile[];
+  sourceRevision: string;
+  version: string;
+}): NotebookWebSpdxDocument {
+  const created = creationDate();
+  const packages: SpdxPackage[] = [
+    {
+      SPDXID: "SPDXRef-Package-notebook-web",
+      name: "nteract-notebook-web",
+      versionInfo: options.version,
+      downloadLocation: "NOASSERTION",
+      filesAnalyzed: true,
+      packageVerificationCode: {
+        packageVerificationCodeValue: sha1(
+          options.shippedWebFiles
+            .map((file) => file.sha1)
+            .sort()
+            .join(""),
+        ),
+      },
+      licenseConcluded: "BSD-3-Clause",
+      licenseDeclared: "BSD-3-Clause",
+      copyrightText: "Copyright (c) 2024, runtimed",
+      externalRefs: [],
+    },
+    ...options.components.map((component) => ({
+      SPDXID: componentId(component),
+      name: component.name,
+      versionInfo: component.version,
+      downloadLocation: "NOASSERTION" as const,
+      filesAnalyzed: false as const,
+      licenseConcluded: component.licenseDeclared,
+      licenseDeclared: component.licenseDeclared,
+      copyrightText: copyrightText(component),
+      externalRefs: [
+        {
+          referenceCategory: "PACKAGE-MANAGER" as const,
+          referenceType: "purl" as const,
+          referenceLocator: packageUrl(component),
+        },
+      ],
+    })),
+  ];
+  const files: SpdxFile[] = options.shippedWebFiles.map((file) => ({
+    SPDXID: fileId(file),
+    fileName: file.path,
+    checksums: [
+      { algorithm: "SHA1", checksumValue: file.sha1 },
+      { algorithm: "SHA256", checksumValue: file.sha256 },
+    ],
+    licenseConcluded: "NOASSERTION",
+    copyrightText: "NOASSERTION",
+  }));
+  return {
+    spdxVersion: "SPDX-2.3",
+    dataLicense: "CC0-1.0",
+    SPDXID: "SPDXRef-DOCUMENT",
+    name: `nteract-notebook-web-${options.version}`,
+    documentNamespace: `https://github.com/nteract/nteract/notebook-web/${encodeURIComponent(options.version)}/${encodeURIComponent(options.sourceRevision)}`,
+    creationInfo: {
+      created,
+      creators: ["Tool: nteract-notebook-web-compliance"],
+    },
+    documentDescribes: ["SPDXRef-Package-notebook-web"],
+    packages,
+    files,
+    relationships: [
+      ...options.components.map((component) => ({
+        spdxElementId: "SPDXRef-Package-notebook-web",
+        relationshipType: "DEPENDS_ON" as const,
+        relatedSpdxElement: componentId(component),
+      })),
+      ...options.shippedWebFiles.map((file) => ({
+        spdxElementId: "SPDXRef-Package-notebook-web",
+        relationshipType: "CONTAINS" as const,
+        relatedSpdxElement: fileId(file),
+      })),
+    ],
+    annotations: [
+      {
+        annotationDate: created,
+        annotationType: "OTHER",
+        annotator: "Tool: nteract-notebook-web-compliance",
+        comment: `Opaque renderer build inputs: ${JSON.stringify(options.opaqueRendererAssets)}`,
+      },
+    ],
+  };
+}
+
+export function buildThirdPartyNotices(
+  components: ComplianceComponent[],
+  opaqueRendererAssets: OpaqueRendererAsset[],
+): string {
+  const sections = [
+    "NTERACT NOTEBOOK WEB THIRD-PARTY NOTICES",
+    "",
+    "This conservative inventory covers the production npm dependency closure, the non-dev runtimed-wasm Cargo dependency closure, and the opaque renderer build inputs listed below.",
+    "",
+    "OPAQUE RENDERER BUILD INPUTS",
+    ...opaqueRendererAssets.map(
+      (asset) =>
+        `${asset.path}  ${asset.sha256}  ${asset.bytes} bytes  components=${asset.components.join(",")}`,
+    ),
+    "",
+  ];
+  for (const component of components) {
+    sections.push(
+      `================================================================================`,
+      `${component.ecosystem}:${component.name}@${component.version}`,
+      `Declared license: ${component.licenseDeclared}`,
+    );
+    if (component.homepage) sections.push(`Homepage: ${component.homepage}`);
+    for (const license of component.licenseTexts) {
+      sections.push("", `--- ${license.name} ---`, license.text);
+    }
+    sections.push("");
+  }
+  return `${sections.join("\n").trimEnd()}\n`;
+}
+
+export async function generateNotebookWebCompliance(options: {
+  outputDir: string;
+  repoRoot: string;
+  sourceRevision: string;
+  version: string;
+}): Promise<void> {
+  const [npmComponents, cargoComponents, opaqueRendererAssets, shippedWebFiles, rootLicense] =
+    await Promise.all([
+      collectNpmComponents(options.repoRoot),
+      collectCargoComponents(options.repoRoot),
+      collectOpaqueRendererAssets(options.repoRoot),
+      collectShippedWebFiles(options.outputDir),
+      readFile(path.join(options.repoRoot, "LICENSE"), "utf8"),
+    ]);
+  const components = [...npmComponents, ...cargoComponents].sort((left, right) =>
+    left.ecosystem.localeCompare(right.ecosystem) ||
+    left.name.localeCompare(right.name) ||
+    left.version.localeCompare(right.version),
+  );
+  const notices = buildThirdPartyNotices(components, opaqueRendererAssets);
+  const spdx = buildSpdxDocument({
+    components,
+    opaqueRendererAssets,
+    shippedWebFiles,
+    sourceRevision: options.sourceRevision,
+    version: options.version,
+  });
+
+  await Promise.all([
+    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_LICENSE), rootLicense),
+    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_NOTICES), notices),
+    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_SBOM), `${JSON.stringify(spdx, null, 2)}\n`),
+  ]);
+}
+
+export async function assertNotebookWebCompliance(outputDir: string): Promise<void> {
+  const [license, notices, spdxText, shippedWebFiles] = await Promise.all([
+    readFile(path.join(outputDir, NOTEBOOK_WEB_LICENSE), "utf8"),
+    readFile(path.join(outputDir, NOTEBOOK_WEB_NOTICES), "utf8"),
+    readFile(path.join(outputDir, NOTEBOOK_WEB_SBOM), "utf8"),
+    collectShippedWebFiles(outputDir),
+  ]);
+  if (!license.includes("BSD 3-Clause License")) throw new Error("Notebook Web LICENSE is invalid");
+  if (!notices.includes("OPAQUE RENDERER BUILD INPUTS")) {
+    throw new Error("Notebook Web third-party notices omit renderer provenance");
+  }
+  const spdx = JSON.parse(spdxText) as NotebookWebSpdxDocument;
+  if (spdx.spdxVersion !== "SPDX-2.3" || spdx.packages.length < 2) {
+    throw new Error("Notebook Web SPDX document is incomplete");
+  }
+  for (const pkg of spdx.packages) validateLicenseExpression(pkg.licenseDeclared);
+  const expectedFiles = shippedWebFiles.map((file) => `${file.path}:${file.sha256}`).sort();
+  const actualFiles = spdx.files
+    .map(
+      (file) =>
+        `${file.fileName}:${file.checksums.find((checksum) => checksum.algorithm === "SHA256")?.checksumValue ?? ""}`,
+    )
+    .sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    throw new Error("Notebook Web SPDX file provenance is incomplete");
+  }
+  const rendererAnnotation = spdx.annotations.find((annotation) =>
+    annotation.comment.startsWith("Opaque renderer build inputs: "),
+  );
+  if (!rendererAnnotation) throw new Error("Notebook Web SPDX document omits renderer provenance");
+  const assets = JSON.parse(rendererAnnotation.comment.slice(rendererAnnotation.comment.indexOf(": ") + 2)) as OpaqueRendererAsset[];
+  const expected = Object.keys(OPAQUE_RENDERER_COMPONENTS).sort();
+  const actual = assets.map((asset) => path.basename(asset.path)).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error("Notebook Web SPDX renderer provenance is incomplete");
+  }
+}

--- a/scripts/notebook-web-compliance.ts
+++ b/scripts/notebook-web-compliance.ts
@@ -109,8 +109,32 @@ export function assertRequiredNotebookNpmComponents(componentNames: Iterable<str
   }
 }
 
-export function pnpmExecutable(platform: NodeJS.Platform = process.platform): string {
-  return platform === "win32" ? "pnpm.cmd" : "pnpm";
+export type PnpmInvocation = { file: string; args: string[] };
+
+export function pnpmInvocation(
+  args: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+): PnpmInvocation {
+  if (platform !== "win32") return { file: "pnpm", args: [...args] };
+  for (const argument of args) {
+    if (!/^[A-Za-z0-9@._/:=+-]+$/.test(argument)) {
+      throw new Error(`Unsafe pnpm argument for Windows command shell: ${JSON.stringify(argument)}`);
+    }
+  }
+  const commandLine = [`"pnpm.cmd"`, ...args.map((argument) => `"${argument}"`)].join(" ");
+  return {
+    file: "cmd.exe",
+    args: ["/d", "/s", "/c", `"${commandLine}"`],
+  };
+}
+
+function execPnpm(repoRoot: string, args: readonly string[]): string {
+  const invocation = pnpmInvocation(args);
+  return execFileSync(invocation.file, invocation.args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
 }
 
 type LicenseText = { name: string; text: string };
@@ -338,19 +362,15 @@ async function pnpmLicenseRecords(
   workspaceFilter: string,
   prod: boolean,
 ): Promise<NpmPackageRecord[]> {
-  const output = execFileSync(
-    pnpmExecutable(),
-    [
-      "--filter",
-      workspaceFilter,
-      "licenses",
-      "list",
-      ...(prod ? ["--prod"] : []),
-      "--json",
-      "--long",
-    ],
-    { cwd: repoRoot, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
-  );
+  const output = execPnpm(repoRoot, [
+    "--filter",
+    workspaceFilter,
+    "licenses",
+    "list",
+    ...(prod ? ["--prod"] : []),
+    "--json",
+    "--long",
+  ]);
   const grouped = JSON.parse(output) as Record<string, PnpmLicenseRecord[]>;
   const records = Object.entries(grouped).flatMap(([license, packages]) =>
     packages.flatMap((entry) => entry.paths.map((packageRoot) => ({ ...entry, packageRoot, license }))),
@@ -379,11 +399,7 @@ async function pnpmLicenseRecords(
 type PnpmWorkspaceRecord = { name?: string; version?: string; path: string };
 
 async function collectWorkspaceNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
-  const output = execFileSync(
-    pnpmExecutable(),
-    ["list", "--recursive", "--depth", "-1", "--json"],
-    { cwd: repoRoot, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
-  );
+  const output = execPnpm(repoRoot, ["list", "--recursive", "--depth", "-1", "--json"]);
   const workspaces = JSON.parse(output) as PnpmWorkspaceRecord[];
   const workspaceByName = new Map(
     workspaces

--- a/scripts/notebook-web-compliance.ts
+++ b/scripts/notebook-web-compliance.ts
@@ -6,6 +6,13 @@ import path from "node:path";
 export const NOTEBOOK_WEB_LICENSE = "LICENSE";
 export const NOTEBOOK_WEB_NOTICES = "THIRD_PARTY_NOTICES.txt";
 export const NOTEBOOK_WEB_SBOM = "notebook-web.spdx.json";
+export const NOTEBOOK_WEB_BUILD_PROVENANCE = "notebook-web-build-provenance.json";
+
+const SPDX_EXCLUDED_METADATA = [
+  NOTEBOOK_WEB_SBOM,
+  "notebook-web-manifest.json",
+  "SHA256SUMS",
+] as const;
 
 const APPROVED_LICENSE_IDS = new Set([
   "0BSD",
@@ -14,6 +21,7 @@ const APPROVED_LICENSE_IDS = new Set([
   "BSD-3-Clause",
   "ISC",
   "MIT",
+  "OFL-1.1",
   "Unicode-3.0",
   "Unlicense",
   "Zlib",
@@ -52,10 +60,26 @@ const LICENSE_FILE_OVERRIDES: Record<string, string> = {
   "remark-math": "remark-math-MIT.txt",
 };
 
+const NOTEBOOK_BUILD_INPUTS = new Set(["@tailwindcss/vite", "tailwindcss", "tw-animate-css"]);
+
+const REQUIRED_NOTEBOOK_RUNTIME_COMPONENTS = [
+  "@dnd-kit/core",
+  "@dnd-kit/sortable",
+  "@dnd-kit/utilities",
+  "@tauri-apps/api",
+  "@tauri-apps/plugin-dialog",
+  "@tauri-apps/plugin-log",
+  "@tauri-apps/plugin-process",
+  "@tauri-apps/plugin-shell",
+  "@tauri-apps/plugin-updater",
+  "rxjs",
+] as const;
+
 type LicenseText = { name: string; text: string };
 
 export type ComplianceComponent = {
-  ecosystem: "cargo" | "npm";
+  ecosystem: "asset" | "cargo" | "npm";
+  scope: "asset" | "build" | "runtime";
   name: string;
   version: string;
   licenseDeclared: string;
@@ -68,6 +92,7 @@ export type OpaqueRendererAsset = {
   bytes: number;
   sha256: string;
   components: readonly string[];
+  outputs: Array<{ path: string; sha256: string }>;
 };
 
 export type ShippedWebFile = {
@@ -83,6 +108,15 @@ type PnpmLicenseRecord = {
   paths: string[];
   license?: string;
   homepage?: string;
+};
+
+type BuildProvenance = {
+  schemaVersion: 1;
+  inputs: Array<{
+    path: string;
+    sha256: string;
+    outputs: Array<{ path: string; sha256: string }>;
+  }>;
 };
 
 type CargoMetadata = {
@@ -109,7 +143,10 @@ type SpdxPackage = {
   versionInfo: string;
   downloadLocation: "NOASSERTION";
   filesAnalyzed: boolean;
-  packageVerificationCode?: { packageVerificationCodeValue: string };
+  packageVerificationCode?: {
+    packageVerificationCodeValue: string;
+    packageVerificationCodeExcludedFiles: string[];
+  };
   licenseConcluded: string;
   licenseDeclared: string;
   copyrightText: string;
@@ -146,7 +183,7 @@ export type NotebookWebSpdxDocument = {
   files: SpdxFile[];
   relationships: Array<{
     spdxElementId: string;
-    relationshipType: "CONTAINS" | "DEPENDS_ON";
+    relationshipType: "BUILD_DEPENDENCY_OF" | "CONTAINS" | "DEPENDS_ON";
     relatedSpdxElement: string;
   }>;
   annotations: Array<{
@@ -236,10 +273,26 @@ async function npmLicenseTexts(
   throw new Error(`No license text or reviewed override for npm package ${component.name}`);
 }
 
-async function collectNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
+type NpmPackageRecord = {
+  name: string;
+  version: string;
+  license: string;
+  homepage?: string;
+  packageRoot: string;
+};
+
+async function pnpmLicenseRecords(repoRoot: string, prod: boolean): Promise<NpmPackageRecord[]> {
   const output = execFileSync(
     "pnpm",
-    ["--filter", ".", "licenses", "list", "--prod", "--json", "--long"],
+    [
+      "--filter",
+      "notebook-ui",
+      "licenses",
+      "list",
+      ...(prod ? ["--prod"] : []),
+      "--json",
+      "--long",
+    ],
     { cwd: repoRoot, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
   );
   const grouped = JSON.parse(output) as Record<string, PnpmLicenseRecord[]>;
@@ -247,11 +300,7 @@ async function collectNpmComponents(repoRoot: string): Promise<ComplianceCompone
     packages.flatMap((entry) => entry.paths.map((packageRoot) => ({ ...entry, packageRoot, license }))),
   );
 
-  const packageRoots = new Map<string, string>();
-  const packageRecords = new Map<
-    string,
-    { name: string; version: string; license: string; homepage?: string; packageRoot: string }
-  >();
+  const packageRecords = new Map<string, NpmPackageRecord>();
   for (const record of records) {
     const packageJson = JSON.parse(
       await readFile(path.join(record.packageRoot, "package.json"), "utf8"),
@@ -260,8 +309,6 @@ async function collectNpmComponents(repoRoot: string): Promise<ComplianceCompone
       throw new Error(`Invalid package metadata under ${record.packageRoot}`);
     }
     const license = packageJson.license ?? record.license;
-    validateLicenseExpression(license);
-    packageRoots.set(packageJson.name, record.packageRoot);
     packageRecords.set(`${packageJson.name}@${packageJson.version}`, {
       name: packageJson.name,
       version: packageJson.version,
@@ -270,14 +317,43 @@ async function collectNpmComponents(repoRoot: string): Promise<ComplianceCompone
       packageRoot: record.packageRoot,
     });
   }
+  return [...packageRecords.values()];
+}
+
+async function collectNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
+  const [runtimeRecords, allRecords] = await Promise.all([
+    pnpmLicenseRecords(repoRoot, true),
+    pnpmLicenseRecords(repoRoot, false),
+  ]);
+  const runtimeNames = new Set(runtimeRecords.map((record) => record.name));
+  const missing = REQUIRED_NOTEBOOK_RUNTIME_COMPONENTS.filter((name) => !runtimeNames.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Notebook runtime license closure is incomplete: ${missing.join(", ")}`);
+  }
+
+  const packageRoots = new Map(allRecords.map((record) => [record.name, record.packageRoot]));
+  const selected = new Map<string, NpmPackageRecord>();
+  for (const record of runtimeRecords) selected.set(`${record.name}@${record.version}`, record);
+  for (const record of allRecords) {
+    if (NOTEBOOK_BUILD_INPUTS.has(record.name)) {
+      selected.set(`${record.name}@${record.version}`, record);
+    }
+  }
+  const missingBuildInputs = [...NOTEBOOK_BUILD_INPUTS].filter(
+    (name) => ![...selected.values()].some((record) => record.name === name),
+  );
+  if (missingBuildInputs.length > 0) {
+    throw new Error(`Notebook CSS build provenance is incomplete: ${missingBuildInputs.join(", ")}`);
+  }
 
   return Promise.all(
-    [...packageRecords.values()]
+    [...selected.values()]
       .sort((left, right) =>
         left.name.localeCompare(right.name) || left.version.localeCompare(right.version),
       )
       .map(async (record) => ({
         ecosystem: "npm" as const,
+        scope: runtimeNames.has(record.name) ? ("runtime" as const) : ("build" as const),
         name: record.name,
         version: record.version,
         licenseDeclared: validateLicenseExpression(record.license),
@@ -347,6 +423,7 @@ async function collectCargoComponents(repoRoot: string): Promise<ComplianceCompo
         if (!pkg.license) throw new Error(`Cargo package ${pkg.name}@${pkg.version} has no license metadata`);
         return {
           ecosystem: "cargo" as const,
+          scope: "runtime" as const,
           name: pkg.name,
           version: pkg.version,
           licenseDeclared: validateLicenseExpression(pkg.license),
@@ -357,8 +434,28 @@ async function collectCargoComponents(repoRoot: string): Promise<ComplianceCompo
   );
 }
 
-export async function collectOpaqueRendererAssets(repoRoot: string): Promise<OpaqueRendererAsset[]> {
+function assertSafeRelativePath(filename: string): void {
+  if (
+    filename.length === 0 ||
+    path.isAbsolute(filename) ||
+    filename.split(/[\\/]/).some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    throw new Error(`Unsafe release provenance path ${JSON.stringify(filename)}`);
+  }
+}
+
+export async function collectOpaqueRendererAssets(
+  repoRoot: string,
+  outputDir: string,
+): Promise<OpaqueRendererAsset[]> {
   const rendererRoot = path.join(repoRoot, "apps/notebook/src/renderer-plugins");
+  const provenance = JSON.parse(
+    await readFile(path.join(outputDir, NOTEBOOK_WEB_BUILD_PROVENANCE), "utf8"),
+  ) as BuildProvenance;
+  if (provenance.schemaVersion !== 1 || !Array.isArray(provenance.inputs)) {
+    throw new Error("Notebook web build provenance is invalid");
+  }
+  const provenanceByPath = new Map(provenance.inputs.map((input) => [input.path, input]));
   return Promise.all(
     Object.entries(OPAQUE_RENDERER_COMPONENTS)
       .sort(([left], [right]) => left.localeCompare(right))
@@ -373,11 +470,31 @@ export async function collectOpaqueRendererAssets(repoRoot: string): Promise<Opa
         if (bytes.byteLength === 0 || new TextDecoder().decode(bytes.subarray(0, 80)).startsWith("version https://git-lfs.github.com/spec/")) {
           throw new Error(`Opaque renderer asset ${filename} has no release payload`);
         }
+        const sourcePath = `apps/notebook/src/renderer-plugins/${filename}`;
+        const sourceSha256 = sha256(bytes);
+        const buildInput = provenanceByPath.get(sourcePath);
+        if (!buildInput || buildInput.sha256 !== sourceSha256 || buildInput.outputs.length === 0) {
+          throw new Error(`Opaque renderer build provenance is stale or missing for ${filename}`);
+        }
+        const outputs = await Promise.all(
+          buildInput.outputs.map(async (output) => {
+            assertSafeRelativePath(output.path);
+            const outputBytes = await readFile(
+              path.join(outputDir, ...output.path.split(/[\\/]/)),
+            );
+            const outputSha256 = sha256(outputBytes);
+            if (output.sha256 !== outputSha256) {
+              throw new Error(`Opaque renderer output provenance is stale for ${output.path}`);
+            }
+            return { path: output.path, sha256: outputSha256 };
+          }),
+        );
         return {
-          path: `apps/notebook/src/renderer-plugins/${filename}`,
+          path: sourcePath,
           bytes: bytes.byteLength,
-          sha256: sha256(bytes),
+          sha256: sourceSha256,
           components,
+          outputs,
         };
       }),
   );
@@ -390,12 +507,15 @@ async function filesBelow(root: string, current = root): Promise<string[]> {
     const absolute = path.join(current, entry.name);
     if (entry.isDirectory()) files.push(...(await filesBelow(root, absolute)));
     else if (entry.isFile()) files.push(path.relative(root, absolute).split(path.sep).join("/"));
+    else throw new Error(`Release artifact contains non-regular entry ${path.relative(root, absolute)}`);
   }
   return files;
 }
 
 export async function collectShippedWebFiles(outputDir: string): Promise<ShippedWebFile[]> {
-  const paths = (await filesBelow(outputDir)).filter((filename) => /\.(?:js|wasm)$/.test(filename));
+  const paths = (await filesBelow(outputDir)).filter(
+    (filename) => !SPDX_EXCLUDED_METADATA.includes(filename as (typeof SPDX_EXCLUDED_METADATA)[number]),
+  );
   return Promise.all(
     paths.map(async (filename) => {
       const absolute = path.join(outputDir, ...filename.split("/"));
@@ -417,6 +537,9 @@ function fileId(file: ShippedWebFile): string {
 function packageUrl(component: ComplianceComponent): string {
   if (component.ecosystem === "cargo") {
     return `pkg:cargo/${encodeURIComponent(component.name)}@${encodeURIComponent(component.version)}`;
+  }
+  if (component.ecosystem === "asset") {
+    return `pkg:generic/${encodeURIComponent(component.name)}@${encodeURIComponent(component.version)}`;
   }
   const npmName = component.name.startsWith("@")
     ? `%40${component.name.slice(1).split("/").map(encodeURIComponent).join("/")}`
@@ -460,6 +583,7 @@ export function buildSpdxDocument(options: {
             .sort()
             .join(""),
         ),
+        packageVerificationCodeExcludedFiles: [...SPDX_EXCLUDED_METADATA],
       },
       licenseConcluded: "BSD-3-Clause",
       licenseDeclared: "BSD-3-Clause",
@@ -508,11 +632,19 @@ export function buildSpdxDocument(options: {
     packages,
     files,
     relationships: [
-      ...options.components.map((component) => ({
-        spdxElementId: "SPDXRef-Package-notebook-web",
-        relationshipType: "DEPENDS_ON" as const,
-        relatedSpdxElement: componentId(component),
-      })),
+      ...options.components.map((component) =>
+        component.scope === "build"
+          ? {
+              spdxElementId: componentId(component),
+              relationshipType: "BUILD_DEPENDENCY_OF" as const,
+              relatedSpdxElement: "SPDXRef-Package-notebook-web",
+            }
+          : {
+              spdxElementId: "SPDXRef-Package-notebook-web",
+              relationshipType: "DEPENDS_ON" as const,
+              relatedSpdxElement: componentId(component),
+            },
+      ),
       ...options.shippedWebFiles.map((file) => ({
         spdxElementId: "SPDXRef-Package-notebook-web",
         relationshipType: "CONTAINS" as const,
@@ -537,12 +669,12 @@ export function buildThirdPartyNotices(
   const sections = [
     "NTERACT NOTEBOOK WEB THIRD-PARTY NOTICES",
     "",
-    "This conservative inventory covers the production npm dependency closure, the non-dev runtimed-wasm Cargo dependency closure, and the opaque renderer build inputs listed below.",
+    "This conservative inventory covers the notebook-ui production npm dependency closure, explicit CSS build inputs, the non-dev runtimed-wasm Cargo dependency closure, shipped asset license families, and the opaque renderer build inputs listed below.",
     "",
     "OPAQUE RENDERER BUILD INPUTS",
     ...opaqueRendererAssets.map(
       (asset) =>
-        `${asset.path}  ${asset.sha256}  ${asset.bytes} bytes  components=${asset.components.join(",")}`,
+        `${asset.path}  ${asset.sha256}  ${asset.bytes} bytes  components=${asset.components.join(",")}  outputs=${asset.outputs.map((output) => `${output.path}:${output.sha256}`).join(",")}`,
     ),
     "",
   ];
@@ -550,6 +682,7 @@ export function buildThirdPartyNotices(
     sections.push(
       `================================================================================`,
       `${component.ecosystem}:${component.name}@${component.version}`,
+      `Scope: ${component.scope}`,
       `Declared license: ${component.licenseDeclared}`,
     );
     if (component.homepage) sections.push(`Homepage: ${component.homepage}`);
@@ -561,26 +694,62 @@ export function buildThirdPartyNotices(
   return `${sections.join("\n").trimEnd()}\n`;
 }
 
+async function collectAssetComponents(
+  repoRoot: string,
+  outputDir: string,
+  npmComponents: ComplianceComponent[],
+): Promise<ComplianceComponent[]> {
+  const shippedPaths = await filesBelow(outputDir);
+  if (!shippedPaths.some((filename) => /\/KaTeX_.+\.(?:ttf|woff2?)$/.test(filename))) {
+    throw new Error("Notebook Web build is missing its KaTeX font assets");
+  }
+  const katex = npmComponents.find((component) => component.name === "katex");
+  if (!katex) throw new Error("Notebook runtime license closure is missing KaTeX");
+  const ofl = await readFile(
+    path.join(repoRoot, "scripts/license-overrides/katex-fonts-OFL-1.1.txt"),
+    "utf8",
+  );
+  return [
+    {
+      ecosystem: "asset",
+      scope: "asset",
+      name: "KaTeX-fonts",
+      version: katex.version,
+      licenseDeclared: "OFL-1.1",
+      licenseTexts: [{ name: "OFL-1.1 (KaTeX font assets)", text: ofl.trim() }],
+      homepage: `https://github.com/KaTeX/KaTeX/tree/v${katex.version}/src/fonts`,
+    },
+  ];
+}
+
 export async function generateNotebookWebCompliance(options: {
   outputDir: string;
   repoRoot: string;
   sourceRevision: string;
   version: string;
 }): Promise<void> {
-  const [npmComponents, cargoComponents, opaqueRendererAssets, shippedWebFiles, rootLicense] =
-    await Promise.all([
-      collectNpmComponents(options.repoRoot),
-      collectCargoComponents(options.repoRoot),
-      collectOpaqueRendererAssets(options.repoRoot),
-      collectShippedWebFiles(options.outputDir),
-      readFile(path.join(options.repoRoot, "LICENSE"), "utf8"),
-    ]);
-  const components = [...npmComponents, ...cargoComponents].sort((left, right) =>
+  const [npmComponents, cargoComponents, opaqueRendererAssets, rootLicense] = await Promise.all([
+    collectNpmComponents(options.repoRoot),
+    collectCargoComponents(options.repoRoot),
+    collectOpaqueRendererAssets(options.repoRoot, options.outputDir),
+    readFile(path.join(options.repoRoot, "LICENSE"), "utf8"),
+  ]);
+  const assetComponents = await collectAssetComponents(
+    options.repoRoot,
+    options.outputDir,
+    npmComponents,
+  );
+  const components = [...assetComponents, ...npmComponents, ...cargoComponents].sort((left, right) =>
     left.ecosystem.localeCompare(right.ecosystem) ||
     left.name.localeCompare(right.name) ||
     left.version.localeCompare(right.version),
   );
   const notices = buildThirdPartyNotices(components, opaqueRendererAssets);
+  await Promise.all([
+    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_LICENSE), rootLicense),
+    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_NOTICES), notices),
+  ]);
+  const shippedWebFiles = await collectShippedWebFiles(options.outputDir);
   const spdx = buildSpdxDocument({
     components,
     opaqueRendererAssets,
@@ -589,11 +758,10 @@ export async function generateNotebookWebCompliance(options: {
     version: options.version,
   });
 
-  await Promise.all([
-    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_LICENSE), rootLicense),
-    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_NOTICES), notices),
-    writeFile(path.join(options.outputDir, NOTEBOOK_WEB_SBOM), `${JSON.stringify(spdx, null, 2)}\n`),
-  ]);
+  await writeFile(
+    path.join(options.outputDir, NOTEBOOK_WEB_SBOM),
+    `${JSON.stringify(spdx, null, 2)}\n`,
+  );
 }
 
 export async function assertNotebookWebCompliance(outputDir: string): Promise<void> {
@@ -622,6 +790,31 @@ export async function assertNotebookWebCompliance(outputDir: string): Promise<vo
   if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
     throw new Error("Notebook Web SPDX file provenance is incomplete");
   }
+  const containedFiles = spdx.relationships
+    .filter(
+      (relationship) =>
+        relationship.spdxElementId === "SPDXRef-Package-notebook-web" &&
+        relationship.relationshipType === "CONTAINS",
+    )
+    .map((relationship) => relationship.relatedSpdxElement)
+    .sort();
+  const expectedContainedFiles = spdx.files.map((file) => file.SPDXID).sort();
+  if (JSON.stringify(containedFiles) !== JSON.stringify(expectedContainedFiles)) {
+    throw new Error("Notebook Web SPDX file relationships are incomplete");
+  }
+  const rootPackage = spdx.packages.find(
+    (pkg) => pkg.SPDXID === "SPDXRef-Package-notebook-web",
+  );
+  const expectedVerificationCode = sha1(shippedWebFiles.map((file) => file.sha1).sort().join(""));
+  if (
+    !rootPackage?.filesAnalyzed ||
+    rootPackage.packageVerificationCode?.packageVerificationCodeValue !==
+      expectedVerificationCode ||
+    JSON.stringify(rootPackage.packageVerificationCode.packageVerificationCodeExcludedFiles) !==
+      JSON.stringify(SPDX_EXCLUDED_METADATA)
+  ) {
+    throw new Error("Notebook Web SPDX package verification code is invalid");
+  }
   const rendererAnnotation = spdx.annotations.find((annotation) =>
     annotation.comment.startsWith("Opaque renderer build inputs: "),
   );
@@ -631,5 +824,21 @@ export async function assertNotebookWebCompliance(outputDir: string): Promise<vo
   const actual = assets.map((asset) => path.basename(asset.path)).sort();
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     throw new Error("Notebook Web SPDX renderer provenance is incomplete");
+  }
+  const spdxFileHashes = new Map(
+    spdx.files.map((file) => [
+      file.fileName,
+      file.checksums.find((checksum) => checksum.algorithm === "SHA256")?.checksumValue,
+    ]),
+  );
+  for (const asset of assets) {
+    if (asset.outputs.length === 0) {
+      throw new Error(`Notebook Web SPDX renderer output provenance is empty for ${asset.path}`);
+    }
+    for (const output of asset.outputs) {
+      if (spdxFileHashes.get(output.path) !== output.sha256) {
+        throw new Error(`Notebook Web SPDX renderer output provenance is stale for ${output.path}`);
+      }
+    }
   }
 }

--- a/scripts/notebook-web-compliance.ts
+++ b/scripts/notebook-web-compliance.ts
@@ -1,7 +1,16 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
+
+type SpdxExpressionNode =
+  | { license: string; exception?: string; plus?: boolean }
+  | { left: SpdxExpressionNode; conjunction: "and" | "or"; right: SpdxExpressionNode };
+
+const parseSpdxExpression = createRequire(import.meta.url)("spdx-expression-parse") as (
+  expression: string,
+) => SpdxExpressionNode;
 
 export const NOTEBOOK_WEB_LICENSE = "LICENSE";
 export const NOTEBOOK_WEB_NOTICES = "THIRD_PARTY_NOTICES.txt";
@@ -62,18 +71,47 @@ const LICENSE_FILE_OVERRIDES: Record<string, string> = {
 
 const NOTEBOOK_BUILD_INPUTS = new Set(["@tailwindcss/vite", "tailwindcss", "tw-animate-css"]);
 
-const REQUIRED_NOTEBOOK_RUNTIME_COMPONENTS = [
+const REQUIRED_NPM_COMPONENTS = [
+  "@chenglou/pretext",
+  "@codemirror/lang-yaml",
   "@dnd-kit/core",
   "@dnd-kit/sortable",
   "@dnd-kit/utilities",
+  "@lezer/yaml",
+  "@nteract/notebook-host",
+  "@nteract/odometer",
+  "@nteract/sift",
   "@tauri-apps/api",
   "@tauri-apps/plugin-dialog",
   "@tauri-apps/plugin-log",
   "@tauri-apps/plugin-process",
   "@tauri-apps/plugin-shell",
   "@tauri-apps/plugin-updater",
+  "leaflet",
+  "lezer-toml",
+  "plotly.js-dist-min",
   "rxjs",
+  "runtimed",
+  "vega",
+  "vega-embed",
+  "vega-lite",
 ] as const;
+
+export function requiredNotebookNpmComponents(): readonly string[] {
+  return REQUIRED_NPM_COMPONENTS;
+}
+
+export function assertRequiredNotebookNpmComponents(componentNames: Iterable<string>): void {
+  const names = new Set(componentNames);
+  const missing = REQUIRED_NPM_COMPONENTS.filter((name) => !names.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Notebook npm and renderer license closure is incomplete: ${missing.join(", ")}`);
+  }
+}
+
+export function pnpmExecutable(platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
 
 type LicenseText = { name: string; text: string };
 
@@ -211,15 +249,29 @@ function normalizedLicenseExpression(expression: string): string {
 
 export function validateLicenseExpression(expression: string): string {
   const normalized = normalizedLicenseExpression(expression);
-  const identifiers = normalized.match(/[A-Za-z0-9.-]+/g) ?? [];
-  const unknown = identifiers.filter(
-    (identifier) => identifier !== "AND" && identifier !== "OR" && !APPROVED_LICENSE_IDS.has(identifier),
-  );
-  if (identifiers.length === 0 || unknown.length > 0) {
+  let parsed: SpdxExpressionNode;
+  try {
+    parsed = parseSpdxExpression(normalized);
+  } catch (error) {
+    throw new Error(`Invalid SPDX license expression ${JSON.stringify(expression)}`, {
+      cause: error,
+    });
+  }
+  const licenses: string[] = [];
+  const visit = (node: SpdxExpressionNode): void => {
+    if ("license" in node) {
+      licenses.push(node.license);
+      if (node.exception || node.plus) licenses.push(node.exception ?? `${node.license}+`);
+      return;
+    }
+    visit(node.left);
+    visit(node.right);
+  };
+  visit(parsed);
+  const unknown = licenses.filter((identifier) => !APPROVED_LICENSE_IDS.has(identifier));
+  if (unknown.length > 0) {
     throw new Error(
-      `Unapproved or unknown license expression ${JSON.stringify(expression)}${
-        unknown.length > 0 ? ` (${unknown.join(", ")})` : ""
-      }`,
+      `Unapproved or unknown license expression ${JSON.stringify(expression)} (${unknown.join(", ")})`,
     );
   }
   return normalized;
@@ -281,12 +333,16 @@ type NpmPackageRecord = {
   packageRoot: string;
 };
 
-async function pnpmLicenseRecords(repoRoot: string, prod: boolean): Promise<NpmPackageRecord[]> {
+async function pnpmLicenseRecords(
+  repoRoot: string,
+  workspaceFilter: string,
+  prod: boolean,
+): Promise<NpmPackageRecord[]> {
   const output = execFileSync(
-    "pnpm",
+    pnpmExecutable(),
     [
       "--filter",
-      "notebook-ui",
+      workspaceFilter,
       "licenses",
       "list",
       ...(prod ? ["--prod"] : []),
@@ -320,16 +376,92 @@ async function pnpmLicenseRecords(repoRoot: string, prod: boolean): Promise<NpmP
   return [...packageRecords.values()];
 }
 
-async function collectNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
-  const [runtimeRecords, allRecords] = await Promise.all([
-    pnpmLicenseRecords(repoRoot, true),
-    pnpmLicenseRecords(repoRoot, false),
-  ]);
-  const runtimeNames = new Set(runtimeRecords.map((record) => record.name));
-  const missing = REQUIRED_NOTEBOOK_RUNTIME_COMPONENTS.filter((name) => !runtimeNames.has(name));
-  if (missing.length > 0) {
-    throw new Error(`Notebook runtime license closure is incomplete: ${missing.join(", ")}`);
+type PnpmWorkspaceRecord = { name?: string; version?: string; path: string };
+
+async function collectWorkspaceNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
+  const output = execFileSync(
+    pnpmExecutable(),
+    ["list", "--recursive", "--depth", "-1", "--json"],
+    { cwd: repoRoot, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  const workspaces = JSON.parse(output) as PnpmWorkspaceRecord[];
+  const workspaceByName = new Map(
+    workspaces
+      .filter((workspace): workspace is Required<PnpmWorkspaceRecord> =>
+        Boolean(workspace.name && workspace.version),
+      )
+      .map((workspace) => [workspace.name, workspace]),
+  );
+  const entryManifests = [
+    path.join(repoRoot, "package.json"),
+    path.join(repoRoot, "apps/notebook/package.json"),
+  ];
+  const pending: string[] = [];
+  for (const manifestPath of entryManifests) {
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    for (const name of Object.keys(manifest.dependencies ?? {})) {
+      if (workspaceByName.has(name)) pending.push(name);
+    }
   }
+
+  const seen = new Set<string>();
+  const manifests = new Map<string, Required<PnpmWorkspaceRecord> & { license?: string }>();
+  while (pending.length > 0) {
+    const name = pending.pop() as string;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const workspace = workspaceByName.get(name);
+    if (!workspace) throw new Error(`Workspace package ${name} is unavailable`);
+    const resolvedRoot = path.resolve(workspace.path);
+    if (resolvedRoot !== repoRoot && !resolvedRoot.startsWith(`${repoRoot}${path.sep}`)) {
+      throw new Error(`Workspace package ${name} resolves outside the repository`);
+    }
+    const manifest = JSON.parse(await readFile(path.join(resolvedRoot, "package.json"), "utf8")) as {
+      name?: string;
+      version?: string;
+      license?: string;
+      dependencies?: Record<string, string>;
+    };
+    if (manifest.name !== name || !manifest.version) {
+      throw new Error(`Invalid workspace package metadata for ${name}`);
+    }
+    manifests.set(name, { ...workspace, version: manifest.version, license: manifest.license });
+    for (const dependency of Object.keys(manifest.dependencies ?? {})) {
+      if (workspaceByName.has(dependency)) pending.push(dependency);
+    }
+  }
+
+  const rootLicense = (await readFile(path.join(repoRoot, "LICENSE"), "utf8")).trim();
+  return [...manifests.values()]
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((workspace) => ({
+      ecosystem: "npm" as const,
+      scope: "runtime" as const,
+      name: workspace.name,
+      version: workspace.version,
+      licenseDeclared: validateLicenseExpression(workspace.license ?? "BSD-3-Clause"),
+      licenseTexts: [{ name: "LICENSE (workspace root)", text: rootLicense }],
+      homepage: "https://github.com/nteract/nteract",
+    }));
+}
+
+async function collectNpmComponents(repoRoot: string): Promise<ComplianceComponent[]> {
+  const [notebookRecords, sharedSourceRecords, rendererRecords, allNotebookRecords, workspaceComponents] =
+    await Promise.all([
+      pnpmLicenseRecords(repoRoot, "notebook-ui", true),
+      pnpmLicenseRecords(repoRoot, ".", true),
+      pnpmLicenseRecords(repoRoot, "@nteract/sift", true),
+      pnpmLicenseRecords(repoRoot, "notebook-ui", false),
+      collectWorkspaceNpmComponents(repoRoot),
+    ]);
+  const runtimeRecords = [...notebookRecords, ...sharedSourceRecords, ...rendererRecords];
+  const allRecords = [...runtimeRecords, ...allNotebookRecords];
+  const runtimeNames = new Set([
+    ...runtimeRecords.map((record) => record.name),
+    ...workspaceComponents.map((component) => component.name),
+  ]);
 
   const packageRoots = new Map(allRecords.map((record) => [record.name, record.packageRoot]));
   const selected = new Map<string, NpmPackageRecord>();
@@ -346,7 +478,7 @@ async function collectNpmComponents(repoRoot: string): Promise<ComplianceCompone
     throw new Error(`Notebook CSS build provenance is incomplete: ${missingBuildInputs.join(", ")}`);
   }
 
-  return Promise.all(
+  const registryComponents = await Promise.all(
     [...selected.values()]
       .sort((left, right) =>
         left.name.localeCompare(right.name) || left.version.localeCompare(right.version),
@@ -361,6 +493,9 @@ async function collectNpmComponents(repoRoot: string): Promise<ComplianceCompone
         homepage: record.homepage,
       })),
   );
+  const components = [...registryComponents, ...workspaceComponents];
+  assertRequiredNotebookNpmComponents(components.map((component) => component.name));
+  return components;
 }
 
 async function cargoLicenseTexts(

--- a/scripts/package-notebook-web.test.ts
+++ b/scripts/package-notebook-web.test.ts
@@ -9,6 +9,57 @@ import {
   NOTEBOOK_WEB_MANIFEST,
   packageNotebookWeb,
 } from "./package-notebook-web.ts";
+import {
+  assertNotebookWebCompliance,
+  buildSpdxDocument,
+  buildThirdPartyNotices,
+  collectShippedWebFiles,
+  NOTEBOOK_WEB_LICENSE,
+  NOTEBOOK_WEB_NOTICES,
+  NOTEBOOK_WEB_SBOM,
+  opaqueRendererAssetNames,
+  type ComplianceComponent,
+  type OpaqueRendererAsset,
+} from "./notebook-web-compliance.ts";
+
+const TEST_COMPONENT: ComplianceComponent = {
+  ecosystem: "npm",
+  name: "fixture-package",
+  version: "1.0.0",
+  licenseDeclared: "MIT",
+  licenseTexts: [
+    {
+      name: "LICENSE",
+      text: "MIT License\n\nCopyright (c) Fixture",
+    },
+  ],
+};
+
+const TEST_RENDERER_ASSETS: OpaqueRendererAsset[] = opaqueRendererAssetNames().map((name) => ({
+  path: `apps/notebook/src/renderer-plugins/${name}`,
+  bytes: 1,
+  sha256: "0".repeat(64),
+  components: ["nteract"],
+}));
+
+async function writeFixtureCompliance(outputDir: string): Promise<void> {
+  const shippedWebFiles = await collectShippedWebFiles(outputDir);
+  const spdx = buildSpdxDocument({
+    components: [TEST_COMPONENT],
+    opaqueRendererAssets: TEST_RENDERER_ASSETS,
+    shippedWebFiles,
+    sourceRevision: "abc1234",
+    version: "0.4.3",
+  });
+  await Promise.all([
+    writeFile(path.join(outputDir, NOTEBOOK_WEB_LICENSE), "BSD 3-Clause License\n"),
+    writeFile(
+      path.join(outputDir, NOTEBOOK_WEB_NOTICES),
+      buildThirdPartyNotices([TEST_COMPONENT], TEST_RENDERER_ASSETS),
+    ),
+    writeFile(path.join(outputDir, NOTEBOOK_WEB_SBOM), `${JSON.stringify(spdx, null, 2)}\n`),
+  ]);
+}
 
 async function fixture(includeWasm = true) {
   const root = await mkdtemp(path.join(os.tmpdir(), "nteract-notebook-web-"));
@@ -17,6 +68,7 @@ async function fixture(includeWasm = true) {
   await mkdir(path.join(distDir, "assets"), { recursive: true });
   await writeFile(path.join(distDir, "index.html"), "<main>notebook</main>");
   await writeFile(path.join(distDir, "assets", "main-AbCd1234.js"), "export {};");
+  await writeFile(path.join(distDir, "stats.html"), "/private/build/path");
   if (includeWasm) await writeFile(path.join(distDir, "assets", "runtime-ZyXw9876.wasm"), "wasm");
   return { distDir, outputDir };
 }
@@ -29,13 +81,21 @@ test("packages a revision-pinned host artifact with deterministic checksums", as
     sourceRevision: "abc1234",
     version: "0.4.3",
     channel: "nightly",
+    writeCompliance: writeFixtureCompliance,
   });
 
   assert.equal(manifest.sourceRevision, "abc1234");
   assert.equal(manifest.runtimeCompatibility.rendererAssets, "embedded-in-runtimed");
   assert.deepEqual(
     manifest.files.map((file) => file.path),
-    ["assets/main-AbCd1234.js", "assets/runtime-ZyXw9876.wasm", "index.html"],
+    [
+      "assets/main-AbCd1234.js",
+      "assets/runtime-ZyXw9876.wasm",
+      "index.html",
+      "LICENSE",
+      "notebook-web.spdx.json",
+      "THIRD_PARTY_NOTICES.txt",
+    ],
   );
   assert.equal(
     JSON.parse(await readFile(path.join(outputDir, NOTEBOOK_WEB_MANIFEST), "utf8")).kind,
@@ -44,6 +104,8 @@ test("packages a revision-pinned host artifact with deterministic checksums", as
   const checksums = await readFile(path.join(outputDir, NOTEBOOK_WEB_CHECKSUMS), "utf8");
   assert.match(checksums, /notebook-web-manifest\.json/);
   assert.match(checksums, /runtime-ZyXw9876\.wasm/);
+  assert.match(checksums, /THIRD_PARTY_NOTICES\.txt/);
+  await assert.rejects(readFile(path.join(outputDir, "stats.html"), "utf8"));
 });
 
 test("rejects a frontend build that omitted runtime WASM", async () => {
@@ -55,7 +117,29 @@ test("rejects a frontend build that omitted runtime WASM", async () => {
       sourceRevision: "abc1234",
       version: "0.4.3",
       channel: "nightly",
+      writeCompliance: writeFixtureCompliance,
     }),
     /missing its generated runtime WASM/,
+  );
+});
+
+test("rejects an SPDX document that omits a shipped web file", async () => {
+  const { distDir, outputDir } = await fixture();
+  await packageNotebookWeb({
+    distDir,
+    outputDir,
+    sourceRevision: "abc1234",
+    version: "0.4.3",
+    channel: "nightly",
+    writeCompliance: writeFixtureCompliance,
+  });
+  const sbomPath = path.join(outputDir, NOTEBOOK_WEB_SBOM);
+  const sbom = JSON.parse(await readFile(sbomPath, "utf8")) as { files: unknown[] };
+  sbom.files.pop();
+  await writeFile(sbomPath, `${JSON.stringify(sbom, null, 2)}\n`);
+
+  await assert.rejects(
+    assertNotebookWebCompliance(outputDir),
+    /SPDX file provenance is incomplete/,
   );
 });

--- a/scripts/package-notebook-web.test.ts
+++ b/scripts/package-notebook-web.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -14,6 +14,7 @@ import {
   buildSpdxDocument,
   buildThirdPartyNotices,
   collectShippedWebFiles,
+  NOTEBOOK_WEB_BUILD_PROVENANCE,
   NOTEBOOK_WEB_LICENSE,
   NOTEBOOK_WEB_NOTICES,
   NOTEBOOK_WEB_SBOM,
@@ -24,6 +25,7 @@ import {
 
 const TEST_COMPONENT: ComplianceComponent = {
   ecosystem: "npm",
+  scope: "runtime",
   name: "fixture-package",
   version: "1.0.0",
   licenseDeclared: "MIT",
@@ -35,30 +37,32 @@ const TEST_COMPONENT: ComplianceComponent = {
   ],
 };
 
-const TEST_RENDERER_ASSETS: OpaqueRendererAsset[] = opaqueRendererAssetNames().map((name) => ({
-  path: `apps/notebook/src/renderer-plugins/${name}`,
-  bytes: 1,
-  sha256: "0".repeat(64),
-  components: ["nteract"],
-}));
-
 async function writeFixtureCompliance(outputDir: string): Promise<void> {
+  await writeFile(path.join(outputDir, NOTEBOOK_WEB_LICENSE), "BSD 3-Clause License\n");
+  const rendererOutput = (await collectShippedWebFiles(outputDir)).find(
+    (file) => file.path === "assets/main-AbCd1234.js",
+  );
+  assert.ok(rendererOutput);
+  const rendererAssets: OpaqueRendererAsset[] = opaqueRendererAssetNames().map((name) => ({
+    path: `apps/notebook/src/renderer-plugins/${name}`,
+    bytes: 1,
+    sha256: "0".repeat(64),
+    components: ["nteract"],
+    outputs: [{ path: rendererOutput.path, sha256: rendererOutput.sha256 }],
+  }));
+  await writeFile(
+    path.join(outputDir, NOTEBOOK_WEB_NOTICES),
+    buildThirdPartyNotices([TEST_COMPONENT], rendererAssets),
+  );
   const shippedWebFiles = await collectShippedWebFiles(outputDir);
   const spdx = buildSpdxDocument({
     components: [TEST_COMPONENT],
-    opaqueRendererAssets: TEST_RENDERER_ASSETS,
+    opaqueRendererAssets: rendererAssets,
     shippedWebFiles,
     sourceRevision: "abc1234",
     version: "0.4.3",
   });
-  await Promise.all([
-    writeFile(path.join(outputDir, NOTEBOOK_WEB_LICENSE), "BSD 3-Clause License\n"),
-    writeFile(
-      path.join(outputDir, NOTEBOOK_WEB_NOTICES),
-      buildThirdPartyNotices([TEST_COMPONENT], TEST_RENDERER_ASSETS),
-    ),
-    writeFile(path.join(outputDir, NOTEBOOK_WEB_SBOM), `${JSON.stringify(spdx, null, 2)}\n`),
-  ]);
+  await writeFile(path.join(outputDir, NOTEBOOK_WEB_SBOM), `${JSON.stringify(spdx, null, 2)}\n`);
 }
 
 async function fixture(includeWasm = true) {
@@ -68,6 +72,12 @@ async function fixture(includeWasm = true) {
   await mkdir(path.join(distDir, "assets"), { recursive: true });
   await writeFile(path.join(distDir, "index.html"), "<main>notebook</main>");
   await writeFile(path.join(distDir, "assets", "main-AbCd1234.js"), "export {};");
+  await writeFile(path.join(distDir, "assets", "main-AbCd1234.css"), "body {}");
+  await writeFile(path.join(distDir, "assets", "KaTeX_Main-Regular-AbCd1234.woff2"), "font");
+  await writeFile(
+    path.join(distDir, NOTEBOOK_WEB_BUILD_PROVENANCE),
+    '{"schemaVersion":1,"inputs":[]}',
+  );
   await writeFile(path.join(distDir, "stats.html"), "/private/build/path");
   if (includeWasm) await writeFile(path.join(distDir, "assets", "runtime-ZyXw9876.wasm"), "wasm");
   return { distDir, outputDir };
@@ -89,10 +99,13 @@ test("packages a revision-pinned host artifact with deterministic checksums", as
   assert.deepEqual(
     manifest.files.map((file) => file.path),
     [
+      "assets/KaTeX_Main-Regular-AbCd1234.woff2",
+      "assets/main-AbCd1234.css",
       "assets/main-AbCd1234.js",
       "assets/runtime-ZyXw9876.wasm",
       "index.html",
       "LICENSE",
+      "notebook-web-build-provenance.json",
       "notebook-web.spdx.json",
       "THIRD_PARTY_NOTICES.txt",
     ],
@@ -101,6 +114,18 @@ test("packages a revision-pinned host artifact with deterministic checksums", as
     JSON.parse(await readFile(path.join(outputDir, NOTEBOOK_WEB_MANIFEST), "utf8")).kind,
     "nteract-notebook-web",
   );
+  const sbom = JSON.parse(await readFile(path.join(outputDir, NOTEBOOK_WEB_SBOM), "utf8")) as {
+    files: Array<{ fileName: string }>;
+  };
+  assert.deepEqual(
+    sbom.files.map((file) => file.fileName),
+    manifest.files
+      .map((file) => file.path)
+      .filter((filename) => filename !== NOTEBOOK_WEB_SBOM),
+  );
+  assert.ok(sbom.files.some((file) => file.fileName.endsWith(".html")));
+  assert.ok(sbom.files.some((file) => file.fileName.endsWith(".css")));
+  assert.ok(sbom.files.some((file) => file.fileName.endsWith(".woff2")));
   const checksums = await readFile(path.join(outputDir, NOTEBOOK_WEB_CHECKSUMS), "utf8");
   assert.match(checksums, /notebook-web-manifest\.json/);
   assert.match(checksums, /runtime-ZyXw9876\.wasm/);
@@ -142,4 +167,24 @@ test("rejects an SPDX document that omits a shipped web file", async () => {
     assertNotebookWebCompliance(outputDir),
     /SPDX file provenance is incomplete/,
   );
+});
+
+test("rejects symlinked build entries before copying the release payload", async () => {
+  const { distDir, outputDir } = await fixture();
+  const outside = path.join(path.dirname(distDir), "outside.js");
+  await writeFile(outside, "sensitive build input");
+  await symlink(outside, path.join(distDir, "assets", "escape-AbCd1234.js"));
+
+  await assert.rejects(
+    packageNotebookWeb({
+      distDir,
+      outputDir,
+      sourceRevision: "abc1234",
+      version: "0.4.3",
+      channel: "nightly",
+      writeCompliance: writeFixtureCompliance,
+    }),
+    /non-regular entry assets\/escape-AbCd1234\.js/,
+  );
+  await assert.rejects(readFile(path.join(outputDir, "index.html"), "utf8"));
 });

--- a/scripts/package-notebook-web.ts
+++ b/scripts/package-notebook-web.ts
@@ -7,6 +7,7 @@ import { execFileSync } from "node:child_process";
 import {
   assertNotebookWebCompliance,
   generateNotebookWebCompliance,
+  NOTEBOOK_WEB_BUILD_PROVENANCE,
   NOTEBOOK_WEB_LICENSE,
   NOTEBOOK_WEB_NOTICES,
   NOTEBOOK_WEB_SBOM,
@@ -49,6 +50,7 @@ async function filesBelow(root: string, current = root): Promise<string[]> {
     const absolute = path.join(current, entry.name);
     if (entry.isDirectory()) files.push(...(await filesBelow(root, absolute)));
     else if (entry.isFile()) files.push(path.relative(root, absolute).split(path.sep).join("/"));
+    else throw new Error(`Notebook web build contains non-regular entry ${path.relative(root, absolute)}`);
   }
   return files;
 }
@@ -100,7 +102,12 @@ export async function packageNotebookWeb(
   await assertNotebookWebCompliance(options.outputDir);
 
   const packagedFiles = await filesBelow(options.outputDir);
-  for (const required of [NOTEBOOK_WEB_LICENSE, NOTEBOOK_WEB_NOTICES, NOTEBOOK_WEB_SBOM]) {
+  for (const required of [
+    NOTEBOOK_WEB_BUILD_PROVENANCE,
+    NOTEBOOK_WEB_LICENSE,
+    NOTEBOOK_WEB_NOTICES,
+    NOTEBOOK_WEB_SBOM,
+  ]) {
     if (!packagedFiles.includes(required)) {
       throw new Error(`Notebook web artifact is missing required compliance file ${required}`);
     }

--- a/scripts/package-notebook-web.ts
+++ b/scripts/package-notebook-web.ts
@@ -4,6 +4,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 
+import {
+  assertNotebookWebCompliance,
+  generateNotebookWebCompliance,
+  NOTEBOOK_WEB_LICENSE,
+  NOTEBOOK_WEB_NOTICES,
+  NOTEBOOK_WEB_SBOM,
+} from "./notebook-web-compliance.ts";
+
 export const NOTEBOOK_WEB_MANIFEST = "notebook-web-manifest.json";
 export const NOTEBOOK_WEB_CHECKSUMS = "SHA256SUMS";
 
@@ -30,6 +38,8 @@ export type PackageNotebookWebOptions = {
   sourceRevision: string;
   version: string;
   channel: string;
+  repoRoot?: string;
+  writeCompliance?: (outputDir: string) => Promise<void>;
 };
 
 async function filesBelow(root: string, current = root): Promise<string[]> {
@@ -73,7 +83,32 @@ export async function packageNotebookWeb(
   await mkdir(path.dirname(options.outputDir), { recursive: true });
   await cp(options.distDir, options.outputDir, { recursive: true });
 
-  const files = await Promise.all(sourceFiles.map((file) => record(options.outputDir, file)));
+  // Bundle visualizer output is a CI diagnostic, not a release payload. It
+  // contains absolute module paths and has no runtime role.
+  await rm(path.join(options.outputDir, "stats.html"), { force: true });
+
+  if (options.writeCompliance) {
+    await options.writeCompliance(options.outputDir);
+  } else {
+    await generateNotebookWebCompliance({
+      outputDir: options.outputDir,
+      repoRoot: options.repoRoot ?? process.cwd(),
+      sourceRevision: options.sourceRevision,
+      version: options.version,
+    });
+  }
+  await assertNotebookWebCompliance(options.outputDir);
+
+  const packagedFiles = await filesBelow(options.outputDir);
+  for (const required of [NOTEBOOK_WEB_LICENSE, NOTEBOOK_WEB_NOTICES, NOTEBOOK_WEB_SBOM]) {
+    if (!packagedFiles.includes(required)) {
+      throw new Error(`Notebook web artifact is missing required compliance file ${required}`);
+    }
+  }
+  if (packagedFiles.includes("stats.html")) {
+    throw new Error("Notebook web release artifact must not include stats.html");
+  }
+  const files = await Promise.all(packagedFiles.map((file) => record(options.outputDir, file)));
   const manifest: NotebookWebManifest = {
     schemaVersion: 1,
     kind: "nteract-notebook-web",
@@ -93,7 +128,7 @@ export async function packageNotebookWeb(
     `${JSON.stringify(manifest, null, 2)}\n`,
   );
 
-  const checksummedFiles = [...sourceFiles, NOTEBOOK_WEB_MANIFEST];
+  const checksummedFiles = [...packagedFiles, NOTEBOOK_WEB_MANIFEST];
   const checksums = await Promise.all(
     checksummedFiles.map(async (file) => {
       const { sha256 } = await record(options.outputDir, file);


### PR DESCRIPTION
## Summary

- package the root BSD license, deterministic third-party notices, and an SPDX 2.3 document with the Notebook Web archive
- inventory a deterministic union of the `notebook-ui` runtime closure, shared root-source dependencies, embedded-renderer dependencies, recursively reached workspace packages, explicit CSS build inputs, and the non-dev `runtimed-wasm` Cargo closure
- cover every regular payload file in SPDX, including HTML, CSS, fonts, JavaScript, WASM, notices, and Vite's renderer provenance metadata; include KaTeX font OFL-1.1 terms and Tailwind CSS build provenance
- emit a deterministic Vite build record that binds each opaque renderer source hash to its content-hashed output chunk, then fail packaging when either side is stale
- parse license expressions with the SPDX grammar and fail packaging when syntax, license metadata, license text, required component coverage, renderer provenance, shipped-file provenance, or regular-file constraints are missing or unknown; reject symlinks before copying the release payload
- invoke pnpm through the platform command shim so the same inventory commands work on Windows
- exclude the bundle visualizer's `stats.html` diagnostic from the release payload because it is not used at runtime and contains local build paths

This is stacked on #4132.

## Verification

- `cargo xtask wasm`
- `cargo xtask renderer-plugins`
- `pnpm --dir apps/notebook build`
- `pnpm notebook-web:test`
- `cargo xtask notebook-web --skip-build`
- `cargo xtask lint --fix`
- `uvx --from spdx-tools pyspdxtools --infile target/notebook-web/notebook-web.spdx.json`
- packaged-artifact check: 483 package records, all 144 non-SBOM payload files represented with matching SPDX `CONTAINS` relationships and verification code, all three compliance documents present, `stats.html` absent, no non-regular entries, and no absolute workspace paths in generated metadata

## Follow-up

- Add exact per-chunk npm component attribution emitted by the bundler. The current deterministic union is intentionally conservative for shared root sources and embedded-renderer dependency closures, while workspace packages, renderer source-to-output mappings, and payload file hashes are exact.
