### PR TITLE
[WIP] feat(node): queue existing synced cells

### DIFF
--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -289,6 +289,14 @@ pub struct QueueCellOptions {
     pub cell_type: Option<String>,
 }
 
+/// Options for `Session.queueExistingCell()`.
+#[napi(object)]
+#[derive(Default)]
+pub struct QueueExistingCellOptions {
+    /// Caller-owned UUID used as an idempotency key for this cell execution.
+    pub execution_id: Option<String>,
+}
+
 /// Options for `Session.waitForExecution()`.
 #[napi(object)]
 #[derive(Default)]
@@ -1172,7 +1180,7 @@ impl Session {
         let opts = options.unwrap_or_default();
         let timeout = Duration::from_millis(opts.timeout_ms.unwrap_or(120_000) as u64);
         ensure_kernel_started(&self.state).await?;
-        let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
+        let execution_id = queue_existing_cell(&self.state, &cell_id, None).await?;
         if let Ok((handle, peer_label)) = session_handle_and_label(&self.state).await {
             notebook_sync::presence::emit_focus(&handle, &cell_id, Some(&peer_label)).await;
         }
@@ -1180,16 +1188,21 @@ impl Session {
         collect_outputs_with_timeout(&self.state, cell_id, execution_id, timeout).await
     }
 
-    /// Queue an existing synced code cell without waiting for execution.
-    /// Returns the daemon-assigned execution ID immediately so hosts can
-    /// correlate status and cancellation with the exact work they submitted.
+    /// Queue an existing synced code cell after the kernel is ready, without
+    /// waiting for execution to finish. A caller-provided execution ID is an
+    /// idempotency key: retrying it for the same cell returns the existing
+    /// active or terminal execution, while reusing it for another cell is
+    /// rejected.
     #[napi]
-    pub async fn queue_existing_cell(&self, cell_id: String) -> Result<QueuedExecution> {
+    pub async fn queue_existing_cell(
+        &self,
+        cell_id: String,
+        options: Option<QueueExistingCellOptions>,
+    ) -> Result<QueuedExecution> {
+        let requested_execution_id = options.and_then(|opts| opts.execution_id);
         ensure_kernel_started(&self.state).await?;
-        let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
-        if let Ok((handle, peer_label)) = session_handle_and_label(&self.state).await {
-            notebook_sync::presence::emit_focus(&handle, &cell_id, Some(&peer_label)).await;
-        }
+        let execution_id =
+            queue_existing_cell(&self.state, &cell_id, requested_execution_id).await?;
 
         Ok(QueuedExecution {
             cell_id,
@@ -1217,7 +1230,7 @@ impl Session {
 
         // 3. Queue the cell. Do this before the timeout wrapper so timeout
         // results still carry an execution ID that can be recovered later.
-        let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
+        let execution_id = queue_existing_cell(&self.state, &cell_id, None).await?;
 
         collect_outputs_with_timeout(&self.state, cell_id, execution_id, timeout).await
     }
@@ -1234,7 +1247,7 @@ impl Session {
 
         ensure_kernel_started(&self.state).await?;
         let cell_id = add_source_cell(&self.state, &source, &cell_type).await?;
-        let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
+        let execution_id = queue_existing_cell(&self.state, &cell_id, None).await?;
 
         Ok(QueuedExecution {
             cell_id,
@@ -2062,7 +2075,11 @@ async fn ensure_kernel_started(state: &Arc<Mutex<SessionState>>) -> Result<()> {
     }
 }
 
-async fn queue_existing_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> Result<String> {
+async fn queue_existing_cell(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    requested_execution_id: Option<String>,
+) -> Result<String> {
     let handle = {
         let st = state.lock().await;
         st.handle
@@ -2075,7 +2092,7 @@ async fn queue_existing_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) ->
         .send_request_after_heads(
             NotebookRequest::ExecuteCell {
                 cell_id: cell_id.to_string(),
-                execution_id: None,
+                execution_id: requested_execution_id,
             },
             required_heads,
         )
@@ -2083,6 +2100,12 @@ async fn queue_existing_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) ->
         .map_err(to_napi_err)?;
     match response {
         NotebookResponse::CellQueued { execution_id, .. } => Ok(execution_id),
+        NotebookResponse::ExecutionIdRejected {
+            execution_id,
+            reason,
+        } => Err(Error::from_reason(format!(
+            "Execution ID {execution_id} rejected: {reason:?}"
+        ))),
         NotebookResponse::Error { error } => Err(Error::from_reason(error)),
         other => Err(Error::from_reason(format!(
             "Unexpected response: {other:?}"

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -1180,6 +1180,23 @@ impl Session {
         collect_outputs_with_timeout(&self.state, cell_id, execution_id, timeout).await
     }
 
+    /// Queue an existing synced code cell without waiting for execution.
+    /// Returns the daemon-assigned execution ID immediately so hosts can
+    /// correlate status and cancellation with the exact work they submitted.
+    #[napi]
+    pub async fn queue_existing_cell(&self, cell_id: String) -> Result<QueuedExecution> {
+        ensure_kernel_started(&self.state).await?;
+        let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
+        if let Ok((handle, peer_label)) = session_handle_and_label(&self.state).await {
+            notebook_sync::presence::emit_focus(&handle, &cell_id, Some(&peer_label)).await;
+        }
+
+        Ok(QueuedExecution {
+            cell_id,
+            execution_id,
+        })
+    }
+
     /// Execute a source string as a new cell. Starts the kernel on demand.
     /// Returns the cell's outputs once execution is terminal.
     #[napi]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1389,6 +1389,24 @@ impl RoomHostHandle {
             .and_then(|v| v.as_str())
             .ok_or_else(|| JsError::new("ExecuteCell request missing cell_id"))?;
 
+        // A client may supply an execution_id for idempotent retries; validate it
+        // as a UUID so a malformed or oversized value can't become a document key.
+        // An existing ID is a retry only when it already belongs to this cell.
+        let requested_id = request.get("execution_id").and_then(|v| v.as_str());
+        if let Some(id) = requested_id {
+            if uuid::Uuid::parse_str(id).is_err() {
+                return Err(JsError::new(&format!(
+                    "execution_id is not a valid UUID: {id}"
+                )));
+            }
+            if let Some(existing) = self.state_doc.get_execution(id) {
+                if existing.cell_id.as_deref() == Some(cell_id) {
+                    return Ok(RoomHostFrameResult::empty());
+                }
+                return Err(JsError::new(&format!("execution_id already exists: {id}")));
+            }
+        }
+
         let cell = self
             .doc
             .get_cell(cell_id)
@@ -1411,6 +1429,11 @@ impl RoomHostHandle {
                 .get_execution(&active_id)
                 .is_some_and(|e| e.status == "queued" || e.status == "running");
             if still_active {
+                if requested_id.is_some() {
+                    return Err(JsError::new(&format!(
+                        "cell already has an active execution: {active_id}"
+                    )));
+                }
                 // No-op: nothing changed. The room logs the materialized frame
                 // (notebook-room.ts room.materialized_frame.applied) with
                 // changed=false, which is the observable signal here.
@@ -1418,17 +1441,7 @@ impl RoomHostHandle {
             }
         }
 
-        // A client may supply an execution_id for idempotent retries; validate it
-        // as a UUID so a malformed or oversized value can't become a document key.
-        // Absent one, the room mints it.
-        let requested_id = request.get("execution_id").and_then(|v| v.as_str());
-        if let Some(id) = requested_id {
-            if uuid::Uuid::parse_str(id).is_err() {
-                return Err(JsError::new(&format!(
-                    "execution_id is not a valid UUID: {id}"
-                )));
-            }
-        }
+        // Absent a caller-owned idempotency key, the room mints the execution ID.
         let execution_id = requested_id
             .map(|s| s.to_string())
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
@@ -1462,10 +1475,9 @@ impl RoomHostHandle {
             )
             .map_err(|e| JsError::new(&format!("create execution: {e}")))?;
         if !created {
-            // The id already exists (a client retried with the same id). Treat it
-            // as an idempotent no-op rather than erroring the peer, matching the
-            // daemon: the existing execution is already in the synced doc.
-            return Ok(RoomHostFrameResult::empty());
+            return Err(JsError::new(&format!(
+                "execution_id already exists: {execution_id}"
+            )));
         }
 
         // Point the cell at its execution, matching the daemon's ExecuteCell path.

--- a/crates/runtimed-wasm/tests/room_host_execution_id_test.ts
+++ b/crates/runtimed-wasm/tests/room_host_execution_id_test.ts
@@ -1,0 +1,98 @@
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
+
+// @ts-nocheck — wasm-bindgen output doesn't have Deno-compatible type declarations
+
+// deno-lint-ignore no-explicit-any
+const { NotebookHandle, RoomHostHandle, RuntimeStatePeerHandle }: any =
+  await loadRuntimedWasm();
+
+const REQUEST_FRAME_TYPE = 0x01;
+const EXECUTION_ID = "11111111-1111-4111-8111-111111111111";
+
+function createRoomHost() {
+  const notebook = new NotebookHandle("hosted-execution-id-test");
+  notebook.add_cell(0, "cell-1", "code");
+  notebook.update_source("cell-1", "print('one')");
+  notebook.add_cell(1, "cell-2", "code");
+  notebook.update_source("cell-2", "print('two')");
+  const host = RoomHostHandle.load_snapshot(
+    notebook.save(),
+    notebook.save_state_doc(),
+  );
+  notebook.free();
+  return host;
+}
+
+function executeCell(
+  host: RoomHostHandle,
+  cellId: string,
+  executionId: string,
+) {
+  const payload = new TextEncoder().encode(
+    JSON.stringify({
+      action: "execute_cell",
+      cell_id: cellId,
+      execution_id: executionId,
+    }),
+  );
+  const frame = new Uint8Array(payload.length + 1);
+  frame[0] = REQUEST_FRAME_TYPE;
+  frame.set(payload, 1);
+  return host.receive_peer_frame(
+    "owner-peer",
+    "user:dev:alice",
+    "user:dev:alice/browser:cloud",
+    "owner",
+    true,
+    frame,
+  );
+}
+
+Deno.test("RoomHostHandle: retries the same requested execution ID for the same cell", () => {
+  let host = createRoomHost();
+  const first = executeCell(host, "cell-1", EXECUTION_ID);
+  assertEquals(first.runtime_state_changed, true);
+  assertEquals(first.notebook_changed, true);
+  assertEquals(host.get_runtime_queue_depth(), 1);
+
+  const activeRetry = executeCell(host, "cell-1", EXECUTION_ID);
+  assertEquals(activeRetry.runtime_state_changed, false);
+  assertEquals(activeRetry.notebook_changed, false);
+  assertEquals(host.get_runtime_queue_depth(), 1);
+
+  const runtime = RuntimeStatePeerHandle.load(
+    host.save_runtime_state_doc(),
+    "runtime:dev:test/agent:hosted",
+  );
+  runtime.set_execution_done(EXECUTION_ID, true);
+  const terminalHost = RoomHostHandle.load_snapshot(
+    host.save_notebook(),
+    runtime.save(),
+  );
+  runtime.free();
+  host.free();
+  host = terminalHost;
+
+  const terminalRetry = executeCell(host, "cell-1", EXECUTION_ID);
+  assertEquals(terminalRetry.runtime_state_changed, false);
+  assertEquals(terminalRetry.notebook_changed, false);
+  assertEquals(host.get_runtime_queue_depth(), 1);
+  host.free();
+});
+
+Deno.test("RoomHostHandle: rejects a requested execution ID owned by another cell", () => {
+  const host = createRoomHost();
+  executeCell(host, "cell-1", EXECUTION_ID);
+
+  assertThrows(
+    () => executeCell(host, "cell-2", EXECUTION_ID),
+    Error,
+    `execution_id already exists: ${EXECUTION_ID}`,
+  );
+  assertEquals(host.get_runtime_queue_depth(), 1);
+  host.free();
+});

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -4799,6 +4799,105 @@ async fn execute_cell_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
 }
 
 #[tokio::test]
+async fn execute_cell_requested_id_retries_same_cell_when_active_or_terminal() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "idempotent.ipynb");
+    let room = Arc::new(room);
+    let execution_id = Uuid::new_v4().to_string();
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "print('once')").unwrap();
+    }
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        .unwrap();
+
+    for expected_status in ["queued", "done"] {
+        let response = crate::requests::execute_cell::handle_with_submitter(
+            &room,
+            "cell-1".to_string(),
+            Some(execution_id.clone()),
+            false,
+            Some("local:test/retry"),
+        )
+        .await;
+        assert!(matches!(
+            response,
+            crate::protocol::NotebookResponse::CellQueued {
+                ref cell_id,
+                execution_id: ref returned_execution_id,
+            } if cell_id == "cell-1" && returned_execution_id == &execution_id
+        ));
+
+        let state = room.state.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(state.executions.len(), 1);
+        assert_eq!(state.executions[&execution_id].status, expected_status);
+
+        if expected_status == "queued" {
+            room.state
+                .with_doc(|sd| sd.set_execution_done(&execution_id, true))
+                .unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn execute_cell_requested_id_rejects_reuse_for_another_cell() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "cross-cell-id.ipynb");
+    let room = Arc::new(room);
+    let execution_id = Uuid::new_v4().to_string();
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.add_cell(1, "cell-2", "code").unwrap();
+    }
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        .unwrap();
+
+    let first = crate::requests::execute_cell::handle_with_submitter(
+        &room,
+        "cell-1".to_string(),
+        Some(execution_id.clone()),
+        false,
+        None,
+    )
+    .await;
+    assert!(matches!(
+        first,
+        crate::protocol::NotebookResponse::CellQueued { .. }
+    ));
+
+    let second = crate::requests::execute_cell::handle_with_submitter(
+        &room,
+        "cell-2".to_string(),
+        Some(execution_id.clone()),
+        false,
+        None,
+    )
+    .await;
+    assert!(matches!(
+        second,
+        crate::protocol::NotebookResponse::ExecutionIdRejected {
+            execution_id: ref rejected_id,
+            reason: notebook_protocol::protocol::ExecutionIdRejectionReason::AlreadyExists,
+        } if rejected_id == &execution_id
+    ));
+    assert_eq!(
+        room.state
+            .read(|sd| sd.read_state())
+            .unwrap()
+            .executions
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn run_all_cells_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, _) = test_room_with_path(&tmp, "test.ipynb");

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -129,7 +129,7 @@ async fn handle_inner(
                     }
                     (source, execution_id, format_heads)
                 }
-                QueueCellResult::AlreadyActive { execution_id } => {
+                QueueCellResult::Existing { execution_id } => {
                     if queue_for_starting_kernel {
                         publish_startup_queue_from_queued_executions(room);
                     }
@@ -203,7 +203,7 @@ enum QueueCellResult {
         execution_id: String,
         format_heads: Vec<ChangeHash>,
     },
-    AlreadyActive {
+    Existing {
         execution_id: String,
     },
     Response(Box<NotebookResponse>),
@@ -226,6 +226,26 @@ async fn queue_cell_if_current(
     }
 
     let mut doc = room.doc.write().await;
+    if let Some(requested_execution_id) = requested_execution_id {
+        let existing_cell_id = room
+            .state
+            .read(|sd| {
+                sd.get_execution(requested_execution_id)
+                    .map(|execution| execution.cell_id.clone())
+            })
+            .unwrap_or(None);
+        if let Some(existing_cell_id) = existing_cell_id {
+            if existing_cell_id.as_deref() == Some(cell_id) {
+                return QueueCellResult::Existing {
+                    execution_id: requested_execution_id.to_string(),
+                };
+            }
+            return QueueCellResult::Response(Box::new(execution_id_rejected(
+                requested_execution_id,
+                ExecutionIdRejectionReason::AlreadyExists,
+            )));
+        }
+    }
     if let Some(observed_heads) = observed_heads {
         if let Err(rejection) = guarded::validate_execute_cell(&mut doc, cell_id, observed_heads) {
             return QueueCellResult::Response(Box::new(rejection.into_response()));
@@ -274,7 +294,7 @@ async fn queue_cell_if_current(
                     error: format!("Cell already has an active execution: {}", eid),
                 }));
             }
-            return QueueCellResult::AlreadyActive {
+            return QueueCellResult::Existing {
                 execution_id: eid.clone(),
             };
         }

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -207,8 +207,12 @@ sessions.
 - `Session.shutdownNotebook()` shuts down this notebook room and closes the session.
 - `Session.runCell(source, options)` appends, runs, and waits for a cell.
 - `Session.queueCell(source, options)` appends a cell, queues it, and returns IDs.
-- `Session.queueExistingCell(cellId)` queues an already-synced cell and returns
-  its execution ID immediately, without introducing a side-channel source.
+- `Session.queueExistingCell(cellId, { executionId? })` queues an already-synced
+  cell without introducing a side-channel source, then returns once the kernel
+  is ready and the daemon has accepted the execution. Cold kernel startup can
+  therefore delay the call. Supply a UUID `executionId` when retries must refer
+  to the same execution attempt. A retry returns the existing active or terminal
+  execution for that cell; reusing the UUID for another cell is rejected.
 - `Session.waitForExecution(executionId, options)` waits for queued work.
   Pass `onUpdate(progress)` to receive resolved output snapshots while the
   execution is still running.

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -207,6 +207,8 @@ sessions.
 - `Session.shutdownNotebook()` shuts down this notebook room and closes the session.
 - `Session.runCell(source, options)` appends, runs, and waits for a cell.
 - `Session.queueCell(source, options)` appends a cell, queues it, and returns IDs.
+- `Session.queueExistingCell(cellId)` queues an already-synced cell and returns
+  its execution ID immediately, without introducing a side-channel source.
 - `Session.waitForExecution(executionId, options)` waits for queued work.
   Pass `onUpdate(progress)` to receive resolved output snapshots while the
   execution is still running.

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -245,6 +245,7 @@ export class Session {
   readonly sessionStatus$: Observable<SessionStatus>;
 
   queueCell(source: string, options?: QueueCellOptions): Promise<QueuedExecution>;
+  queueExistingCell(cellId: string): Promise<QueuedExecution>;
   waitForExecution(executionId: string, options?: WaitExecutionOptions): Promise<CellResult>;
   runCell(source: string, options?: RunCellOptions): Promise<CellResult>;
   saveNotebook(path?: string): Promise<void>;

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -116,6 +116,14 @@ export interface QueueCellOptions {
   cellType?: "code" | "markdown" | "raw";
 }
 
+export interface QueueExistingCellOptions {
+  /**
+   * Caller-owned UUID used to make retries for this cell idempotent. Retries
+   * return the existing active or terminal execution.
+   */
+  executionId?: string;
+}
+
 export interface DependencyEditOptions {
   packageManager?: PackageManager;
 }
@@ -245,7 +253,7 @@ export class Session {
   readonly sessionStatus$: Observable<SessionStatus>;
 
   queueCell(source: string, options?: QueueCellOptions): Promise<QueuedExecution>;
-  queueExistingCell(cellId: string): Promise<QueuedExecution>;
+  queueExistingCell(cellId: string, options?: QueueExistingCellOptions): Promise<QueuedExecution>;
   waitForExecution(executionId: string, options?: WaitExecutionOptions): Promise<CellResult>;
   runCell(source: string, options?: RunCellOptions): Promise<CellResult>;
   saveNotebook(path?: string): Promise<void>;

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -74,6 +74,10 @@ class Session {
     return this._native.queueCell(source, options);
   }
 
+  queueExistingCell(cellId) {
+    return this._native.queueExistingCell(cellId);
+  }
+
   async waitForExecution(executionId, options = {}) {
     const { onUpdate, ...nativeOptions } = options ?? {};
     const cellId = nativeOptions.cellId;

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -74,8 +74,8 @@ class Session {
     return this._native.queueCell(source, options);
   }
 
-  queueExistingCell(cellId) {
-    return this._native.queueExistingCell(cellId);
+  queueExistingCell(cellId, options) {
+    return this._native.queueExistingCell(cellId, options);
   }
 
   async waitForExecution(executionId, options = {}) {

--- a/packages/runtimed-node/tests/session-native.test.ts
+++ b/packages/runtimed-node/tests/session-native.test.ts
@@ -27,7 +27,11 @@ type Session = {
   };
   createCell(source: string, options?: { cellType?: "code" | "markdown" }): Promise<string>;
   approveTrust(): Promise<void>;
-  executeCell(cellId: string, options?: { timeoutMs?: number }): Promise<unknown>;
+  queueExistingCell(cellId: string): Promise<{ cellId: string; executionId: string }>;
+  waitForExecution(
+    executionId: string,
+    options?: { cellId?: string; timeoutMs?: number },
+  ): Promise<unknown>;
   getCellOutputs(cellId: string): Promise<Output[] | null>;
   close(): Promise<void>;
   shutdownNotebook(): Promise<boolean>;
@@ -96,7 +100,10 @@ async function executeWhenReady(session: Session, cellId: string): Promise<void>
   const deadline = Date.now() + 120_000;
   while (true) {
     try {
-      await session.executeCell(cellId, { timeoutMs: 180_000 });
+      const queued = await session.queueExistingCell(cellId);
+      expect(queued.cellId).toBe(cellId);
+      expect(queued.executionId).not.toBe("");
+      await session.waitForExecution(queued.executionId, { cellId, timeoutMs: 180_000 });
       return;
     } catch (error) {
       if (!String(error).includes("pool empty") || Date.now() >= deadline) throw error;

--- a/packages/runtimed-node/tests/session-native.test.ts
+++ b/packages/runtimed-node/tests/session-native.test.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -27,7 +28,10 @@ type Session = {
   };
   createCell(source: string, options?: { cellType?: "code" | "markdown" }): Promise<string>;
   approveTrust(): Promise<void>;
-  queueExistingCell(cellId: string): Promise<{ cellId: string; executionId: string }>;
+  queueExistingCell(
+    cellId: string,
+    options?: { executionId?: string },
+  ): Promise<{ cellId: string; executionId: string }>;
   waitForExecution(
     executionId: string,
     options?: { cellId?: string; timeoutMs?: number },
@@ -96,15 +100,18 @@ async function waitForSocket(timeoutMs = 60_000): Promise<void> {
   throw new Error(`timed out waiting for runtimed socket at ${socketPath}`);
 }
 
-async function executeWhenReady(session: Session, cellId: string): Promise<void> {
+async function executeWhenReady(session: Session, cellId: string): Promise<string> {
   const deadline = Date.now() + 120_000;
+  const executionId = randomUUID();
   while (true) {
     try {
-      const queued = await session.queueExistingCell(cellId);
+      const queued = await session.queueExistingCell(cellId, { executionId });
       expect(queued.cellId).toBe(cellId);
-      expect(queued.executionId).not.toBe("");
+      expect(queued.executionId).toBe(executionId);
+      await expect(session.queueExistingCell(cellId, { executionId })).resolves.toEqual(queued);
       await session.waitForExecution(queued.executionId, { cellId, timeoutMs: 180_000 });
-      return;
+      await expect(session.queueExistingCell(cellId, { executionId })).resolves.toEqual(queued);
+      return executionId;
     } catch (error) {
       if (!String(error).includes("pool empty") || Date.now() >= deadline) throw error;
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -193,7 +200,11 @@ describeNative("@runtimed/node native session outputs", () => {
       { cellType: "code" },
     );
     await first.approveTrust();
-    await executeWhenReady(first, executedCell);
+    const executionId = await executeWhenReady(first, executedCell);
+    const anotherCell = await first.createCell("print('must not run')", { cellType: "code" });
+    await expect(first.queueExistingCell(anotherCell, { executionId })).rejects.toThrow(
+      /AlreadyExists/,
+    );
     await first.close();
     sessions.splice(sessions.indexOf(first), 1);
 

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -359,21 +359,22 @@ describe("@runtimed/node Session wrapper", () => {
   });
 
   it("queues an existing synced cell without resending its source", async () => {
+    const executionId = "01234567-89ab-4def-8123-456789abcdef";
     const native = {
       notebookId: "nb-1",
       queueExistingCell: vi.fn(async () => ({
         cellId: "cell-1",
-        executionId: "exec-1",
+        executionId,
       })),
       close: vi.fn(async () => {}),
     };
     const session = new Session(native);
 
-    await expect(session.queueExistingCell("cell-1")).resolves.toEqual({
+    await expect(session.queueExistingCell("cell-1", { executionId })).resolves.toEqual({
       cellId: "cell-1",
-      executionId: "exec-1",
+      executionId,
     });
-    expect(native.queueExistingCell).toHaveBeenCalledWith("cell-1");
+    expect(native.queueExistingCell).toHaveBeenCalledWith("cell-1", { executionId });
   });
 
   it("passes snapshot pair export through to the native session", async () => {

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -358,6 +358,24 @@ describe("@runtimed/node Session wrapper", () => {
     });
   });
 
+  it("queues an existing synced cell without resending its source", async () => {
+    const native = {
+      notebookId: "nb-1",
+      queueExistingCell: vi.fn(async () => ({
+        cellId: "cell-1",
+        executionId: "exec-1",
+      })),
+      close: vi.fn(async () => {}),
+    };
+    const session = new Session(native);
+
+    await expect(session.queueExistingCell("cell-1")).resolves.toEqual({
+      cellId: "cell-1",
+      executionId: "exec-1",
+    });
+    expect(native.queueExistingCell).toHaveBeenCalledWith("cell-1");
+  });
+
   it("passes snapshot pair export through to the native session", async () => {
     const snapshot = {
       notebookId: "nb-1",


### PR DESCRIPTION
> [!IMPORTANT]
> **WIP programmatic-client exploration.** This convenience API is not required for embedding the notebook frontend. Embedded hosts should pump opaque frames through `@runtimed/node/relay` and let the shared JS/WASM `NotebookClient` own document and execution semantics. This draft remains open while we decide whether its higher-level Node surface should move into or delegate to that shared client.

## Summary

- add `Session.queueExistingCell(cellId, { executionId? })` to `@runtimed/node`
- queue only source already present in the synced NotebookDoc and return the accepted execution handle without waiting for terminal output
- let callers supply a UUID as an idempotency key so a lost response can recover the same active or terminal execution
- reject reuse of an execution UUID for a different cell in both the daemon and hosted WASM room host
- preserve edit cursor/selection presence when execution is queued

## Motivation

Programmatic Node clients that separate execution admission from observation need the execution ID before they can call `waitForExecution`, correlate progress, or make safe ownership decisions. The existing `executeCell` convenience method returns only after terminal output, while sending source again would bypass the live synced notebook document.

The daemon-side operation keeps NotebookDoc as the source of truth. It captures current heads, sends only the cell ID, and uses the daemon's required-head gate before execution is accepted.

Supplying `executionId` also gives callers retry safety:

- same UUID + same cell returns the existing active or terminal execution
- same UUID + different cell is rejected
- a new requested UUID cannot bypass other active work on the cell

The call returns after kernel readiness and daemon acceptance. Cold kernel startup can therefore delay admission; terminal waiting remains a separate operation.

## Compatibility

The wire operation is additive to protocol v4 but must be gated by an advertised semantic capability before independently released clients rely on it. Daemon version/source revision is diagnostic metadata, not the compatibility boundary.

## Verification

- `cargo test -p runtimed-node`: 25 passed
- focused daemon retry/cross-cell tests: passed
- `cargo test -p runtimed-wasm`: 87 passed
- exported WASM Deno tests: 149 passed, 5 ignored
- `@runtimed/node` wrapper tests: 9 passed
- real Node -> native addon -> daemon -> kernel integration: passed
- Tokio mutex lint: passed
- `cargo xtask lint --fix`: passed

## Stack

- base: #4138
