### PR TITLE
[WIP] feat(runtimed): explore opt-in host-owned daemon instances

### DIFF
--- a/crates/kernel-env/AGENTS.md
+++ b/crates/kernel-env/AGENTS.md
@@ -89,7 +89,7 @@ Every notebook's env is isolated per notebook via `env_id` — no cross-notebook
 | UV | `kernel_env::uv::compute_unified_env_hash` | `~/.cache/runt/envs/{hash}/` |
 | Conda | `kernel_env::conda::compute_unified_env_hash` | `~/.cache/runt/conda-envs/{hash}/` |
 
-Cache paths are channel-aware: stable → `runt/`, nightly → `runt-nightly/`, dev worktree → `runt/worktrees/{hash}/`.
+Cache paths are daemon-context-aware: stable → `runt/`, nightly → `runt-nightly/`, dev worktree → `runt/worktrees/{hash}/`, and a host-owned daemon instance → `<channel>/instances/{hash}/`. Materialized environments must not be shared across daemon instances because each daemon's GC only knows its own live kernels.
 
 Cache hit check: verify `{hash}/bin/python` (Unix) or `{hash}/Scripts/python.exe` (Windows).
 

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -702,6 +702,8 @@ mod tests {
             execution_store_dir: None,
             worktree_path: None,
             workspace_description: None,
+            instance_id: None,
+            daemon_base_dir: None,
         }
     }
 

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -136,6 +136,46 @@ pub fn cache_namespace() -> &'static str {
 /// Directory name of the cache root shared by every channel and worktree.
 pub const SHARED_CACHE_NAMESPACE: &str = "runt-shared";
 
+/// Optional host-owned daemon instance identifier.
+///
+/// When set to a non-empty value, daemon-owned state is nested below an
+/// instance-specific directory and the default socket/pipe is instance-specific.
+/// This lets an embedding host run its bundled daemon alongside nteract's normal
+/// stable or nightly daemon without sharing mutable runtime state.
+pub const DAEMON_INSTANCE_ID_ENV: &str = "RUNTIMED_INSTANCE_ID";
+
+/// Return the normalized host-owned daemon instance id, when configured.
+///
+/// The id is an opaque label, not a path segment. Filesystem and named-pipe
+/// paths use [`daemon_instance_key`] so separators and other host-provided
+/// characters can never escape the instance namespace.
+pub fn daemon_instance_id() -> Option<String> {
+    std::env::var(DAEMON_INSTANCE_ID_ENV)
+        .ok()
+        .and_then(|value| normalize_daemon_instance_id(&value).map(str::to_owned))
+}
+
+fn normalize_daemon_instance_id(instance_id: &str) -> Option<&str> {
+    let normalized = instance_id.trim();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+/// Stable, path-safe key for a host-owned daemon instance id.
+///
+/// Twelve hex characters matches the existing worktree namespace and keeps
+/// Unix socket paths short enough for macOS's `sun_path` limit.
+pub fn daemon_instance_key(instance_id: &str) -> Result<String, &'static str> {
+    let normalized =
+        normalize_daemon_instance_id(instance_id).ok_or("daemon instance id must not be empty")?;
+    Ok(daemon_instance_key_from_normalized(normalized))
+}
+
+fn daemon_instance_key_from_normalized(normalized: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    hex::encode(&hasher.finalize()[..6])
+}
+
 /// Cache root shared by every daemon process regardless of channel or dev
 /// worktree: `~/.cache/runt-shared/`. Cross-process facts that stable,
 /// nightly, and per-worktree dev daemons must all see (e.g. file claims)
@@ -150,6 +190,48 @@ pub fn shared_cache_root() -> PathBuf {
 /// Channel-specific config root directory name.
 pub fn config_namespace() -> &'static str {
     config_namespace_for(build_channel())
+}
+
+/// Get the daemon-owned configuration directory for the current channel and
+/// optional host-owned instance.
+///
+/// The normal nteract profile keeps its historical path. An embedded daemon
+/// gets an isolated settings document so independently versioned processes do
+/// not watch and rewrite the same JSON file.
+pub fn daemon_config_dir() -> PathBuf {
+    let base = daemon_config_dir_without_instance(build_channel());
+    match daemon_instance_id() {
+        Some(instance_id) => base
+            .join("instances")
+            .join(daemon_instance_key_from_normalized(&instance_id)),
+        None => base,
+    }
+}
+
+/// Get the daemon-owned configuration directory for an explicit host-owned
+/// instance, ignoring `RUNTIMED_INSTANCE_ID`.
+pub fn daemon_config_dir_for_instance(
+    channel: BuildChannel,
+    instance_id: &str,
+) -> Result<PathBuf, &'static str> {
+    Ok(daemon_config_dir_without_instance(channel)
+        .join("instances")
+        .join(daemon_instance_key(instance_id)?))
+}
+
+/// Get the settings JSON path for an explicit host-owned daemon instance,
+/// ignoring `RUNTIMED_INSTANCE_ID`.
+pub fn settings_json_path_for_instance(
+    channel: BuildChannel,
+    instance_id: &str,
+) -> Result<PathBuf, &'static str> {
+    Ok(daemon_config_dir_for_instance(channel, instance_id)?.join("settings.json"))
+}
+
+fn daemon_config_dir_without_instance(channel: BuildChannel) -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(config_namespace_for(channel))
 }
 
 /// Channel-specific daemon executable base name (without extension).
@@ -1018,11 +1100,15 @@ pub fn vite_port_for_workspace(path: &Path) -> u16 {
 /// - Nightly channel: 47830 (bumps 47830..=47839)
 /// - Dev worktree:    48000 + hash(worktree) % 1000 (stable per-worktree,
 ///   no cross-worktree collisions)
+/// - Host instance:   one stable ten-port block in 49000..=58999
 ///
 /// Stable and nightly get disjoint 10-port ranges so they never bump into
 /// each other's preferred port when both are running on the same machine.
 /// See `PREFERRED_BLOB_PORT_RANGE` for the bump budget.
 pub fn preferred_blob_port() -> u16 {
+    if let Some(instance_id) = daemon_instance_id() {
+        return preferred_blob_port_for_normalized_instance(build_channel(), &instance_id);
+    }
     if is_dev_mode() {
         if let Some(worktree) = get_workspace_path() {
             let hash = worktree_hash(&worktree);
@@ -1035,6 +1121,36 @@ pub fn preferred_blob_port() -> u16 {
         BuildChannel::Stable => 47820,
         BuildChannel::Nightly => 47830,
     }
+}
+
+/// Derive a stable preferred blob-server port block for a host-owned instance.
+///
+/// The channel participates in the hash so stable and nightly instances with
+/// the same host id do not prefer the same block. Binding still probes the ten
+/// consecutive ports and falls back to an OS-assigned port on collision.
+pub fn preferred_blob_port_for_instance(
+    channel: BuildChannel,
+    instance_id: &str,
+) -> Result<u16, &'static str> {
+    let normalized =
+        normalize_daemon_instance_id(instance_id).ok_or("daemon instance id must not be empty")?;
+    Ok(preferred_blob_port_for_normalized_instance(
+        channel, normalized,
+    ))
+}
+
+fn preferred_blob_port_for_normalized_instance(channel: BuildChannel, normalized: &str) -> u16 {
+    let mut hasher = Sha256::new();
+    hasher.update(cache_namespace_for(channel).as_bytes());
+    hasher.update([0]);
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    let block = u16::from_be_bytes([digest[0], digest[1]]) % 500;
+    let channel_base = match channel {
+        BuildChannel::Stable => 49000,
+        BuildChannel::Nightly => 54000,
+    };
+    channel_base + block * PREFERRED_BLOB_PORT_RANGE
 }
 
 /// How many consecutive ports past `preferred_blob_port()` the blob server
@@ -1054,9 +1170,38 @@ pub const PREFERRED_BLOB_PORT_RANGE: u16 = 10;
 /// In dev mode: `~/.cache/runt/worktrees/{hash}/`
 /// Otherwise: `~/.cache/runt/`
 pub fn daemon_base_dir() -> PathBuf {
-    let base = dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(cache_namespace());
+    match daemon_instance_id() {
+        Some(instance_id) => channel_cache_root(build_channel())
+            .join("instances")
+            .join(daemon_instance_key_from_normalized(&instance_id)),
+        None => daemon_base_dir_for(build_channel()),
+    }
+}
+
+/// Get the base directory for a specific channel's daemon context.
+///
+/// Like `daemon_base_dir()`, but accepts an explicit channel instead of
+/// using the compile-time default. Useful for cross-channel discovery
+/// (e.g., a stable-compiled binary finding the nightly socket).
+pub fn daemon_base_dir_for(channel: BuildChannel) -> PathBuf {
+    daemon_base_dir_without_instance(channel)
+}
+
+/// Get the base directory for an explicit host-owned daemon instance.
+///
+/// Unlike [`daemon_base_dir_for`], this ignores `RUNTIMED_INSTANCE_ID` and uses
+/// the supplied id. Embedding clients use this to derive the socket they should
+/// probe before spawning a child with the matching environment variable.
+pub fn daemon_base_dir_for_instance(
+    channel: BuildChannel,
+    instance_id: &str,
+) -> Result<PathBuf, &'static str> {
+    let key = daemon_instance_key(instance_id)?;
+    Ok(channel_cache_root(channel).join("instances").join(key))
+}
+
+fn daemon_base_dir_without_instance(channel: BuildChannel) -> PathBuf {
+    let base = channel_cache_root(channel);
 
     if is_dev_mode() {
         if let Some(worktree) = get_workspace_path() {
@@ -1067,23 +1212,10 @@ pub fn daemon_base_dir() -> PathBuf {
     base
 }
 
-/// Get the base directory for a specific channel's daemon context.
-///
-/// Like `daemon_base_dir()`, but accepts an explicit channel instead of
-/// using the compile-time default. Useful for cross-channel discovery
-/// (e.g., a stable-compiled binary finding the nightly socket).
-pub fn daemon_base_dir_for(channel: BuildChannel) -> PathBuf {
-    let base = dirs::cache_dir()
+fn channel_cache_root(channel: BuildChannel) -> PathBuf {
+    dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(cache_namespace_for(channel));
-
-    if is_dev_mode() {
-        if let Some(worktree) = get_workspace_path() {
-            let hash = worktree_hash(&worktree);
-            return base.join("worktrees").join(hash);
-        }
-    }
-    base
+        .join(cache_namespace_for(channel))
 }
 
 /// Get the default log path for the notebook app.
@@ -1172,7 +1304,13 @@ pub fn default_socket_path() -> PathBuf {
     if let Some(path) = socket_path_from_env() {
         return path;
     }
-    socket_path_for_channel(build_channel())
+    match daemon_instance_id() {
+        Some(instance_id) => match socket_path_for_instance(build_channel(), &instance_id) {
+            Ok(path) => path,
+            Err(_) => socket_path_for_channel(build_channel()),
+        },
+        None => socket_path_for_channel(build_channel()),
+    }
 }
 
 /// Get the endpoint path for a specific channel's daemon.
@@ -1187,17 +1325,52 @@ pub fn socket_path_for_channel(channel: BuildChannel) -> PathBuf {
     daemon_base_dir_for(channel).join("runtimed.sock")
 }
 
+/// Get the Unix socket path for an explicit host-owned daemon instance.
+#[cfg(unix)]
+pub fn socket_path_for_instance(
+    channel: BuildChannel,
+    instance_id: &str,
+) -> Result<PathBuf, &'static str> {
+    Ok(daemon_base_dir_for_instance(channel, instance_id)?.join("runtimed.sock"))
+}
+
 /// Get the endpoint path for a specific channel's daemon (Windows).
 #[cfg(windows)]
 pub fn socket_path_for_channel(channel: BuildChannel) -> PathBuf {
     let pipe_name = daemon_binary_basename_for(channel);
-    if is_dev_mode() {
+    PathBuf::from(windows_pipe_name(pipe_name, None, true))
+}
+
+/// Get the Windows named-pipe path for an explicit host-owned daemon instance.
+#[cfg(windows)]
+pub fn socket_path_for_instance(
+    channel: BuildChannel,
+    instance_id: &str,
+) -> Result<PathBuf, &'static str> {
+    let instance_key = daemon_instance_key(instance_id)?;
+    Ok(PathBuf::from(windows_pipe_name(
+        daemon_binary_basename_for(channel),
+        Some(&instance_key),
+        false,
+    )))
+}
+
+#[cfg(windows)]
+fn windows_pipe_name(pipe_name: &str, instance_key: Option<&str>, include_dev: bool) -> String {
+    let mut suffixes = Vec::new();
+    if include_dev && is_dev_mode() {
         if let Some(worktree) = get_workspace_path() {
-            let hash = worktree_hash(&worktree);
-            return PathBuf::from(format!(r"\\.\pipe\{}-{}", pipe_name, hash));
+            suffixes.push(worktree_hash(&worktree));
         }
     }
-    PathBuf::from(format!(r"\\.\pipe\{}", pipe_name))
+    if let Some(instance_key) = instance_key {
+        suffixes.push(format!("instance-{instance_key}"));
+    }
+    if suffixes.is_empty() {
+        format!(r"\\.\pipe\{}", pipe_name)
+    } else {
+        format!(r"\\.\pipe\{}-{}", pipe_name, suffixes.join("-"))
+    }
 }
 
 /// Check `RUNTIMED_SOCKET_PATH` env var and return the path if valid.
@@ -1222,10 +1395,7 @@ fn socket_path_from_env() -> Option<PathBuf> {
 
 /// Get the path to the JSON settings file (for migration and fallback).
 pub fn settings_json_path() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(config_namespace())
-        .join("settings.json")
+    daemon_config_dir().join("settings.json")
 }
 
 /// Get the path to the session state file.
@@ -1473,6 +1643,71 @@ mod tests {
     }
 
     #[test]
+    fn daemon_instance_key_is_stable_trimmed_and_path_safe() {
+        let key = daemon_instance_key("desktop-host").unwrap();
+        assert_eq!(key.len(), 12);
+        assert!(key.chars().all(|character| character.is_ascii_hexdigit()));
+        assert_eq!(daemon_instance_key(" desktop-host ").unwrap(), key);
+        assert_ne!(daemon_instance_key("other-host").unwrap(), key);
+        assert_eq!(daemon_instance_key("../../desktop-host").unwrap().len(), 12);
+        assert!(daemon_instance_key("   ").is_err());
+    }
+
+    #[test]
+    fn explicit_daemon_instance_paths_share_one_safe_key() {
+        let key = daemon_instance_key("desktop-host").unwrap();
+        let base = daemon_base_dir_for_instance(BuildChannel::Nightly, "desktop-host").unwrap();
+        let config = daemon_config_dir_for_instance(BuildChannel::Nightly, "desktop-host").unwrap();
+        let settings =
+            settings_json_path_for_instance(BuildChannel::Nightly, "desktop-host").unwrap();
+
+        assert!(base.ends_with(Path::new("instances").join(&key)));
+        assert!(config.ends_with(Path::new("instances").join(&key)));
+        assert_eq!(settings, config.join("settings.json"));
+        assert_ne!(base, daemon_base_dir_for(BuildChannel::Nightly));
+        assert_eq!(
+            config,
+            daemon_config_dir_without_instance(BuildChannel::Nightly)
+                .join("instances")
+                .join(key)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_daemon_instance_socket_is_below_its_base() {
+        let base = daemon_base_dir_for_instance(BuildChannel::Stable, "desktop-host").unwrap();
+        assert_eq!(
+            socket_path_for_instance(BuildChannel::Stable, "desktop-host").unwrap(),
+            base.join("runtimed.sock")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn explicit_daemon_instance_pipe_is_path_safe() {
+        let key = daemon_instance_key("../../desktop-host").unwrap();
+        let pipe = socket_path_for_instance(BuildChannel::Stable, "../../desktop-host").unwrap();
+        assert_eq!(
+            pipe,
+            PathBuf::from(format!(r"\\.\pipe\runtimed-instance-{key}"))
+        );
+    }
+
+    #[test]
+    fn explicit_daemon_instance_blob_port_is_stable_and_channel_scoped() {
+        let stable =
+            preferred_blob_port_for_instance(BuildChannel::Stable, "desktop-host").unwrap();
+        let nightly =
+            preferred_blob_port_for_instance(BuildChannel::Nightly, "desktop-host").unwrap();
+        assert!((49000..=53990).contains(&stable));
+        assert!((54000..=58990).contains(&nightly));
+        assert_eq!(stable % PREFERRED_BLOB_PORT_RANGE, 0);
+        assert_eq!(nightly % PREFERRED_BLOB_PORT_RANGE, 0);
+        assert_ne!(stable, nightly);
+    }
+
+    #[test]
     fn test_target_dir_env_empty_is_ignored() {
         let workspace = Path::new("/workspace");
         assert_eq!(target_dir_from_env_value(workspace, None), None);
@@ -1570,7 +1805,10 @@ mod tests {
         // compile time and from process-wide env vars), so just sanity-check
         // that the returned port is in one of the expected ranges.
         let port = preferred_blob_port();
-        let ok = port == 47820 || port == 47830 || (48000..49000).contains(&port);
+        let ok = port == 47820
+            || port == 47830
+            || (48000..49000).contains(&port)
+            || (49000..=58990).contains(&port);
         assert!(ok, "unexpected preferred_blob_port: {port}");
     }
 

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -93,6 +93,11 @@ pub struct DaemonInfo {
     pub worktree_path: Option<String>,
     /// Human-readable workspace description (dev mode only).
     pub workspace_description: Option<String>,
+    /// Host-owned daemon instance id. `None` for the normal channel daemon.
+    pub instance_id: Option<String>,
+    /// Default namespace directory selected by the daemon process environment.
+    /// Explicit path overrides may place individual resources elsewhere.
+    pub daemon_base_dir: Option<String>,
 }
 
 impl PongInfo {
@@ -225,6 +230,8 @@ impl PoolClient {
                 execution_store_dir,
                 worktree_path,
                 workspace_description,
+                instance_id,
+                daemon_base_dir,
             } => Ok(DaemonInfo {
                 protocol_version,
                 daemon_version,
@@ -234,6 +241,8 @@ impl PoolClient {
                 execution_store_dir,
                 worktree_path,
                 workspace_description,
+                instance_id,
+                daemon_base_dir,
             }),
             Response::Error { message } => Err(ClientError::DaemonError(message)),
             _ => Err(ClientError::ProtocolError(

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -201,10 +201,7 @@ pub fn connections_dir() -> PathBuf {
 
 /// Get the path to the settings JSON Schema file.
 pub fn settings_schema_path() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(runt_workspace::config_namespace())
-        .join("settings.schema.json")
+    runt_workspace::settings_json_path().with_file_name("settings.schema.json")
 }
 
 /// Get the default directory for persisted notebook Automerge documents.
@@ -236,6 +233,11 @@ fn ipc_socket_base_dir() -> PathBuf {
 #[cfg(unix)]
 pub fn ipc_socket_dir() -> PathBuf {
     let base = ipc_socket_base_dir();
+    if let Some(instance_id) = runt_workspace::daemon_instance_id() {
+        if let Ok(key) = runt_workspace::daemon_instance_key(&instance_id) {
+            return base.join(format!("instance-{key}"));
+        }
+    }
     if is_dev_mode() {
         if let Some(worktree) = get_workspace_path() {
             return base.join(format!("wt-{}", worktree_hash(&worktree)));

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -151,6 +151,13 @@ pub enum Response {
         /// Human-readable workspace description (dev mode only).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         workspace_description: Option<String>,
+        /// Host-owned daemon instance id. Normal nteract daemons return None.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        instance_id: Option<String>,
+        /// Default namespace directory selected by the daemon process environment.
+        /// Explicit path overrides may place individual resources elsewhere.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        daemon_base_dir: Option<String>,
     },
 
     /// Shutdown acknowledged.
@@ -725,6 +732,54 @@ mod tests {
                 assert_eq!(daemon_version, None);
             }
             _ => panic!("unexpected response type"),
+        }
+    }
+
+    #[test]
+    fn daemon_info_instance_fields_are_additive() {
+        let old_json = r#"{
+            "type":"daemon_info",
+            "protocol_version":4,
+            "daemon_version":"2.6.3+abc123",
+            "pid":42,
+            "started_at":"2026-08-11T00:00:00Z"
+        }"#;
+        match serde_json::from_str::<Response>(old_json).unwrap() {
+            Response::DaemonInfo {
+                instance_id,
+                daemon_base_dir,
+                ..
+            } => {
+                assert_eq!(instance_id, None);
+                assert_eq!(daemon_base_dir, None);
+            }
+            other => panic!("unexpected response type: {other:?}"),
+        }
+
+        let response = Response::DaemonInfo {
+            protocol_version: 4,
+            daemon_version: "2.6.3+abc123".into(),
+            pid: 42,
+            started_at: chrono::DateTime::parse_from_rfc3339("2026-08-11T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            blob_port: Some(54_000),
+            execution_store_dir: Some("/cache/instances/key/executions".into()),
+            worktree_path: None,
+            workspace_description: None,
+            instance_id: Some("desktop-host".into()),
+            daemon_base_dir: Some("/cache/instances/key".into()),
+        };
+        match roundtrip_response(&response) {
+            Response::DaemonInfo {
+                instance_id,
+                daemon_base_dir,
+                ..
+            } => {
+                assert_eq!(instance_id.as_deref(), Some("desktop-host"));
+                assert_eq!(daemon_base_dir.as_deref(), Some("/cache/instances/key"));
+            }
+            other => panic!("unexpected response type: {other:?}"),
         }
     }
 

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -31,6 +31,13 @@ pub struct DaemonInfo {
     /// Human-readable workspace description (dev mode only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_description: Option<String>,
+    /// Host-owned daemon instance id. `None` for the normal channel daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    /// Default namespace directory selected by the daemon process environment.
+    /// Explicit path overrides may place individual resources elsewhere.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_base_dir: Option<String>,
 }
 
 /// Get the path to the daemon lock file.
@@ -56,6 +63,8 @@ pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<Daemon
             execution_store_dir: info.execution_store_dir,
             worktree_path: info.worktree_path,
             workspace_description: info.workspace_description,
+            instance_id: info.instance_id,
+            daemon_base_dir: info.daemon_base_dir,
         });
     }
     None

--- a/crates/runtimed-node/src/lib.rs
+++ b/crates/runtimed-node/src/lib.rs
@@ -5,7 +5,8 @@
 //! `runtimed` daemon, creating and executing cells, and reading outputs.
 //!
 //! Phase 1 surface (intentionally small):
-//!   - `defaultSocketPath()` / `socketPathForChannel(channel)`
+//!   - `defaultSocketPath()` / `socketPathForChannel(channel)` /
+//!     `socketPathForInstance(channel, instanceId)`
 //!   - `createNotebook({ runtime, workingDir?, socketPath?, dependencies?, packageManager?, environmentMode? }) -> Session`
 //!   - `openNotebook(notebookId, { socketPath? }) -> Session`
 //!   - `getExecutionResult(executionId, { socketPath? }) -> CellResult`
@@ -59,18 +60,30 @@ pub fn default_socket_path() -> String {
 /// "nightly"). Ignores `RUNTIMED_SOCKET_PATH`.
 #[napi]
 pub fn socket_path_for_channel(channel: String) -> napi::Result<String> {
-    let ch = match channel.as_str() {
-        "stable" => runt_workspace::BuildChannel::Stable,
-        "nightly" => runt_workspace::BuildChannel::Nightly,
-        other => {
-            return Err(napi::Error::from_reason(format!(
-                "channel must be \"stable\" or \"nightly\", got {other:?}"
-            )));
-        }
-    };
+    let ch = parse_channel(&channel)?;
     Ok(runt_workspace::socket_path_for_channel(ch)
         .to_string_lossy()
         .to_string())
+}
+
+/// Return the daemon socket path for a host-owned instance in a specific
+/// channel. Ignores both `RUNTIMED_SOCKET_PATH` and `RUNTIMED_INSTANCE_ID`.
+#[napi]
+pub fn socket_path_for_instance(channel: String, instance_id: String) -> napi::Result<String> {
+    let ch = parse_channel(&channel)?;
+    runt_workspace::socket_path_for_instance(ch, &instance_id)
+        .map(|path| path.to_string_lossy().to_string())
+        .map_err(napi::Error::from_reason)
+}
+
+fn parse_channel(channel: &str) -> napi::Result<runt_workspace::BuildChannel> {
+    match channel {
+        "stable" => Ok(runt_workspace::BuildChannel::Stable),
+        "nightly" => Ok(runt_workspace::BuildChannel::Nightly),
+        other => Err(napi::Error::from_reason(format!(
+            "channel must be \"stable\" or \"nightly\", got {other:?}"
+        ))),
+    }
 }
 
 // Session + openNotebook/createNotebook are registered from session.rs

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -104,7 +104,7 @@ Rules:
 
 ## Blob store
 
-Content-addressed storage lives under `runt_workspace::daemon_base_dir()/blobs` (stable expands to `~/.cache/runt/blobs/`; source builds normally use the nightly namespace). Entries are sharded by first 2 hex chars. Each blob has a `.meta` sidecar with `{media_type, size, created_at}`. Blobs are ephemeral — regenerated from `.ipynb` on daemon restart.
+Content-addressed storage lives under `runt_workspace::daemon_base_dir()/blobs` (stable expands to `~/.cache/runt/blobs/`; source builds normally use the nightly namespace; host-owned instances add `instances/<hash>/`). Entries are sharded by first 2 hex chars. Each blob has a `.meta` sidecar with `{media_type, size, created_at}`. Blobs are ephemeral — regenerated from `.ipynb` on daemon restart.
 
 Manifests are inline Automerge Maps in RuntimeStateDoc. Each contains `ContentRef` entries per MIME type: `{"inline": "<data>"}` for ≤1KB text, `{"blob": "<hash>", "size": N}` for content >1KB or any binary. MIME types and sizes are readable directly from the CRDT — no blob fetch needed for metadata.
 
@@ -159,6 +159,8 @@ Source builds default to the nightly channel (affects cache/socket namespaces). 
 - Unix socket at `~/.cache/<namespace>/runtimed.sock`, mode `0600`
 - Socket directory kept owner-private (`0700`)
 - `RUNTIMED_SOCKET_PATH` is a capability-bearing pointer — only set it for processes that should control the daemon
+- `RUNTIMED_INSTANCE_ID` isolates one embedding host's whole daemon root; it is collision isolation within the same OS user, not authentication
+- `runt-shared/file-claims` stays shared across instances to prevent two daemons from saving the same file-backed notebook
 - Blob HTTP server binds `127.0.0.1`, read-only, content-addressed
 
 ## Python bindings (runtimed-py)

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -198,9 +198,17 @@ fn legacy_settings_doc_path(config: &DaemonConfig) -> PathBuf {
 
 #[cfg(unix)]
 fn channel_socket_parent() -> Option<PathBuf> {
-    runt_workspace::socket_path_for_channel(runt_workspace::build_channel())
-        .parent()
-        .map(Path::to_path_buf)
+    let channel = runt_workspace::build_channel();
+    let path = match runt_workspace::daemon_instance_id() {
+        Some(instance_id) => {
+            match runt_workspace::socket_path_for_instance(channel, &instance_id) {
+                Ok(path) => path,
+                Err(_) => runt_workspace::socket_path_for_channel(channel),
+            }
+        }
+        None => runt_workspace::socket_path_for_channel(channel),
+    };
+    path.parent().map(Path::to_path_buf)
 }
 
 #[cfg(unix)]
@@ -1952,6 +1960,12 @@ impl Daemon {
             ),
             worktree_path,
             workspace_description,
+            instance_id: runt_workspace::daemon_instance_id(),
+            daemon_base_dir: Some(
+                runt_workspace::daemon_base_dir()
+                    .to_string_lossy()
+                    .to_string(),
+            ),
         }
     }
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -273,15 +273,11 @@ enum Commands {
 /// Get a log path that works even when HOME is not set.
 /// Falls back to /tmp if the normal cache directory is unavailable.
 fn early_log_path() -> PathBuf {
-    // Try the standard location first
-    if let Some(cache) = dirs::cache_dir() {
-        let path = cache
-            .join(runt_workspace::cache_namespace())
-            .join("runtimed.log");
-        if let Some(parent) = path.parent() {
-            if std::fs::create_dir_all(parent).is_ok() {
-                return path;
-            }
+    // Try the instance-aware standard location first.
+    let path = runtimed::default_log_path();
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_ok() {
+            return path;
         }
     }
     // Fallback to /tmp which should always be writable

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -132,6 +132,12 @@ fn placeholder_daemon_info(custom_lock_dir: Option<&PathBuf>) -> client_singleto
         execution_store_dir: None,
         worktree_path: None,
         workspace_description: None,
+        instance_id: runt_workspace::daemon_instance_id(),
+        daemon_base_dir: Some(
+            runt_workspace::daemon_base_dir()
+                .to_string_lossy()
+                .to_string(),
+        ),
     }
 }
 

--- a/crates/runtimed/tests/instance_namespace.rs
+++ b/crates/runtimed/tests/instance_namespace.rs
@@ -1,0 +1,175 @@
+// Tests can use unwrap/expect freely - panics are acceptable in test code.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Process-level verification for host-owned daemon instances.
+//!
+//! This intentionally launches the real `runtimed` binary. In-process
+//! `DaemonConfig` tests can inject separate lock directories without proving
+//! that the production environment/path contract isolates a whole daemon.
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use runtimed::client::PoolClient;
+use runtimed_client::client::DaemonInfo;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn runtimed_binary() -> PathBuf {
+    match option_env!("CARGO_BIN_EXE_runtimed") {
+        Some(path) => PathBuf::from(path),
+        None => panic!("cargo must provide the runtimed binary to integration tests"),
+    }
+}
+
+struct InstanceProcess {
+    child: Child,
+    base_dir: PathBuf,
+    config_dir: PathBuf,
+}
+
+impl InstanceProcess {
+    fn spawn(instance_id: &str) -> Self {
+        let channel = runt_workspace::build_channel();
+        let base_dir = runt_workspace::daemon_base_dir_for_instance(channel, instance_id)
+            .expect("non-empty test instance id");
+        let config_dir = runt_workspace::daemon_config_dir_for_instance(channel, instance_id)
+            .expect("non-empty test instance id");
+        let binary = runtimed_binary();
+        let child = Command::new(binary)
+            .args([
+                "--log-level",
+                "warn",
+                "run",
+                "--uv-pool-size",
+                "0",
+                "--conda-pool-size",
+                "0",
+                "--pixi-pool-size",
+                "0",
+            ])
+            .env(runt_workspace::DAEMON_INSTANCE_ID_ENV, instance_id)
+            .env_remove("RUNTIMED_SOCKET_PATH")
+            .env_remove("RUNTIMED_DEV")
+            .env_remove("RUNTIMED_WORKSPACE_PATH")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn runtimed instance");
+        Self {
+            child,
+            base_dir,
+            config_dir,
+        }
+    }
+
+    fn wait_for_exit(&mut self) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for InstanceProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.base_dir);
+        let _ = std::fs::remove_dir_all(&self.config_dir);
+    }
+}
+
+async fn wait_for_info(client: &PoolClient) -> DaemonInfo {
+    let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+    loop {
+        if let Ok(info) = client.daemon_info().await {
+            return info;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "daemon did not become ready within {READY_TIMEOUT:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn host_instances_coexist_and_preserve_per_instance_singletons() {
+    let nonce = uuid::Uuid::new_v4();
+    let first_id = format!("instance-test-{nonce}-a");
+    let second_id = format!("instance-test-{nonce}-b");
+    let channel = runt_workspace::build_channel();
+    let first_socket = runt_workspace::socket_path_for_instance(channel, &first_id).unwrap();
+    let second_socket = runt_workspace::socket_path_for_instance(channel, &second_id).unwrap();
+    let normal_socket = runt_workspace::socket_path_for_channel(channel);
+
+    assert_ne!(first_socket, second_socket);
+    assert_ne!(first_socket, normal_socket);
+    assert_ne!(second_socket, normal_socket);
+
+    let mut first = InstanceProcess::spawn(&first_id);
+    let first_client = PoolClient::new(first_socket.clone());
+    let first_info = wait_for_info(&first_client).await;
+
+    let mut second = InstanceProcess::spawn(&second_id);
+    let second_client = PoolClient::new(second_socket.clone());
+    let second_info = wait_for_info(&second_client).await;
+
+    assert_ne!(first_info.pid, second_info.pid);
+    assert_eq!(first_info.instance_id.as_deref(), Some(first_id.as_str()));
+    assert_eq!(second_info.instance_id.as_deref(), Some(second_id.as_str()));
+    assert_eq!(
+        first_info.daemon_base_dir.as_deref(),
+        Some(first.base_dir.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        second_info.daemon_base_dir.as_deref(),
+        Some(second.base_dir.to_string_lossy().as_ref())
+    );
+    assert_ne!(first_info.blob_port, second_info.blob_port);
+    assert!(first.base_dir.join("daemon.lock").is_file());
+    assert!(second.base_dir.join("daemon.lock").is_file());
+    assert!(first.config_dir.join("settings.json").is_file());
+    assert!(second.config_dir.join("settings.json").is_file());
+
+    let binary = runtimed_binary();
+    let duplicate = Command::new(binary)
+        .args([
+            "--log-level",
+            "warn",
+            "run",
+            "--uv-pool-size",
+            "0",
+            "--conda-pool-size",
+            "0",
+            "--pixi-pool-size",
+            "0",
+        ])
+        .env(runt_workspace::DAEMON_INSTANCE_ID_ENV, &first_id)
+        .env_remove("RUNTIMED_SOCKET_PATH")
+        .env_remove("RUNTIMED_DEV")
+        .env_remove("RUNTIMED_WORKSPACE_PATH")
+        .output()
+        .expect("run duplicate instance");
+    assert!(duplicate.status.success());
+    assert!(String::from_utf8_lossy(&duplicate.stderr).contains("Another daemon already running"));
+    assert_eq!(
+        first_client.daemon_info().await.unwrap().pid,
+        first_info.pid
+    );
+    assert!(second_client.ping().await.is_ok());
+
+    first_client.shutdown().await.unwrap();
+    second_client.shutdown().await.unwrap();
+    first.wait_for_exit();
+    second.wait_for_exit();
+}

--- a/docs/adr/notebook-identity-and-path-binding.md
+++ b/docs/adr/notebook-identity-and-path-binding.md
@@ -85,12 +85,64 @@ A claim follows activity, not room residency. It is held while the room has conn
 
 Claims are leases, never locks: a dead pid or a lapsed refresh window makes a claim stale, and the next writer reaps it, so a crashed daemon cannot brick a path. The registry holds facts only; source-conflict reconciliation stays the last line of defense when a claim lied or a race slipped through.
 
+## Decision 7: Embedding hosts may own an isolated daemon instance
+
+The stable and nightly channel namespaces are product defaults, not a complete
+process identity. A desktop application embedding nteract may need to ship a
+daemon built from a different revision while the user's normal nteract daemon
+continues serving live notebooks. A different `--socket` is insufficient: the
+singleton lock and the rest of the daemon's mutable state still resolve through
+the channel's `daemon_base_dir()`.
+
+An embedding host may set `RUNTIMED_INSTANCE_ID` on the daemon child. The id is
+an opaque label; path and named-pipe derivation uses its 12-character SHA-256
+key. The ordinary stable/nightly layout is unchanged when the variable is
+absent. When present, daemon-owned cache/state moves below
+`<channel-cache-root>/instances/<key>/`, including:
+
+- the singleton lock and default socket or named pipe;
+- notebook documents and registry, execution records, blobs, and kernel
+  connection/manifests;
+- the trust database;
+- mutable UV, Conda, Pixi, inline, launcher, and tool directories.
+
+The settings document and its schema use the corresponding
+`<channel-config-root>/instances/<key>/` directory. They cannot remain on the
+normal profile: two independently versioned daemons would otherwise watch and
+rewrite the same configuration file.
+
+Materialized environments are intentionally not shared. Environment garbage
+collection protects only kernels known to its own daemon, so sharing that
+directory would let one process delete another process's active environment.
+Package-manager download caches may still be shared through their existing
+upstream cache mechanisms; those are not daemon-owned runtime state.
+
+The one deliberate exception is `runt-shared/file-claims`. Every instance must
+continue to use the same cross-daemon lease registry so two processes cannot
+open and save the same file-backed notebook concurrently. Instance isolation
+removes version and lifecycle coupling; it does not weaken the one-daemon-per-
+path invariant from Decision 6.
+
+Clients must derive and probe the same endpoint before spawning. Rust exposes
+`socket_path_for_instance(channel, id)` and `@runtimed/node` exposes
+`socketPathForInstance(channel, id)` for that purpose. The child receives the
+matching `RUNTIMED_INSTANCE_ID`; clients continue passing the resulting socket
+path explicitly. The live `GetDaemonInfo` response reports the normalized
+instance id for diagnostics and ownership checks.
+
 ## Rejected alternatives
 
 - **Path-encoded or path-derived ids.** Couples identity to location; every move mints a new id and you are back to needing a remap table. Rejected in Decision 1.
 - **Embed the local id in `.ipynb` metadata.** Breaks git collaboration: id churn or cross-machine collision. Rejected in Decision 3. Only a cloud id is embeddable.
 - **`old_id -> new_id` remap table.** A symptom of path-derived ids. With a stable id and a mutable path attribute it has nothing to track. Rejected in Decision 1.
 - **Treat the UUID as durable and reload by UUID across daemons.** The UUID is daemon-instance scoped; the live failure above is exactly this. Rejected in Decision 2.
+- **Socket-only isolation.** A custom socket leaves the channel-wide singleton
+  lock and mutable daemon state shared. The second process either exits without
+  binding or, if the lock is bypassed, risks cross-process state corruption.
+  Rejected in Decision 7.
+- **Share materialized environment directories to save disk.** Each daemon's GC
+  has only local kernel liveness, so it cannot safely decide whether another
+  daemon still needs an environment. Rejected in Decision 7.
 
 ## Open Follow-ups
 

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -121,6 +121,11 @@ sessions.
   or the `RUNTIMED_SOCKET_PATH` override.
 - `socketPathForChannel("stable" | "nightly")` returns a channel-specific
   daemon socket path.
+- `socketPathForInstance("stable" | "nightly", instanceId)` returns the
+  isolated socket or named-pipe path for a host-owned daemon instance. Spawn
+  the matching daemon with `RUNTIMED_INSTANCE_ID=instanceId`; its lock, socket,
+  notebook documents, blobs, execution records, trust database, and mutable
+  environment pools will live under that instance namespace.
 - `listActiveNotebooks(options)` lists active daemon notebook rooms.
 - `createNotebook(options)` creates a notebook and records optional first-call dependencies.
 - `openNotebook(notebookId, options)` connects to an existing daemon notebook.
@@ -146,6 +151,7 @@ sessions.
 - `Session.waitForExecution(executionId, options)` waits for queued work.
   Pass `onUpdate(progress)` to receive resolved output snapshots while the
   execution is still running.
+
 - `Session.runtimeState$`, `Session.executionTransitions$`,
   `Session.executionViewChanges$`, `Session.cellChanges$`, `Session.broadcasts$`,
   and `Session.sessionStatus$` expose the same projected event families used by
@@ -168,6 +174,39 @@ sessions.
 - `Session.syncEnvironment()` installs recorded notebook dependencies.
 - `Session.saveNotebook(path?)` saves the notebook.
 - `Session.close()` releases the daemon connection.
+
+## Host-owned daemon instances
+
+An embedding host can run its bundled daemon beside the user's normal nteract
+daemon without attaching to or stopping it:
+
+```js
+const { spawn } = require("node:child_process");
+const { socketPathForInstance } = require("@runtimed/node");
+
+const instanceId = "my-desktop-app-production";
+const socketPath = socketPathForInstance("stable", instanceId);
+const daemonEnv = { ...process.env, RUNTIMED_INSTANCE_ID: instanceId };
+
+// Production hosts should not inherit endpoint or source-worktree overrides.
+delete daemonEnv.RUNTIMED_SOCKET_PATH;
+delete daemonEnv.RUNTIMED_DEV;
+delete daemonEnv.RUNTIMED_WORKSPACE_PATH;
+
+const child = spawn(runtimedBinary, [], { env: daemonEnv });
+```
+
+Probe `socketPath` and query its live daemon metadata before considering the
+child ready; a successful spawn alone is not readiness. Pass `socketPath`
+explicitly to every `@runtimed/node` session or relay. Use a stable instance id
+per host and release channel (for example production, staging, and development),
+and set the variable on the child only so unrelated nteract clients keep their
+normal channel paths.
+
+The instance id is collision isolation inside the current OS user account, not
+an authentication boundary. Cross-daemon file claims intentionally remain
+shared, so two instances still refuse to serve the same file-backed notebook at
+the same time.
 
 ## Daemon Requirements
 

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -265,6 +265,7 @@ export const NativeSession: unknown;
 
 export function defaultSocketPath(): string;
 export function socketPathForChannel(channel: "stable" | "nightly"): string;
+export function socketPathForInstance(channel: "stable" | "nightly", instanceId: string): string;
 export function createNotebook(options?: CreateNotebookOptions): Promise<Session>;
 export function openNotebook(notebookId: string, options?: OpenNotebookOptions): Promise<Session>;
 export function getExecutionResult(

--- a/packages/runtimed-node/tests/arrow-ipc.test.ts
+++ b/packages/runtimed-node/tests/arrow-ipc.test.ts
@@ -10,6 +10,8 @@ const runNativeIntegration = process.env.RUNTIMED_NODE_NATIVE_INTEGRATION === "1
 const describeNative = runNativeIntegration ? describe : describe.skip;
 
 type NativeBinding = {
+  socketPathForChannel: (channel: "stable" | "nightly") => string;
+  socketPathForInstance: (channel: "stable" | "nightly", instanceId: string) => string;
   readArrowFile: (
     filePath: string,
     offset: number,
@@ -42,6 +44,8 @@ function loadNativeBinding(): NativeBinding {
   try {
     const loaded = require("../src/index.cjs") as Partial<NativeBinding>;
     if (
+      typeof loaded.socketPathForChannel !== "function" ||
+      typeof loaded.socketPathForInstance !== "function" ||
       typeof loaded.readArrowFile !== "function" ||
       typeof loaded.readArrowChunks !== "function" ||
       typeof loaded.summarizeArrowFile !== "function" ||
@@ -72,7 +76,21 @@ function nativeBinding(): NativeBinding {
   return binding;
 }
 
-describeNative("@runtimed/node Arrow IPC native integration", () => {
+describeNative("@runtimed/node native integration", () => {
+  it("derives a deterministic isolated endpoint without changing the channel endpoint", () => {
+    const native = nativeBinding();
+    const channelPath = native.socketPathForChannel("stable");
+    const first = native.socketPathForInstance("stable", "desktop-host");
+    const second = native.socketPathForInstance("stable", " desktop-host ");
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(channelPath);
+    expect(first).toContain("instance");
+    expect(() => native.socketPathForInstance("stable", "   ")).toThrow(
+      /instance id must not be empty/,
+    );
+  });
+
   it("reads and summarizes a real Utf8View Arrow stream fixture", () => {
     const native = nativeBinding();
     const page = native.readArrowFile(fixture, 0, 3);


### PR DESCRIPTION
> [!IMPORTANT]
> **WIP design exploration.** This is not proposed as the default daemon model or as a
> release dependency. The preferred default remains one user-level singleton so nteract,
> embedding hosts, users, and multiple agents can join the same live notebook through one
> daemon. Client compatibility should be governed by negotiated protocol versions and
> capabilities, not by creating a second daemon for each host revision.

## Current direction

- keep the normal stable/nightly singleton as the product default and collaboration authority
- let independently released clients attach when their protocol version and required capabilities are compatible
- retain source revisions as diagnostic provenance rather than the compatibility boundary
- consider an instance namespace only as an explicit opt-in for tests or deployments that intentionally require isolation

The current implementation remains open as research while that narrower opt-in use case is
evaluated. Its shared file claim prevents two daemons from writing one file-backed notebook,
but that safety property is not equivalent to collaboration: the second daemon is refused
instead of joining the existing live document.

## Experimental implementation

- add an opt-in `RUNTIMED_INSTANCE_ID` namespace for desktop and Electron hosts that bundle an independently versioned daemon
- isolate the singleton, endpoint, settings, documents, execution records, blobs, trust state, kernel IPC, and mutable environment/tool roots while preserving the legacy stable/nightly paths when the variable is absent
- keep the cross-daemon file-claim registry shared so separate instances still refuse concurrent ownership of the same file-backed notebook
- expose deterministic `socket_path_for_instance` / `socketPathForInstance` helpers and additive daemon diagnostics

## Original motivation

A custom socket alone does not isolate a daemon. The channel-wide singleton and other mutable state still resolve through the normal stable or nightly root, so an embedding host cannot safely run a bundled revision beside the user's ordinary daemon.

This experiment gives a host one stable opaque instance id. The daemon hashes it into a short path-safe key, uses a whole-root namespace, and reports the live instance identity. Hosts can derive and probe the endpoint before spawning, set the id on the daemon child only, and pass the derived endpoint explicitly to every client session.

Materialized environments are deliberately instance-local because each daemon's garbage collector only knows about its own live kernels. Shared package-manager download caches remain available through their existing upstream mechanisms.

## Compatibility and security

- no instance id means the exact existing channel/worktree paths and endpoints
- the instance id is collision isolation within one OS user, not authentication
- endpoint and dev-worktree overrides should be scrubbed from a production child environment
- explicit CLI/programmatic path overrides still take precedence for the resources they configure
- the shared file-claim lease remains the cross-instance guard for file-backed notebooks

## Verification

- `cargo xtask lint --fix`
- `cargo clippy -p runt-workspace -p runtimed-client -p runtimed -p runtimed-node --all-targets -- -D warnings`
- `cargo test -p runt-workspace -p runtimed-client --lib`
- `cargo test -p runtimed --test instance_namespace -- --nocapture`
- `cargo test -p runtimed singleton`
- `cargo test -p runt-mcp daemon_watch`
- `pnpm --dir packages/runtimed-node build`
- `RUNTIMED_NODE_NATIVE_INTEGRATION=1 pnpm exec vp test run packages/runtimed-node/tests/arrow-ipc.test.ts`
- `cargo check -p runt-workspace --target x86_64-pc-windows-msvc`

Manual process smoke also kept the ordinary nightly daemon running while two isolated instances started with different endpoints, locks, settings, PIDs, and blob ports. A duplicate of the same instance id exited without disturbing the owner; a second instance was refused when it tried to open the same file-backed notebook; execution worked through the native Node client; and reopening after an instance restart recovered notebook source and the durable execution result.
