### PR TITLE
feat(protocol): negotiate semantic capabilities

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -20,7 +20,8 @@ pub use framing::{
 pub use handshake::{
     recv_typed_bootstrap_frame, send_typed_bootstrap_frame, ConnectionBootstrap,
     CreateNotebookRequest, Handshake, NotebookConnectionInfo, ProtocolCapabilities,
-    PutBlobCapability, PROTOCOL_V4, PROTOCOL_VERSION,
+    PutBlobCapability, FEATURE_CALLER_OWNED_EXECUTION_IDS, FEATURE_CONFIRM_NOTEBOOK_HEADS,
+    FEATURE_EXACT_EXECUTION_CANCELLATION, FEATURE_VERSION_1, PROTOCOL_V4, PROTOCOL_VERSION,
 };
 
 #[cfg(windows)]
@@ -314,6 +315,7 @@ mod tests {
                 protocol: PROTOCOL_V4.into(),
                 protocol_version,
                 daemon_version,
+                features: Default::default(),
                 put_blob: None,
                 actor_label: None,
                 connection_scope: None,
@@ -447,6 +449,29 @@ mod tests {
         );
         assert!(put_blob.multipart);
         assert!(put_blob.ephemeral_supported);
+    }
+
+    #[test]
+    fn semantic_features_are_versioned_independently_of_protocol_v4() {
+        let baseline = ProtocolCapabilities::v4(None);
+        assert_eq!(baseline.protocol_version, Some(4));
+        assert!(!baseline.supports_feature(FEATURE_CONFIRM_NOTEBOOK_HEADS, 1));
+
+        let capabilities = ProtocolCapabilities::runtimed_v4(None);
+        assert!(capabilities.supports_feature(FEATURE_CALLER_OWNED_EXECUTION_IDS, 1));
+        assert!(capabilities.supports_feature(FEATURE_CONFIRM_NOTEBOOK_HEADS, 1));
+        assert!(capabilities.supports_feature(FEATURE_EXACT_EXECUTION_CANCELLATION, 1));
+        assert!(!capabilities.supports_feature(FEATURE_EXACT_EXECUTION_CANCELLATION, 2));
+
+        let json = serde_json::to_value(&capabilities).unwrap();
+        assert_eq!(
+            json["features"][FEATURE_EXACT_EXECUTION_CANCELLATION],
+            FEATURE_VERSION_1
+        );
+
+        let legacy: ProtocolCapabilities =
+            serde_json::from_str(r#"{"protocol":"v4","protocol_version":4}"#).unwrap();
+        assert!(legacy.features.is_empty());
     }
 
     #[tokio::test]

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -1,5 +1,7 @@
 //! Connection handshake data structures.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -182,6 +184,16 @@ pub const PROTOCOL_V4: &str = "v4";
 /// is not wire-compatible with v3 clients.
 pub const PROTOCOL_VERSION: u8 = 4;
 
+/// Semantic feature names advertised inside a wire-compatible protocol.
+///
+/// A missing feature is unsupported. Unknown features must be ignored. Values
+/// are independent feature schema versions, allowing an additive operation to
+/// evolve without conflating it with the framing-level protocol number.
+pub const FEATURE_CALLER_OWNED_EXECUTION_IDS: &str = "caller_owned_execution_ids";
+pub const FEATURE_CONFIRM_NOTEBOOK_HEADS: &str = "confirm_notebook_heads";
+pub const FEATURE_EXACT_EXECUTION_CANCELLATION: &str = "exact_execution_cancellation";
+pub const FEATURE_VERSION_1: u32 = 1;
+
 /// Server response indicating protocol capabilities.
 ///
 /// Sent immediately after handshake, before starting sync.
@@ -198,6 +210,14 @@ pub struct ProtocolCapabilities {
     /// Useful for debugging version mismatches.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_version: Option<String>,
+    /// Versioned additive semantics supported by this endpoint.
+    ///
+    /// This is distinct from `protocol_version`: the protocol number governs
+    /// framing and serialization compatibility, while this map lets callers
+    /// gate optional operations before sending them. Missing means
+    /// unsupported; clients ignore keys they do not recognize.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub features: BTreeMap<String, u32>,
     /// Blob upload support advertised by the daemon.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub put_blob: Option<PutBlobCapability>,
@@ -226,6 +246,7 @@ impl ProtocolCapabilities {
             protocol: PROTOCOL_V4.to_string(),
             protocol_version: Some(PROTOCOL_VERSION.into()),
             daemon_version,
+            features: BTreeMap::new(),
             put_blob: Some(PutBlobCapability {
                 version: 1,
                 single_frame_max: put_blob_limits.cap as u64,
@@ -237,6 +258,34 @@ impl ProtocolCapabilities {
             comments_doc_id: None,
             comments_notebook_ref: None,
         }
+    }
+
+    /// Protocol-v4 capabilities implemented by the local runtimed endpoint.
+    pub fn runtimed_v4(daemon_version: Option<String>) -> Self {
+        let mut capabilities = Self::v4(daemon_version);
+        capabilities.features = BTreeMap::from([
+            (
+                FEATURE_CALLER_OWNED_EXECUTION_IDS.to_string(),
+                FEATURE_VERSION_1,
+            ),
+            (
+                FEATURE_CONFIRM_NOTEBOOK_HEADS.to_string(),
+                FEATURE_VERSION_1,
+            ),
+            (
+                FEATURE_EXACT_EXECUTION_CANCELLATION.to_string(),
+                FEATURE_VERSION_1,
+            ),
+        ]);
+        capabilities
+    }
+
+    /// Whether this endpoint implements at least `minimum_version` of an
+    /// additive semantic feature.
+    pub fn supports_feature(&self, name: &str, minimum_version: u32) -> bool {
+        self.features
+            .get(name)
+            .is_some_and(|version| *version >= minimum_version)
     }
 
     /// Attach authenticated identity metadata to this capability response.

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -50,6 +50,9 @@ pub struct ConnectResult {
 
     /// Initial metadata string (legacy format, for handshake compat).
     pub initial_metadata: Option<String>,
+
+    /// Negotiated protocol metadata for gating additive operations.
+    pub capabilities: ProtocolCapabilities,
 }
 
 /// Result of connecting to an existing notebook file.
@@ -306,6 +309,7 @@ pub async fn connect_with_options(
             handle,
             broadcast_rx,
             initial_metadata,
+            capabilities: caps,
         })
 }
 
@@ -503,6 +507,10 @@ where
             handle,
             broadcast_rx,
             initial_metadata: None,
+            // This path receives already-authenticated typed frames after a
+            // transport-specific handshake. Until that handshake forwards a
+            // feature map, optional local-daemon semantics remain unsupported.
+            capabilities: ProtocolCapabilities::v4(None),
         })
 }
 

--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -16,6 +16,7 @@ Scope: `crates/notebook-wire/`, `crates/notebook-doc/`, `crates/notebook-protoco
 Two independent integers, separate from the artifact version:
 
 - **`PROTOCOL_VERSION`** (`connection/handshake.rs`, currently `4`) governs wire compatibility. Bump for framing, handshake, or serialization changes. Every connection starts with a 5-byte preamble (`0xC0DE01AC` + version byte). `Pool` stays version-tolerant so older stable apps can probe during upgrade; other channels require `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`. Protocol v4 dropped legacy environment-sync request/response variants.
+- **Semantic features** (`ProtocolCapabilities.features`) version additive operations inside a wire-compatible protocol. Missing keys are unsupported; unknown keys are ignored. Gate a feature before sending its request or applying local mutations. Do not use artifact versions or source revisions as the compatibility boundary.
 - **`SCHEMA_VERSION`** (`notebook-doc/src/lib.rs`, currently `5`) governs Automerge doc compatibility. Stored at the doc root as `schema_version`. Cells live in a fractional-indexed `Map`; `NotebookDoc` also carries `runtime_state_doc_id` so outputs and runtime lifecycle can live in the paired `RuntimeStateDoc`. Any future bump ships `migrate_vN_to_v(N+1)` that preserves user data.
 
 Artifact versions follow standard semver. Protocol or schema bumps don't automatically force a major version bump.

--- a/crates/runtimed-node/src/relay.rs
+++ b/crates/runtimed-node/src/relay.rs
@@ -94,6 +94,8 @@ pub struct RelayInfo {
     pub comments_notebook_ref_json: Option<String>,
     pub protocol: String,
     pub protocol_version: Option<u32>,
+    /// JSON object mapping additive semantic feature names to their versions.
+    pub features_json: String,
     pub daemon_version: Option<String>,
     pub socket_path: String,
     pub blob_port: Option<u32>,
@@ -385,6 +387,8 @@ fn relay_info_from_capabilities(
         .comments_notebook_ref
         .as_ref()
         .and_then(|value| serde_json::to_string(value).ok());
+    let features_json =
+        serde_json::to_string(&capabilities.features).unwrap_or_else(|_| "{}".to_string());
     RelayInfo {
         notebook_id,
         cell_count,
@@ -398,11 +402,11 @@ fn relay_info_from_capabilities(
         comments_notebook_ref_json,
         protocol: capabilities.protocol,
         protocol_version: capabilities.protocol_version,
-        // This is deliberately handshake-only. A later pool query can race a
-        // daemon restart and therefore cannot identify the process that owns
-        // this relay. Hosts that enforce admission or reconnect compatibility
-        // must be able to distinguish an omitted handshake identity from pool
-        // metadata returned by another process.
+        features_json,
+        // This is deliberately handshake-only diagnostic metadata. A later
+        // pool query can race a daemon restart and therefore cannot identify
+        // the process that owns this relay. Compatibility is negotiated from
+        // protocol_version and features above.
         daemon_version: capabilities.daemon_version,
         socket_path: socket_path.to_string_lossy().into_owned(),
         blob_port: daemon

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -4,6 +4,7 @@
 //! Phase 2 will extract the shared logic into a `runtimed-session` crate
 //! and collapse both `-py` and `-node` onto it.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,6 +15,10 @@ use napi_derive::napi;
 use serde::Serialize;
 use tokio::sync::Mutex;
 
+use notebook_protocol::connection::{
+    FEATURE_CALLER_OWNED_EXECUTION_IDS, FEATURE_CONFIRM_NOTEBOOK_HEADS,
+    FEATURE_EXACT_EXECUTION_CANCELLATION, FEATURE_VERSION_1,
+};
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 use notebook_sync::{
     BroadcastReceiver, ConnectionState, DocHandle, InitialLoadPhase, NotebookDocPhase,
@@ -465,6 +470,7 @@ struct SessionState {
     socket_path: PathBuf,
     working_dir: Option<String>,
     peer_label: String,
+    protocol_features: BTreeMap<String, u32>,
 }
 
 struct OutputResolutionContext<'a> {
@@ -558,6 +564,17 @@ impl Session {
     #[napi(getter)]
     pub fn notebook_id(&self) -> String {
         self.notebook_id.clone()
+    }
+
+    /// Additive semantic feature versions negotiated with the daemon.
+    #[napi(getter)]
+    pub fn protocol_features_json(&self) -> Result<String> {
+        let state = self
+            .state
+            .try_lock()
+            .map_err(|_| Error::from_reason("Session state busy"))?;
+        serde_json::to_string(&state.protocol_features)
+            .map_err(|error| Error::from_reason(format!("Serialize protocol features: {error}")))
     }
 
     /// Subscribe to RuntimeStateDoc snapshots. Callback receives a JSON string.
@@ -1110,6 +1127,12 @@ impl Session {
         source: String,
         options: Option<CreateCellOptions>,
     ) -> Result<String> {
+        require_protocol_feature(
+            &self.state,
+            FEATURE_CONFIRM_NOTEBOOK_HEADS,
+            FEATURE_VERSION_1,
+        )
+        .await?;
         let opts = options.unwrap_or_default();
         let cell_type = normalize_cell_type(opts.cell_type)?;
         let (handle, peer_label) = session_handle_and_label(&self.state).await?;
@@ -1150,6 +1173,12 @@ impl Session {
     /// Replace a cell's source and/or type. Returns true if the cell existed.
     #[napi]
     pub async fn set_cell(&self, cell_id: String, options: SetCellOptions) -> Result<bool> {
+        require_protocol_feature(
+            &self.state,
+            FEATURE_CONFIRM_NOTEBOOK_HEADS,
+            FEATURE_VERSION_1,
+        )
+        .await?;
         let cell_type = options
             .cell_type
             .map(|cell_type| normalize_cell_type(Some(cell_type)))
@@ -1184,6 +1213,12 @@ impl Session {
     /// Delete a cell. Returns true if the cell existed.
     #[napi]
     pub async fn delete_cell(&self, cell_id: String) -> Result<bool> {
+        require_protocol_feature(
+            &self.state,
+            FEATURE_CONFIRM_NOTEBOOK_HEADS,
+            FEATURE_VERSION_1,
+        )
+        .await?;
         let (handle, peer_label) = session_handle_and_label(&self.state).await?;
         let deleted = handle.delete_cell(&cell_id).map_err(to_napi_err)?;
         if deleted {
@@ -1201,6 +1236,12 @@ impl Session {
         cell_id: String,
         options: Option<MoveCellOptions>,
     ) -> Result<String> {
+        require_protocol_feature(
+            &self.state,
+            FEATURE_CONFIRM_NOTEBOOK_HEADS,
+            FEATURE_VERSION_1,
+        )
+        .await?;
         let handle = session_handle(&self.state).await?;
         let after_cell_id = options.and_then(|opts| opts.after_cell_id);
         let position = handle
@@ -1242,6 +1283,14 @@ impl Session {
         options: Option<QueueExistingCellOptions>,
     ) -> Result<QueuedExecution> {
         let requested_execution_id = options.and_then(|opts| opts.execution_id);
+        if requested_execution_id.is_some() {
+            require_protocol_feature(
+                &self.state,
+                FEATURE_CALLER_OWNED_EXECUTION_IDS,
+                FEATURE_VERSION_1,
+            )
+            .await?;
+        }
         ensure_kernel_started(&self.state).await?;
         let execution_id =
             queue_existing_cell(&self.state, &cell_id, requested_execution_id).await?;
@@ -1319,6 +1368,12 @@ impl Session {
     /// queued targets are removed without affecting other work.
     #[napi]
     pub async fn cancel_execution(&self, execution_id: String) -> Result<CancelExecutionResult> {
+        require_protocol_feature(
+            &self.state,
+            FEATURE_EXACT_EXECUTION_CANCELLATION,
+            FEATURE_VERSION_1,
+        )
+        .await?;
         let handle = session_handle(&self.state).await?;
         let response = handle
             .send_request(NotebookRequest::CancelExecution {
@@ -1480,6 +1535,7 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
         .map_err(to_napi_err)?;
 
     let notebook_id = result.info.notebook_id.clone();
+    let protocol_features = result.info.capabilities.features.clone();
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
 
     let state = SessionState {
@@ -1492,6 +1548,7 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
         socket_path,
         working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
         peer_label: actor_label.clone(),
+        protocol_features,
     };
 
     notebook_sync::presence::announce(
@@ -1567,6 +1624,7 @@ pub async fn open_notebook_path(
         .map_err(to_napi_err)?;
 
     let notebook_id = result.info.notebook_id.clone();
+    let protocol_features = result.info.capabilities.features.clone();
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
     let (kernel_started, runtime) = kernel_state_from_handle(&result.handle);
 
@@ -1580,6 +1638,7 @@ pub async fn open_notebook_path(
         socket_path,
         working_dir: None,
         peer_label: actor_label.clone(),
+        protocol_features,
     };
 
     notebook_sync::presence::announce(
@@ -1616,6 +1675,7 @@ pub async fn open_notebook(
         .map_err(to_napi_err)?;
 
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
+    let protocol_features = result.capabilities.features.clone();
 
     // Try to hydrate kernel state from the RuntimeStateDoc.
     let (kernel_started, runtime) = kernel_state_from_handle(&result.handle);
@@ -1630,6 +1690,7 @@ pub async fn open_notebook(
         socket_path,
         working_dir: None,
         peer_label: actor_label.clone(),
+        protocol_features,
     };
 
     notebook_sync::presence::announce(
@@ -1708,6 +1769,23 @@ async fn session_handle(state: &Arc<Mutex<SessionState>>) -> Result<DocHandle> {
         .as_ref()
         .ok_or_else(|| Error::from_reason("Not connected"))
         .cloned()
+}
+
+async fn require_protocol_feature(
+    state: &Arc<Mutex<SessionState>>,
+    name: &str,
+    minimum_version: u32,
+) -> Result<()> {
+    let st = state.lock().await;
+    match st.protocol_features.get(name) {
+        Some(version) if *version >= minimum_version => Ok(()),
+        Some(version) => Err(Error::from_reason(format!(
+            "Protocol feature {name}@{minimum_version} is required; daemon advertises {name}@{version}"
+        ))),
+        None => Err(Error::from_reason(format!(
+            "Protocol feature {name}@{minimum_version} is required but was not advertised by the daemon"
+        ))),
+    }
 }
 
 async fn session_handle_and_label(state: &Arc<Mutex<SessionState>>) -> Result<(DocHandle, String)> {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -169,7 +169,7 @@ async fn send_error_response<W: AsyncWrite + Unpin>(
         ProtocolCapabilities,
     };
     let response = NotebookConnectionInfo {
-        capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
+        capabilities: ProtocolCapabilities::runtimed_v4(Some(crate::daemon_version().to_string())),
         notebook_id: String::new(),
         cell_count: 0,
         needs_trust_approval: false,
@@ -3549,12 +3549,14 @@ impl Daemon {
 
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
-            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
-                .with_identity(
-                    connection_identity.actor_label().as_str(),
-                    connection_identity.scope().as_str(),
-                )
-                .with_comments_doc_id(comments_doc_id),
+            capabilities: ProtocolCapabilities::runtimed_v4(Some(
+                crate::daemon_version().to_string(),
+            ))
+            .with_identity(
+                connection_identity.actor_label().as_str(),
+                connection_identity.scope().as_str(),
+            )
+            .with_comments_doc_id(comments_doc_id),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval: false,
@@ -4233,12 +4235,14 @@ impl Daemon {
         // used for logging and file-watcher wiring below.
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
-            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
-                .with_identity(
-                    connection_identity.actor_label().as_str(),
-                    connection_identity.scope().as_str(),
-                )
-                .with_comments_doc_identity(comments_doc_id, comments_notebook_ref),
+            capabilities: ProtocolCapabilities::runtimed_v4(Some(
+                crate::daemon_version().to_string(),
+            ))
+            .with_identity(
+                connection_identity.actor_label().as_str(),
+                connection_identity.scope().as_str(),
+            )
+            .with_comments_doc_identity(comments_doc_id, comments_notebook_ref),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,
@@ -4422,7 +4426,9 @@ impl Daemon {
             );
             let (mut reader, mut writer) = tokio::io::split(stream);
             let response = NotebookConnectionInfo {
-                capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
+                capabilities: ProtocolCapabilities::runtimed_v4(Some(
+                    crate::daemon_version().to_string(),
+                )),
                 notebook_id: String::new(),
                 cell_count: 0,
                 needs_trust_approval: false,
@@ -4505,12 +4511,14 @@ impl Daemon {
             .transpose()
             .context("serialize comments notebook ref for create notebook response")?;
         let response = NotebookConnectionInfo {
-            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
-                .with_identity(
-                    connection_identity.actor_label().as_str(),
-                    connection_identity.scope().as_str(),
-                )
-                .with_comments_doc_identity(comments_doc_id, comments_notebook_ref),
+            capabilities: ProtocolCapabilities::runtimed_v4(Some(
+                crate::daemon_version().to_string(),
+            ))
+            .with_identity(
+                connection_identity.actor_label().as_str(),
+                connection_identity.scope().as_str(),
+            )
+            .with_comments_doc_identity(comments_doc_id, comments_notebook_ref),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -344,12 +344,14 @@ where
             .map(serde_json::to_value)
             .transpose()
             .context("serialize comments notebook ref for notebook sync capabilities")?;
-        let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
-            .with_identity(
-                ctx.connection_identity.actor_label().as_str(),
-                ctx.connection_identity.scope().as_str(),
-            )
-            .with_comments_doc_identity(comments_doc_id, comments_notebook_ref);
+        let caps = connection::ProtocolCapabilities::runtimed_v4(Some(
+            crate::daemon_version().to_string(),
+        ))
+        .with_identity(
+            ctx.connection_identity.actor_label().as_str(),
+            ctx.connection_identity.scope().as_str(),
+        )
+        .with_comments_doc_identity(comments_doc_id, comments_notebook_ref);
         if typed_capabilities {
             connection::send_typed_bootstrap_frame(
                 &mut writer,

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -83,9 +83,9 @@ readiness.
 exact handshake. It is intentionally left undefined when an older daemon omits
 it rather than being filled from a later pool query, which could race a daemon
 restart. Treat that artifact version as diagnostic metadata. Compatibility is
-determined by the negotiated protocol number and, for optional semantics, the
-capabilities advertised by the connection. Use `queryDaemonInfo()` only for
-readiness and diagnostics.
+determined by `relay.info.protocolVersion` and the integer versions in
+`relay.info.features`; a missing feature is unsupported and unknown features
+are ignored. Use `queryDaemonInfo()` only for readiness and diagnostics.
 
 Frames include the one-byte notebook frame discriminator and omit the daemon
 socket's length prefix; an empty buffer is not a frame and is rejected. The
@@ -205,10 +205,9 @@ sessions.
   synchronize, so re-read the cell before retrying. A repeated `createCell()`
   with the same `cellId`, source, and type is idempotent; conflicting content is
   rejected, including concurrent attempts in the same session.
-  Durable mutation acknowledgement requires `@runtimed/node` and the runtimed
-  daemon to come from the same compatible release. Older daemons do not
-  recognize the confirmation barrier; explicit capability negotiation is
-  future work.
+  Durable mutation acknowledgement requires the `confirm_notebook_heads`
+  feature at version 1. The wrapper rejects before mutation when the daemon
+  does not advertise it.
 - `Session.executeCell(cellId, options)` runs an existing code cell.
 - `Session.showNotebook()` opens the session in nteract Desktop when a display
   is available.
@@ -219,7 +218,8 @@ sessions.
   and never interrupts a successor or unrelated execution. The returned
   outcome is `interrupted`, `cancelled_queued`, `already_terminal`, or
   `not_found`; `terminalStatus` is present for an already-terminal execution.
-  Daemon-bridged hosted notebooks do not support exact cancellation yet.
+  This requires `exact_execution_cancellation` at version 1; daemon-bridged
+  hosted notebooks do not support exact cancellation yet.
 - `Session.shutdownNotebook()` shuts down this notebook room and closes the session.
 - `Session.runCell(source, options)` appends, runs, and waits for a cell.
 - `Session.queueCell(source, options)` appends a cell, queues it, and returns IDs.
@@ -228,7 +228,8 @@ sessions.
   is ready and the daemon has accepted the execution. Cold kernel startup can
   therefore delay the call. Supply a UUID `executionId` when retries must refer
   to the same execution attempt. A retry returns the existing active or terminal
-  execution for that cell; reusing the UUID for another cell is rejected.
+  execution for that cell; reusing the UUID for another cell is rejected. A
+  caller-supplied ID requires `caller_owned_execution_ids` at version 1.
 - `Session.waitForExecution(executionId, options)` waits for queued work.
   Pass `onUpdate(progress)` to receive resolved output snapshots while the
   execution is still running.

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -253,6 +253,8 @@ export interface DependencyStatus {
 
 export class Session {
   readonly notebookId: string;
+  /** Additive semantic feature versions; missing keys are unsupported. */
+  readonly protocolFeatures: Readonly<Record<string, number>>;
   readonly runtimeState$: Observable<RuntimeState>;
   readonly executionTransitions$: Observable<ExecutionTransition>;
   readonly executionViewChanges$: Observable<ExecutionViewChangeset>;

--- a/packages/runtimed-node/src/relay-session.cjs
+++ b/packages/runtimed-node/src/relay-session.cjs
@@ -102,7 +102,7 @@ function toBuffer(frame) {
 }
 
 function normalizeRelayInfo(info) {
-  const { commentsNotebookRefJson, ...rest } = info;
+  const { commentsNotebookRefJson, featuresJson, ...rest } = info;
   let commentsNotebookRef = null;
   if (commentsNotebookRefJson) {
     try {
@@ -112,7 +112,22 @@ function normalizeRelayInfo(info) {
       // notebook synchronization do not depend on this presentation hint.
     }
   }
-  return { ...rest, commentsNotebookRef };
+  let features = {};
+  if (featuresJson) {
+    try {
+      const parsed = JSON.parse(featuresJson);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        features = Object.fromEntries(
+          Object.entries(parsed).filter(
+            ([name, version]) => name.length > 0 && Number.isInteger(version) && version >= 0,
+          ),
+        );
+      }
+    } catch {
+      // Missing/malformed optional capabilities are treated as unsupported.
+    }
+  }
+  return { ...rest, commentsNotebookRef, features };
 }
 
 module.exports = { RelaySession, normalizeRelayInfo, toBuffer };

--- a/packages/runtimed-node/src/relay.d.ts
+++ b/packages/runtimed-node/src/relay.d.ts
@@ -50,6 +50,8 @@ export interface RelayInfo {
   commentsNotebookRef: CommentsNotebookRef | null;
   protocol: string;
   protocolVersion?: number;
+  /** Additive semantic feature versions; missing keys are unsupported. */
+  features: Readonly<Record<string, number>>;
   /** Exact notebook-handshake identity; never filled from a later pool query. */
   daemonVersion?: string;
   socketPath: string;

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -70,6 +70,20 @@ class Session {
     return this._native.notebookId;
   }
 
+  get protocolFeatures() {
+    try {
+      const parsed = JSON.parse(this._native.protocolFeaturesJson ?? "{}");
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+      return Object.fromEntries(
+        Object.entries(parsed).filter(
+          ([name, version]) => name.length > 0 && Number.isInteger(version) && version >= 0,
+        ),
+      );
+    } catch {
+      return {};
+    }
+  }
+
   queueCell(source, options) {
     return this._native.queueCell(source, options);
   }

--- a/packages/runtimed-node/tests/relay.test.ts
+++ b/packages/runtimed-node/tests/relay.test.ts
@@ -149,11 +149,31 @@ describe("@runtimed/node relay wrapper", () => {
       normalizeRelayInfo({
         notebookId: "notebook-1",
         commentsNotebookRefJson: '{"kind":"local_path","canonical_path":"/tmp/a.ipynb"}',
+        featuresJson:
+          '{"caller_owned_execution_ids":1,"exact_execution_cancellation":1,"unknown_future_feature":7}',
       }),
     ).toEqual({
       notebookId: "notebook-1",
       commentsNotebookRef: { kind: "local_path", canonical_path: "/tmp/a.ipynb" },
+      features: {
+        caller_owned_execution_ids: 1,
+        exact_execution_cancellation: 1,
+        unknown_future_feature: 7,
+      },
     });
+  });
+
+  it("treats missing or malformed feature metadata as unsupported", () => {
+    expect(normalizeRelayInfo({ notebookId: "notebook-1" })).toMatchObject({ features: {} });
+    expect(
+      normalizeRelayInfo({ notebookId: "notebook-1", featuresJson: "not-json" }),
+    ).toMatchObject({ features: {} });
+    expect(
+      normalizeRelayInfo({
+        notebookId: "notebook-1",
+        featuresJson: '{"valid":2,"string":"1","negative":-1,"fractional":1.5}',
+      }),
+    ).toMatchObject({ features: { valid: 2 } });
   });
 
   it("rejects values that are not binary frames", () => {

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -20,6 +20,7 @@ const { Session } = require("../src/session.cjs") as {
       };
     };
     getExecutionView: () => unknown;
+    protocolFeatures: Readonly<Record<string, number>>;
     runCell: (source: string, options?: Record<string, unknown>) => Promise<unknown>;
     exportSnapshotPair: () => Promise<unknown>;
     getCellOutputs: (cellId: string) => Promise<unknown>;
@@ -28,6 +29,21 @@ const { Session } = require("../src/session.cjs") as {
 };
 
 describe("@runtimed/node Session wrapper", () => {
+  it("projects negotiated protocol feature versions and defaults missing metadata safely", () => {
+    const session = new Session({
+      notebookId: "nb-1",
+      protocolFeaturesJson: '{"caller_owned_execution_ids":1,"exact_execution_cancellation":1}',
+      close: vi.fn(async () => {}),
+    });
+    const legacy = new Session({ notebookId: "nb-legacy", close: vi.fn(async () => {}) });
+
+    expect(session.protocolFeatures).toEqual({
+      caller_owned_execution_ids: 1,
+      exact_execution_cancellation: 1,
+    });
+    expect(legacy.protocolFeatures).toEqual({});
+  });
+
   it("replays native status emitted during session construction", () => {
     const disconnected = {
       connection: "disconnected",


### PR DESCRIPTION
## Summary

- keep protocol v4 as the framing and serialization compatibility boundary
- add a versioned `features` map to `ProtocolCapabilities` for additive semantics within v4
- advertise caller-owned execution IDs, durable notebook-head confirmation, and exact execution cancellation at feature version 1
- carry negotiated features through `notebook-sync`, the native relay, and the high-level Node session
- reject feature-dependent Node operations before kernel launch, request delivery, or local document mutation when the daemon did not advertise the required version
- remove exact source-revision admission from the Node relay; artifact versions remain diagnostic metadata

## Contract

The handshake now distinguishes two independent compatibility axes:

- `protocol_version` governs framing and wire serialization
- `features: Record<string, number>` governs additive operation semantics

A missing feature is unsupported. Unknown features are ignored. A caller may use a feature only when the advertised integer is at least the version it requires.

The local runtimed endpoint currently advertises:

```json
{
  "caller_owned_execution_ids": 1,
  "confirm_notebook_heads": 1,
  "exact_execution_cancellation": 1
}
```

Pre-authenticated frame transports that do not forward handshake capabilities default to an empty feature set. This prevents a cloud or custom transport from accidentally inheriting local-daemon semantics.

## Node behavior

- `RelaySession.info.features` exposes the generic version map to embedding hosts
- `Session.protocolFeatures` exposes the same map to programmatic clients
- caller-supplied execution IDs are checked before lazy kernel launch
- exact cancellation is checked before its request is sent
- durable cell create/set/delete/move APIs are checked before applying a local Automerge mutation
- malformed JavaScript feature metadata is treated as unsupported

## Verification

- `cargo xtask lint --fix`
- `cargo test -p notebook-protocol -p notebook-sync -p runtimed-node`
- `cargo check -p runtimed`
- focused Node relay/session wrapper tests: 21 passed
- rebuilt `@runtimed/node` native addon
- live isolated dev-daemon relay smoke passed
- live handshake observed protocol 4 and all three feature flags at version 1

## Stack

- base: #4142

This remains draft while the programmatic Node authoring stack is evaluated against the shared JS/WASM client ownership boundary.
