### PR TITLE
chore(release): bump versions for 2.7.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "nteract",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "source": {
         "source": "local",
         "path": "./plugins/nteract"
@@ -19,7 +19,7 @@
     },
     {
       "name": "nightly",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "source": {
         "source": "local",
         "path": "./plugins/nightly"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.4.3"
+      "version": "0.5.0"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.4.3"
+      "version": "0.5.0"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "automerge-recovery"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "automerge",
  "thiserror 2.0.18",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "automerge",
  "serde_json",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "build-metadata"
-version = "0.2.3"
+version = "0.3.0"
 
 [[package]]
 name = "bumpalo"
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "comments-doc"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4445,11 +4445,11 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-client-branding"
-version = "0.2.3"
+version = "0.3.0"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "libc",
@@ -4759,7 +4759,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-cloud-transport"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4825,7 +4825,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-wire"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "serde",
 ]
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-identity"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "futures",
  "jsonwebtoken",
@@ -4938,7 +4938,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-markdown-engine"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "markdown",
  "serde",
@@ -4947,14 +4947,14 @@ dependencies = [
 
 [[package]]
 name = "nteract-markdown-wasm"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "nteract-markdown-engine",
 ]
 
 [[package]]
 name = "nteract-mcp"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-telemetry"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "log",
  "reqwest 0.12.28",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -7378,7 +7378,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -7414,7 +7414,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7449,7 +7449,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -7460,7 +7460,7 @@ dependencies = [
 
 [[package]]
 name = "runt-publish"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -7482,7 +7482,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7490,7 +7490,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7505,7 +7505,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "aho-corasick",
  "alacritty_terminal",
@@ -7596,7 +7596,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7622,7 +7622,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7648,7 +7648,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-outputs"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "base64 0.22.1",
  "notebook-doc",
@@ -7663,7 +7663,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "kernel-env",
  "log",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-service"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "dirs",
  "log",
@@ -7696,7 +7696,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-settings-sync"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "automerge",
  "log",
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "automerge",
  "comments-doc",
@@ -8428,7 +8428,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11734,7 +11734,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/crates/automerge-recovery/Cargo.toml
+++ b/crates/automerge-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge-recovery"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "Small panic recovery helpers for Automerge operations"
 repository.workspace = true

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/build-metadata/Cargo.toml
+++ b/crates/build-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-metadata"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "Shared build-script metadata helpers for nteract desktop"
 repository.workspace = true

--- a/crates/comments-doc/Cargo.toml
+++ b/crates/comments-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comments-doc"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "CommentsDoc — durable per-notebook Automerge document for comments"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-client-branding/Cargo.toml
+++ b/crates/mcp-client-branding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-client-branding"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "Canonical display names for known MCP clients"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-cloud-transport/Cargo.toml
+++ b/crates/notebook-cloud-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-cloud-transport"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "Cloud-WebSocket FrameTransport for the runtime agent (dials a hosted notebook room as a runtime peer)"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook-wire/Cargo.toml
+++ b/crates/notebook-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-wire"
-version = "0.3.3"
+version = "0.4.0"
 edition.workspace = true
 description = "Low-level notebook wire constants, frame limits, and session-control types"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-identity/Cargo.toml
+++ b/crates/nteract-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-identity"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "Identity and authorization primitives for nteract notebook rooms"
 repository.workspace = true

--- a/crates/nteract-markdown-engine/Cargo.toml
+++ b/crates/nteract-markdown-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-markdown-engine"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/nteract-markdown-wasm/Cargo.toml
+++ b/crates/nteract-markdown-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-markdown-wasm"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/nteract-telemetry/Cargo.toml
+++ b/crates/nteract-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-telemetry"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Anonymous phone-home telemetry for nteract Rust binaries"
 repository.workspace = true

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-publish/Cargo.toml
+++ b/crates/runt-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-publish"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 description = "Publisher library for hosted nteract notebook-cloud demos (CLI surface: `runt publish`)"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Notebook trust extraction for the per-machine package allowlist"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for runtime-authoritative state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-outputs/Cargo.toml
+++ b/crates/runtimed-outputs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-outputs"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Output resolution and LLM-friendly output formatting for runtimed"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.6.3"
+version = "2.7.0"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-service/Cargo.toml
+++ b/crates/runtimed-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-service"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Cross-platform service management for the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-settings-sync/Cargo.toml
+++ b/crates/runtimed-settings-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-settings-sync"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Live settings sync client over the runtimed UDS protocol"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 license = "BSD-3-Clause"
 repository = "https://github.com/nteract/nteract"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.6.3"
+version = "2.7.0"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository = "https://github.com/nteract/nteract"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-darwin-arm64",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-win32-x64-msvc",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.win32-x64-msvc.node",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Persistent notebook-backed Python REPL for Pi coding agents. Stateful execution, hot dependency sync, zero cold starts.",
   "author": "nteract contributors",
   "icon": "icon.png",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.3.3"
+version = "2.4.0"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.5.3"
+version = "0.6.0"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.6.3"
+version = "2.7.0"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.3.3"
+version = "0.4.0"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.6.3"
+version = "2.7.0"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- bump the coordinated nteract desktop, daemon, CLI, and Python release line from 2.6.3 to 2.7.0
- bump the independently versioned Rust, JavaScript, plugin, and marketplace packages by one minor version
- publish the new Electron notebook host API from `@runtimed/node` as 0.5.0 after this change is merged and tagged
- refresh `Cargo.lock` using the repository release task

## Why

The Electron notebook host adapter landed in #4147 and is now on `main`. Agentic Desktop needs a published stable `@runtimed/node` containing that API, and this coordinated minor bump prepares the repository for that release. Anaconda channel-handling updates can land separately before the stable tag is created.

This does not change `PROTOCOL_VERSION` or `SCHEMA_VERSION`.

## Generated with

```bash
cargo xtask bump minor
```

## Verification

- `cargo xtask lint --fix`
- `cargo test -p xtask bump::tests -- --nocapture` (11 passed)
- `cargo xtask artifacts ensure sift,renderer`
- `cargo check --workspace`
- verified the changed-file set matches the previous coordinated release bump shape
- verified `PROTOCOL_VERSION`, `SCHEMA_VERSION`, and `pnpm-lock.yaml` are unchanged
