### PR TITLE
fix(env): trust Anaconda default channels

### DIFF
--- a/crates/kernel-env/src/channels.rs
+++ b/crates/kernel-env/src/channels.rs
@@ -1,0 +1,84 @@
+//! Shared Conda-channel resolution for Conda and Pixi environments.
+
+use anyhow::Result;
+use rattler_conda_types::{Channel, ChannelConfig, Platform};
+
+/// The channels represented by Conda's special `defaults` multichannel.
+///
+/// `rattler_conda_types::Channel` resolves ordinary names against
+/// `conda.anaconda.org`; it does not expand Conda's `defaults` alias. Keep the
+/// expansion explicit so Conda and Pixi environments reach the official
+/// Anaconda repositories rather than a nonexistent community channel.
+pub(crate) const ANACONDA_DEFAULT_CHANNELS: &[&str] = &[
+    "https://repo.anaconda.com/pkgs/main",
+    "https://repo.anaconda.com/pkgs/r",
+    "https://repo.anaconda.com/pkgs/msys2",
+];
+
+pub(crate) fn parse_channels(
+    declared_channels: &[String],
+    channel_config: &ChannelConfig,
+    platform: Platform,
+) -> Result<Vec<Channel>> {
+    if declared_channels.is_empty() {
+        return Ok(vec![Channel::from_str("conda-forge", channel_config)?]);
+    }
+
+    let mut channels = Vec::new();
+    for declared in declared_channels {
+        if declared == "defaults" {
+            for default_channel in ANACONDA_DEFAULT_CHANNELS {
+                // The msys2 repository is part of Anaconda's Windows defaults;
+                // querying it for Unix platforms only produces missing repodata.
+                if default_channel.ends_with("/msys2") && !platform.is_windows() {
+                    continue;
+                }
+                channels.push(Channel::from_str(default_channel, channel_config)?);
+            }
+        } else {
+            channels.push(Channel::from_str(declared, channel_config)?);
+        }
+    }
+    Ok(channels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn defaults_expands_to_anaconda_channels_instead_of_community_alias() {
+        let config = ChannelConfig::default_with_root_dir(PathBuf::from("/tmp"));
+        let declared = vec!["defaults".to_string()];
+
+        let unix_channels = parse_channels(&declared, &config, Platform::Linux64).unwrap();
+        let unix_urls = unix_channels
+            .iter()
+            .map(|channel| channel.base_url.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            unix_urls,
+            vec![
+                "https://repo.anaconda.com/pkgs/main/",
+                "https://repo.anaconda.com/pkgs/r/",
+            ]
+        );
+        assert!(unix_urls
+            .iter()
+            .all(|url| !url.contains("conda.anaconda.org/defaults")));
+
+        let windows_channels = parse_channels(&declared, &config, Platform::Win64).unwrap();
+        assert_eq!(
+            windows_channels
+                .iter()
+                .map(|channel| channel.base_url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "https://repo.anaconda.com/pkgs/main/",
+                "https://repo.anaconda.com/pkgs/r/",
+                "https://repo.anaconda.com/pkgs/msys2/",
+            ]
+        );
+    }
+}

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -62,6 +62,18 @@ pub const CONDA_BASE_PACKAGES: &[&str] = &[
     "pyarrow>=14",
 ];
 
+/// The channels represented by Conda's special `defaults` multichannel.
+///
+/// `rattler_conda_types::Channel` resolves ordinary names against
+/// `conda.anaconda.org`; it does not expand Conda's `defaults` alias. Keep the
+/// expansion explicit so an `environment.yml` written by Conda reaches the
+/// official Anaconda repositories rather than a nonexistent community channel.
+pub const ANACONDA_DEFAULT_CHANNELS: &[&str] = &[
+    "https://repo.anaconda.com/pkgs/main",
+    "https://repo.anaconda.com/pkgs/r",
+    "https://repo.anaconda.com/pkgs/msys2",
+];
+
 /// Return [`CONDA_BASE_PACKAGES`] as owned package spec strings for install paths.
 pub fn conda_base_packages() -> Vec<String> {
     CONDA_BASE_PACKAGES
@@ -96,6 +108,33 @@ fn should_enforce_gil_python(deps: &CondaDependencies) -> bool {
         .python
         .as_deref()
         .is_some_and(conda_python_requests_free_threading)
+}
+
+fn parse_channels(
+    declared_channels: &[String],
+    channel_config: &ChannelConfig,
+    platform: Platform,
+) -> Result<Vec<Channel>> {
+    if declared_channels.is_empty() {
+        return Ok(vec![Channel::from_str("conda-forge", channel_config)?]);
+    }
+
+    let mut channels = Vec::new();
+    for declared in declared_channels {
+        if declared == "defaults" {
+            for default_channel in ANACONDA_DEFAULT_CHANNELS {
+                // The msys2 repository is part of Anaconda's Windows defaults;
+                // querying it for Unix platforms only produces missing repodata.
+                if default_channel.ends_with("/msys2") && !platform.is_windows() {
+                    continue;
+                }
+                channels.push(Channel::from_str(default_channel, channel_config)?);
+            }
+        } else {
+            channels.push(Channel::from_str(declared, channel_config)?);
+        }
+    }
+    Ok(channels)
 }
 
 /// Compute the unified env hash for a notebook. Used by the captured-deps
@@ -493,15 +532,9 @@ async fn install_conda_env(
         .to_path_buf();
     let channel_config = ChannelConfig::default_with_root_dir(cache_dir);
 
-    // Parse channels
-    let channels: Vec<Channel> = if deps.channels.is_empty() {
-        vec![Channel::from_str("conda-forge", &channel_config)?]
-    } else {
-        deps.channels
-            .iter()
-            .map(|c| Channel::from_str(c, &channel_config))
-            .collect::<std::result::Result<Vec<_>, _>>()?
-    };
+    // Parse channels, including Conda's special `defaults` multichannel.
+    let install_platform = Platform::current();
+    let channels = parse_channels(&deps.channels, &channel_config, install_platform)?;
 
     let channel_names: Vec<String> = channels.iter().map(|c| c.name().to_string()).collect();
 
@@ -553,7 +586,6 @@ async fn install_conda_env(
     let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
 
     // Query repodata with offline-first strategy
-    let install_platform = Platform::current();
     let platforms = vec![install_platform, Platform::NoArch];
 
     let repo_data = crate::repodata::query_repodata_offline_first(
@@ -936,14 +968,8 @@ pub async fn sync_dependencies(
         .to_path_buf();
     let channel_config = ChannelConfig::default_with_root_dir(cache_dir);
 
-    let channels: Vec<Channel> = if deps.channels.is_empty() {
-        vec![Channel::from_str("conda-forge", &channel_config)?]
-    } else {
-        deps.channels
-            .iter()
-            .map(|c| Channel::from_str(c, &channel_config))
-            .collect::<std::result::Result<Vec<_>, _>>()?
-    };
+    let install_platform = Platform::current();
+    let channels = parse_channels(&deps.channels, &channel_config, install_platform)?;
 
     let match_spec_options = ParseMatchSpecOptions::strict();
 
@@ -1001,7 +1027,6 @@ pub async fn sync_dependencies(
     let download_client = reqwest::Client::builder().build()?;
     let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
 
-    let install_platform = Platform::current();
     let platforms = vec![install_platform, Platform::NoArch];
 
     let repo_data = crate::repodata::query_repodata_offline_first(
@@ -1393,6 +1418,41 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn defaults_expands_to_anaconda_channels_instead_of_community_alias() {
+        let config = ChannelConfig::default_with_root_dir(PathBuf::from("/tmp"));
+        let declared = vec!["defaults".to_string()];
+
+        let unix_channels = parse_channels(&declared, &config, Platform::Linux64).unwrap();
+        let unix_urls = unix_channels
+            .iter()
+            .map(|channel| channel.base_url.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            unix_urls,
+            vec![
+                "https://repo.anaconda.com/pkgs/main/",
+                "https://repo.anaconda.com/pkgs/r/",
+            ]
+        );
+        assert!(unix_urls
+            .iter()
+            .all(|url| !url.contains("conda.anaconda.org/defaults")));
+
+        let windows_channels = parse_channels(&declared, &config, Platform::Win64).unwrap();
+        assert_eq!(
+            windows_channels
+                .iter()
+                .map(|channel| channel.base_url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "https://repo.anaconda.com/pkgs/main/",
+                "https://repo.anaconda.com/pkgs/r/",
+                "https://repo.anaconda.com/pkgs/msys2/",
+            ]
+        );
+    }
 
     #[test]
     fn test_compute_env_hash_stable() {

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -8,8 +8,8 @@ use anyhow::{anyhow, Context, Result};
 use log::{info, warn};
 use rattler::{default_cache_dir, install::Installer};
 use rattler_conda_types::{
-    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions,
-    ParseStrictness, Platform, PrefixRecord, Version, VersionSpec,
+    ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, ParseStrictness,
+    Platform, PrefixRecord, Version, VersionSpec,
 };
 use rattler_solve::{resolvo, SolverImpl, SolverTask};
 use serde::{Deserialize, Serialize};
@@ -19,7 +19,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::progress::{EnvProgressPhase, ProgressHandler, RattlerReporter};
+use crate::{
+    channels::parse_channels,
+    progress::{EnvProgressPhase, ProgressHandler, RattlerReporter},
+};
 
 /// Conda dependency specification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,18 +65,6 @@ pub const CONDA_BASE_PACKAGES: &[&str] = &[
     "pyarrow>=14",
 ];
 
-/// The channels represented by Conda's special `defaults` multichannel.
-///
-/// `rattler_conda_types::Channel` resolves ordinary names against
-/// `conda.anaconda.org`; it does not expand Conda's `defaults` alias. Keep the
-/// expansion explicit so an `environment.yml` written by Conda reaches the
-/// official Anaconda repositories rather than a nonexistent community channel.
-pub const ANACONDA_DEFAULT_CHANNELS: &[&str] = &[
-    "https://repo.anaconda.com/pkgs/main",
-    "https://repo.anaconda.com/pkgs/r",
-    "https://repo.anaconda.com/pkgs/msys2",
-];
-
 /// Return [`CONDA_BASE_PACKAGES`] as owned package spec strings for install paths.
 pub fn conda_base_packages() -> Vec<String> {
     CONDA_BASE_PACKAGES
@@ -108,33 +99,6 @@ fn should_enforce_gil_python(deps: &CondaDependencies) -> bool {
         .python
         .as_deref()
         .is_some_and(conda_python_requests_free_threading)
-}
-
-fn parse_channels(
-    declared_channels: &[String],
-    channel_config: &ChannelConfig,
-    platform: Platform,
-) -> Result<Vec<Channel>> {
-    if declared_channels.is_empty() {
-        return Ok(vec![Channel::from_str("conda-forge", channel_config)?]);
-    }
-
-    let mut channels = Vec::new();
-    for declared in declared_channels {
-        if declared == "defaults" {
-            for default_channel in ANACONDA_DEFAULT_CHANNELS {
-                // The msys2 repository is part of Anaconda's Windows defaults;
-                // querying it for Unix platforms only produces missing repodata.
-                if default_channel.ends_with("/msys2") && !platform.is_windows() {
-                    continue;
-                }
-                channels.push(Channel::from_str(default_channel, channel_config)?);
-            }
-        } else {
-            channels.push(Channel::from_str(declared, channel_config)?);
-        }
-    }
-    Ok(channels)
 }
 
 /// Compute the unified env hash for a notebook. Used by the captured-deps
@@ -1418,41 +1382,6 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn defaults_expands_to_anaconda_channels_instead_of_community_alias() {
-        let config = ChannelConfig::default_with_root_dir(PathBuf::from("/tmp"));
-        let declared = vec!["defaults".to_string()];
-
-        let unix_channels = parse_channels(&declared, &config, Platform::Linux64).unwrap();
-        let unix_urls = unix_channels
-            .iter()
-            .map(|channel| channel.base_url.as_str())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            unix_urls,
-            vec![
-                "https://repo.anaconda.com/pkgs/main/",
-                "https://repo.anaconda.com/pkgs/r/",
-            ]
-        );
-        assert!(unix_urls
-            .iter()
-            .all(|url| !url.contains("conda.anaconda.org/defaults")));
-
-        let windows_channels = parse_channels(&declared, &config, Platform::Win64).unwrap();
-        assert_eq!(
-            windows_channels
-                .iter()
-                .map(|channel| channel.base_url.as_str())
-                .collect::<Vec<_>>(),
-            vec![
-                "https://repo.anaconda.com/pkgs/main/",
-                "https://repo.anaconda.com/pkgs/r/",
-                "https://repo.anaconda.com/pkgs/msys2/",
-            ]
-        );
-    }
 
     #[test]
     fn test_compute_env_hash_stable() {

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -28,6 +28,8 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 #[cfg(feature = "runtime")]
+mod channels;
+#[cfg(feature = "runtime")]
 pub mod conda;
 #[cfg(feature = "runtime")]
 pub mod gc;

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -17,14 +17,17 @@ use anyhow::{anyhow, Context, Result};
 use log::{debug, info, warn};
 use rattler::{default_cache_dir, install::Installer};
 use rattler_conda_types::{
-    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
+    ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
 };
 use rattler_solve::{resolvo, SolverImpl, SolverTask};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::progress::{EnvProgressPhase, ProgressHandler, RattlerReporter};
+use crate::{
+    channels::parse_channels,
+    progress::{EnvProgressPhase, ProgressHandler, RattlerReporter},
+};
 
 /// A resolved pixi environment on disk.
 ///
@@ -206,11 +209,9 @@ async fn install_pixi_env(
         .to_path_buf();
     let channel_config = ChannelConfig::default_with_root_dir(cache_dir);
 
-    // Parse channels
-    let channels: Vec<Channel> = channels
-        .iter()
-        .map(|c| Channel::from_str(c, &channel_config))
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+    // Parse channels, including Conda's special `defaults` multichannel.
+    let install_platform = Platform::current();
+    let channels = parse_channels(channels, &channel_config, install_platform)?;
 
     // Build specs -- always include python
     let match_spec_options = ParseMatchSpecOptions::strict();
@@ -232,7 +233,6 @@ async fn install_pixi_env(
     let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
 
     // Query repodata with offline-first strategy
-    let install_platform = Platform::current();
     let platforms = vec![install_platform, Platform::NoArch];
 
     let repo_data = crate::repodata::query_repodata_offline_first(
@@ -411,6 +411,24 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pixi_defaults_use_shared_anaconda_channel_expansion() {
+        let config = ChannelConfig::default_with_root_dir(PathBuf::from("/tmp"));
+        let channels =
+            parse_channels(&["defaults".to_string()], &config, Platform::Linux64).unwrap();
+
+        assert_eq!(
+            channels
+                .iter()
+                .map(|channel| channel.base_url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "https://repo.anaconda.com/pkgs/main/",
+                "https://repo.anaconda.com/pkgs/r/",
+            ]
+        );
+    }
 
     #[test]
     fn test_generate_pixi_manifest_basic() {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -499,6 +499,18 @@ const DEFAULT_DATA_PACKAGES: &[&str] = &["pandas", "polars", "matplotlib", "plot
 /// They still land in the env when a notebook declares them as inline
 /// deps; this constant just controls trust seeding.
 const DEFAULT_TRUSTED_EXTRA_PACKAGES: &[&str] = &["numpy", "scipy"];
+/// Public Conda sources that do not require a per-machine approval prompt.
+/// Keep arbitrary organization and URL channels behind the normal trust gate.
+const DEFAULT_TRUSTED_CONDA_CHANNELS: &[&str] = &[
+    "conda-forge",
+    "defaults",
+    "https://repo.anaconda.com/pkgs/main",
+    "https://repo.anaconda.com/pkgs/main/",
+    "https://repo.anaconda.com/pkgs/r",
+    "https://repo.anaconda.com/pkgs/r/",
+    "https://repo.anaconda.com/pkgs/msys2",
+    "https://repo.anaconda.com/pkgs/msys2/",
+];
 const BASE_RUNTIME_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",
@@ -507,6 +519,23 @@ const BASE_RUNTIME_PACKAGES: &[&str] = &[
     "nbformat",
     "pyarrow",
 ];
+
+fn seed_trusted_defaults(store: &TrustedPackageStore) {
+    for ecosystem in ["pypi", "conda"] {
+        if let Err(e) = store.seed_defaults(ecosystem, BASE_RUNTIME_PACKAGES) {
+            warn!("[trusted-packages] Failed to seed base runtime packages ({ecosystem}): {e}");
+        }
+        if let Err(e) = store.seed_defaults(ecosystem, DEFAULT_DATA_PACKAGES) {
+            warn!("[trusted-packages] Failed to seed default data packages ({ecosystem}): {e}");
+        }
+        if let Err(e) = store.seed_defaults(ecosystem, DEFAULT_TRUSTED_EXTRA_PACKAGES) {
+            warn!("[trusted-packages] Failed to seed extra trusted packages ({ecosystem}): {e}");
+        }
+    }
+    if let Err(e) = store.seed_default_channels(DEFAULT_TRUSTED_CONDA_CHANNELS) {
+        warn!("[trusted-packages] Failed to seed default Conda channels: {e}");
+    }
+}
 
 fn has_package_named(packages: &[String], name: &str) -> bool {
     packages
@@ -1581,25 +1610,14 @@ impl Daemon {
         let execution_store = runtimed_client::execution_store::ExecutionStore::new(
             config.execution_store_dir.clone(),
         );
-        let trusted_packages = match TrustedPackageStore::open(
-            config.trusted_packages_db_path.clone(),
-        ) {
-            Ok(store) => {
-                for ecosystem in ["pypi", "conda"] {
-                    if let Err(e) = store.seed_defaults(ecosystem, BASE_RUNTIME_PACKAGES) {
-                        warn!("[trusted-packages] Failed to seed base runtime packages ({ecosystem}): {e}");
-                    }
-                    if let Err(e) = store.seed_defaults(ecosystem, DEFAULT_DATA_PACKAGES) {
-                        warn!("[trusted-packages] Failed to seed default data packages ({ecosystem}): {e}");
-                    }
-                    if let Err(e) = store.seed_defaults(ecosystem, DEFAULT_TRUSTED_EXTRA_PACKAGES) {
-                        warn!("[trusted-packages] Failed to seed extra trusted packages ({ecosystem}): {e}");
-                    }
+        let trusted_packages =
+            match TrustedPackageStore::open(config.trusted_packages_db_path.clone()) {
+                Ok(store) => {
+                    seed_trusted_defaults(&store);
+                    store
                 }
-                store
-            }
-            Err(error) => TrustedPackageStore::unavailable(error.to_string()),
-        };
+                Err(error) => TrustedPackageStore::unavailable(error.to_string()),
+            };
         log_store_unavailable(&trusted_packages);
 
         let notebook_registry = NotebookRegistry::open(config.notebook_registry_db_path.clone())
@@ -7657,6 +7675,37 @@ mod tests {
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn daemon_defaults_preapprove_official_conda_sources() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = TrustedPackageStore::open(tmp.path().join("trusted.sqlite")).unwrap();
+        seed_trusted_defaults(&store);
+
+        let channels = DEFAULT_TRUSTED_CONDA_CHANNELS
+            .iter()
+            .map(|channel| (*channel).to_string())
+            .collect::<Vec<_>>();
+        let mut info = runt_trust::TrustInfo {
+            status: runt_trust::TrustStatus::Untrusted,
+            uv_dependencies: vec![],
+            approved_uv_dependencies: vec![],
+            conda_dependencies: vec![],
+            approved_conda_dependencies: vec![],
+            conda_channels: channels.clone(),
+            approved_conda_channels: vec![],
+            pixi_dependencies: vec![],
+            approved_pixi_dependencies: vec![],
+            pixi_pypi_dependencies: vec![],
+            approved_pixi_pypi_dependencies: vec![],
+            pixi_channels: channels.clone(),
+            approved_pixi_channels: vec![],
+        };
+
+        store.enrich_info(&mut info).unwrap();
+        assert_eq!(info.approved_conda_channels, channels);
+        assert_eq!(info.approved_pixi_channels, info.pixi_channels);
+    }
 
     #[test]
     fn test_prewarmed_packages_derive_from_kernel_env_base_constants() {

--- a/crates/runtimed/src/trusted_packages.rs
+++ b/crates/runtimed/src/trusted_packages.rs
@@ -181,6 +181,39 @@ impl TrustedPackageStore {
         Ok(())
     }
 
+    /// Seed public Conda channel sources that are part of the product's
+    /// default policy. Channels have their own exact-match identity and must
+    /// not pass through package-name normalization.
+    pub(crate) fn seed_default_channels(&self, channels: &[&str]) -> Result<()> {
+        let StoreInner::Sqlite { conn } = self.inner.as_ref() else {
+            return Ok(());
+        };
+
+        let approved_at = chrono::Utc::now().to_rfc3339();
+        let mut conn = conn
+            .lock()
+            .map_err(|_| anyhow::anyhow!("trusted package store mutex poisoned"))?;
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                r#"
+                INSERT INTO trusted_packages (ecosystem, normalized_name, approved_at, source)
+                VALUES (?1, ?2, ?3, ?4)
+                ON CONFLICT(ecosystem, normalized_name) DO NOTHING
+                "#,
+            )?;
+            for ecosystem in [ECOSYSTEM_CONDA_CHANNEL, ECOSYSTEM_PIXI_CHANNEL] {
+                for channel in channels {
+                    if let Some(source) = normalize_channel_source(channel) {
+                        stmt.execute(params![ecosystem, source, approved_at, "daemon-default"])?;
+                    }
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     fn approved_raw_specs(&self, ecosystem: &'static str, specs: &[String]) -> Result<Vec<String>> {
         let StoreInner::Sqlite { conn } = self.inner.as_ref() else {
             return Ok(vec![]);
@@ -643,6 +676,44 @@ mod tests {
             approved_pixi_channels: vec![],
         };
         assert!(!store.all_dependencies_approved(&pypi_only).unwrap());
+    }
+
+    #[test]
+    fn seed_default_channels_covers_conda_and_pixi_without_trusting_other_sources() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = TrustedPackageStore::open(tmp.path().join("trusted.sqlite")).unwrap();
+
+        store
+            .seed_default_channels(&[
+                "conda-forge",
+                "defaults",
+                "https://repo.anaconda.com/pkgs/main",
+            ])
+            .unwrap();
+
+        let info = runt_trust::TrustInfo {
+            status: runt_trust::TrustStatus::Untrusted,
+            uv_dependencies: vec![],
+            approved_uv_dependencies: vec![],
+            conda_dependencies: vec![],
+            approved_conda_dependencies: vec![],
+            conda_channels: vec![
+                "defaults".into(),
+                "https://repo.anaconda.com/pkgs/main".into(),
+            ],
+            approved_conda_channels: vec![],
+            pixi_dependencies: vec![],
+            approved_pixi_dependencies: vec![],
+            pixi_pypi_dependencies: vec![],
+            approved_pixi_pypi_dependencies: vec![],
+            pixi_channels: vec!["conda-forge".into()],
+            approved_pixi_channels: vec![],
+        };
+        assert!(store.all_dependencies_approved(&info).unwrap());
+
+        let mut untrusted = info;
+        untrusted.conda_channels = vec!["https://packages.example.test/conda".into()];
+        assert!(!store.all_dependencies_approved(&untrusted).unwrap());
     }
 
     #[test]

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1323,7 +1323,7 @@ async fn test_launch_kernel_environment_mode_controls_project_priority() {
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(
         project_dir.join("environment.yml"),
-        "name: runtimed-env-mode-missing\nchannels:\n  - defaults\ndependencies:\n  - python=3.11\n",
+        "name: runtimed-env-mode-missing\nchannels:\n  - https://packages.example.invalid/conda\ndependencies:\n  - python=3.11\n",
     )
     .unwrap();
     let notebook_path = project_dir.join("notebook.ipynb");

--- a/docs/adr/kernel-env-trust.md
+++ b/docs/adr/kernel-env-trust.md
@@ -168,10 +168,8 @@ Not every approval entry point runs all four steps. The four sources in the stor
 |---|---|---|---|
 | `ApproveTrust` (dialog) | yes | yes | `ON CONFLICT DO UPDATE` |
 | `seed_trust_from_doc_metadata` (MCP) | yes | yes (via subsequent notebook-doc frame) | `ON CONFLICT DO UPDATE` |
-| `seed_defaults` (startup) | yes, scoped to `pypi` and `conda` only (not channels) | no (no room exists at startup) | `ON CONFLICT DO NOTHING` so user approvals are preserved (`trusted_packages.rs:171`) |
-| `ApproveProjectEnvironment` (`environment.yml`) | yes | **no broadcast, no recheck** (`approve_project_environment.rs:38`) | `ON CONFLICT DO UPDATE` |
-
-`ApproveProjectEnvironment` not triggering a recheck means the user has to send a subsequent sync-driving action (cell edit, refresh) before the verdict updates. Worth flagging.
+| `seed_defaults` / `seed_default_channels` (startup) | yes, scoped to default package names and built-in public Conda sources | no (no room exists at startup) | `ON CONFLICT DO NOTHING` so user approvals are preserved (`trusted_packages.rs`) |
+| `ApproveProjectEnvironment` (`environment.yml`) | yes | yes | `ON CONFLICT DO UPDATE` |
 
 The notebook doc is not mutated. The allowlist is the source of truth; the doc only declares what is wanted. Two implications:
 
@@ -182,6 +180,7 @@ Three other approval entry points exist alongside the dialog:
 
 - `seed_trust_from_doc_metadata(room, source)` - the daemon seeds the allowlist when the caller is asserting that the deps already in the doc came from a consent-bearing channel. The MCP `create_notebook` tool uses this when the user has explicitly passed `dependencies` to the tool call: the act of typing those deps into the prompt is the consent. The same path is used by other paths that synthesize a notebook with known-good deps.
 - `seed_defaults(ecosystem, specs)` - the daemon pre-approves a user-configured default set on startup (`pandas`, `matplotlib`, etc., from synced settings). Source column reads `daemon-default`. This is what makes "open a fresh notebook, run a cell" silent for the user's curated default set.
+- `seed_default_channels(channels)` - the daemon pre-approves the built-in public channel policy for both Conda and Pixi: `conda-forge`, Conda's `defaults` alias, and the canonical `repo.anaconda.com/pkgs/{main,r,msys2}` URLs (with or without a trailing slash). Other named channels and URLs still require explicit approval.
 - `ApproveProjectEnvironment` - separate request for project-file consent (`crates/runtimed/src/requests/approve_project_environment.rs`). Records the *project file's* declared deps (today: only `environment.yml`) into the allowlist with source `project_env_dialog`. This is its own dialog because the deps in a project file are not in NotebookDoc; the regular trust dialog can't see them.
 
 ## Decision 6: Kernel launch consults the trust gate; sync_environment also gates


### PR DESCRIPTION
## Summary

- pre-approve Conda's public `defaults` alias and canonical Anaconda main-channel URLs for Conda and Pixi environments
- expand `defaults` through one shared Conda/Pixi resolver to the documented `repo.anaconda.com` repositories before rattler resolves repodata
- retain explicit approval for arbitrary named channels and third-party URLs
- document the built-in channel policy in the environment trust ADR

## Verification

- [x] `cargo xtask lint --fix`
- [x] `cargo test -p kernel-env` (97 unit tests plus launcher integration)
- [x] focused daemon trust-policy tests
- [x] `cargo test -p runtimed --test integration test_launch_kernel_environment_mode_controls_project_priority -- --exact`
- [x] isolated reruns of both timing-sensitive daemon tests encountered during broad runs
- [x] GitHub CI

Two broad local `runtimed` runs each passed 1,260 tests and encountered a different unrelated timing-sensitive failure. `shell_env_overlay::tests::capture_returns_at_least_path` and `notebook_sync_server::peer_runtime_agent::tests::runtime_agent_doc_change_is_rolled_back_until_journal_commit` both passed when rerun individually. The first GitHub run similarly hit an unrelated peer-session bootstrap flake that passed locally in isolation; its retry then exposed that the environment-mode fixture depended on `defaults` being untrusted. Commit `a412f90f4` gives that fixture an intentionally untrusted third-party channel, preserving its mode-priority scope under the new policy. The final GitHub run passed after rerunning an unrelated `local-file-permissions` browser test that had already passed on the previous head.

## External review

- Claude Opus 4.8 finding: Pixi trusted `defaults` without expanding it during installation — `confirmed-fix` in `300b0098f`
- Follow-up Claude Opus 4.8 review: clear (`review_complete`), no actionable findings
- Final Claude Opus 4.8 review after the CI fixture correction: clear (`review_complete`), no actionable findings
