### PR TITLE
fix(outputs): settle bounded Arrow head samples

### DIFF
--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -107,8 +107,14 @@ export interface ElementsNotebookOutputState {
   siftParquetRows: number;
   siftArrowStreamChunkUrl: string;
   siftArrowStreamManifest: {
-    chunks: { url: string }[];
+    chunks: { url: string; row_count: number }[];
     complete: boolean;
+    summary: {
+      total_rows: number;
+      included_rows: number;
+      sampled: boolean;
+      sample_strategy: string;
+    };
   };
 }
 
@@ -716,8 +722,14 @@ const siftParquetUrl =
 const siftParquetRows = 8;
 const siftArrowStreamChunkUrl = "/fixtures/sift-polars-utf8view.arrow";
 const siftArrowStreamManifest = {
-  chunks: [{ url: siftArrowStreamChunkUrl }],
+  chunks: [{ url: siftArrowStreamChunkUrl, row_count: 100 }],
   complete: true,
+  summary: {
+    total_rows: 100_000,
+    included_rows: 100,
+    sampled: true,
+    sample_strategy: "head",
+  },
 };
 
 const outputState: ElementsNotebookOutputState = {

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -1223,7 +1223,7 @@ export function OutputRenderersExample() {
               </div>
               <div className="mt-1 text-xs leading-5 text-fd-muted-foreground">
                 The manifest points at a docs-served Arrow IPC chunk and exercises SiftTable's
-                appendable WASM store without daemon blob resolution.
+                terminal head-sample state without daemon blob resolution.
               </div>
             </div>
           </div>

--- a/docs/adr/arrow-c-stream-output-protocol.md
+++ b/docs/adr/arrow-c-stream-output-protocol.md
@@ -117,22 +117,24 @@ Summary hints in manifests should be cheap and explicit:
 }
 ```
 
-The automatic repr path emits a bounded head rather than the whole table, so
-the manifest says so rather than pretending the table is complete:
-`complete: false`, `sampled: true`, `sample_strategy: "head"`, and a smaller
-`included_rows`. See `memos/arrow-bounded-head-and-progressive-fetch.md` for
-the size rule that picks the head.
+`complete` describes the manifest lifecycle: `false` means more chunk-manifest
+updates may arrive for the same display, and `true` means the current chunk list
+is final. Dataset coverage is separate. The automatic repr path emits a bounded
+head with `complete: true`, `sampled: true`, `sample_strategy: "head"`, and a
+smaller `included_rows`; it is a terminal sample, not an open stream. See
+`memos/arrow-bounded-head-and-progressive-fetch.md` for the size rule that picks
+the head.
 
-`total_rows` is exact only when `complete` is true. When `complete` is false it
-is a lower bound: a source that cannot report its length, such as an unbounded
-`RecordBatchReader`, yields a manifest whose `total_rows` equals
-`included_rows` even though more rows exist. Counting the true total would mean
+When the producer knows the source length, `total_rows` is exact even for a
+sample. A source that cannot report its length, such as an unbounded
+`RecordBatchReader`, yields a terminal sampled manifest whose `total_rows`
+equals `included_rows` as a lower bound. Counting the true total would mean
 draining the stream, which is the cost the bounded head exists to avoid.
 
-Consumers must therefore read `complete` before presenting `total_rows` as a
-total. Rendering "`included_rows` of `total_rows`" is correct for a complete
-manifest and misleading for an open one, where "`included_rows` loaded, more
-available" is the honest phrasing.
+Consumers use `complete` for loading state and `sampled` for dataset coverage.
+They should render "`included_rows` of `total_rows` shown" only when the known
+total exceeds the included count; a sampled manifest with equal counts should
+say that the shown row count is a head sample without claiming an exact total.
 
 ## Decision 6: Vendor MIME is the incubation boundary
 

--- a/docs/memos/arrow-bounded-head-and-progressive-fetch.md
+++ b/docs/memos/arrow-bounded-head-and-progressive-fetch.md
@@ -110,17 +110,17 @@ to the explicit `display_arrow_stream` helper.
 `_emit_arrow_stream` takes a total byte budget alongside the existing per-chunk
 size and stops draining the iterator when the budget is spent.
 
-The manifest states what it did. `_summary_hints` already computed the right
-shape, so the producer sets `complete: false`, `sampled: true`,
+The manifest states what it did. The producer sets `complete: true` because the
+one-shot manifest is final, alongside `sampled: true`,
 `sample_strategy: "head"`, and a truthful `total_rows` against a smaller
-`included_rows`. Consumers that already read `summary` needed no change.
+`included_rows`. Consumers use the summary to explain the cap separately from
+their manifest-loading state.
 
-`total_rows` is exact only when `complete` is true. A source that cannot report
-its length, such as an unbounded `RecordBatchReader`, produces a manifest whose
-`total_rows` equals `included_rows` while more rows exist. Learning the true
-total would mean draining the stream, which is the cost this work exists to
-avoid, so `total_rows` is defined as a lower bound whenever `complete` is
-false. Consumers read `complete` before presenting it as a total. Recorded in
+`complete` belongs to manifest lifecycle, while `sampled` describes dataset
+coverage. A source that cannot report its length, such as an unbounded
+`RecordBatchReader`, produces a terminal sampled manifest whose `total_rows`
+equals `included_rows` as a lower bound. Learning the true total would mean
+draining the stream, which is the cost this work exists to avoid. Recorded in
 `adr/arrow-c-stream-output-protocol.md`.
 
 The size rule is a clamp, not a plain budget. Measured row sizes span roughly
@@ -143,6 +143,10 @@ rows = clamp(byte_budget / bytes_per_row, MIN_ROWS, MAX_ROWS)
 With `MIN_ROWS = 100`, `byte_budget = 16 MiB`, and `MAX_ROWS = 50_000`, images
 clamp up to 100 rows and both text and skinny clamp down to 50,000.
 
+The Hugging Face `Dataset` adapter applies `MAX_ROWS` to the logical dataset
+slice before Arrow materialization. This preserves selected/shuffled row order
+without first asking `datasets` to materialize the entire logical dataset.
+
 `MIN_ROWS` makes the byte budget soft, so it needs a hard ceiling above it or a
 5 MB/row video dataset would send 500 MB to honor the floor. `_MAX_PAYLOAD_BYTES`
 is already declared at 90 MiB and currently unreachable; this is the job it was
@@ -152,9 +156,10 @@ written for. When the floor exceeds it, the slice shrinks below `MIN_ROWS`.
 element-height limits on million-row tables (`arrow-native-outputs.md`), so the
 renderer should not receive unbounded rows even when they are cheap.
 
-The renderer still needs to distinguish "still arriving" from "capped here" in
-the footer. `complete: false` flows to `setStreamingDone` either way, so that
-distinction is not yet surfaced to the reader. See open question 1.
+The renderer distinguishes "still arriving" from "capped here" using
+`complete`, and surfaces the independent sampling state from `summary` in the
+footer. A terminal capped head removes the streaming runner and says how many
+rows are shown.
 
 This trades a stability win for a capability regression: previously you
 eventually got all 3000 rows, and now you get the head with no path to more.
@@ -237,15 +242,11 @@ now" is the question to settle before the shape is fixed.
 
 ## Open Questions
 
-1. Whether `complete: false` alone is enough for the renderer to distinguish a
-   capped table from one still receiving chunks, or whether the summary needs an
-   explicit reason. This also governs how the footer should present an open
-   manifest, given that `total_rows` is only a lower bound there.
-2. The `nteract.dx.*` comm namespace predates the launcher owning this path.
+1. The `nteract.dx.*` comm namespace predates the launcher owning this path.
    New launcher config uses `NTERACT_ARROW_REPR_*`; whether the reserved comm
    namespace should follow is open, and renaming it carries a compatibility
    cost the new env vars did not.
-3. Step 3 retention, per above.
-4. Whether `MIN_ROWS`, `byte_budget`, and `MAX_ROWS` should be configurable per
+2. Step 3 retention, per above.
+3. Whether `MIN_ROWS`, `byte_budget`, and `MAX_ROWS` should be configurable per
    host. Hosted viewers pay real network cost for a budget that is nearly free
    on a desktop loopback blob server.

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -48,7 +48,15 @@ export {
 } from "./filter-schema";
 export type { SiftFocusStatusProps, SiftScrollHandoffCueProps } from "./handoff";
 export { SiftFocusStatus, SiftScrollHandoffCue } from "./handoff";
-export type { SiftTableHandle, SiftTableProps } from "./react";
+export type {
+  ArrowStreamManifest,
+  ArrowStreamManifestChunk,
+  ArrowStreamSummary,
+  SiftLoadMilestone,
+  SiftSource,
+  SiftTableHandle,
+  SiftTableProps,
+} from "./react";
 // React component
 export { SiftTable, useSiftEngine } from "./react";
 export type {

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -1126,7 +1126,14 @@
 .sift-footer-control {
   display: inline-flex;
   align-items: center;
+  gap: 8px;
   margin-right: 6px;
+}
+
+.sift-sample-hint {
+  color: var(--sift-muted);
+  font: 500 11px/1.2 var(--sift-font);
+  white-space: nowrap;
 }
 
 .sift-focus-hint {

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -282,6 +282,47 @@ describe("SiftTable", () => {
     vi.useFakeTimers();
   });
 
+  it("settles a terminal head sample and explains the display cap", async () => {
+    vi.useRealTimers();
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+      }),
+    );
+
+    const { container } = render(
+      <SiftTable
+        source={{
+          kind: "arrow-stream-manifest",
+          manifest: {
+            chunks: [{ url: "http://127.0.0.1:9000/blob/capped-head", row_count: 50_000 }],
+            complete: true,
+            summary: {
+              total_rows: 100_000,
+              included_rows: 50_000,
+              sampled: true,
+              sample_strategy: "head",
+            },
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(predicateModule.finish_arrow_stream_store).toHaveBeenCalledWith(9);
+      expect(container.querySelector(".sift-status-indicator")?.className).toContain(
+        "sift-status-ready",
+      );
+    });
+    expect(container.querySelector(".sift-progress-bar")?.className).toContain(
+      "sift-progress-bar-done",
+    );
+    expect(container.querySelector(".sift-sample-hint")?.textContent).toBe(
+      "50,000 of 100,000 rows shown · head sample",
+    );
+  });
+
   it("fetches trailing Arrow stream chunks sequentially after each append", async () => {
     vi.useRealTimers();
     const fetchResolvers: ((response: {

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -44,9 +44,17 @@ export type ArrowStreamManifestChunk = {
   row_count?: number;
 };
 
+export type ArrowStreamSummary = {
+  total_rows?: number;
+  included_rows?: number;
+  sampled?: boolean;
+  sample_strategy?: string;
+};
+
 export type ArrowStreamManifest = {
   chunks: ArrowStreamManifestChunk[];
   complete?: boolean;
+  summary?: ArrowStreamSummary;
 };
 
 export type SiftSource =
@@ -116,6 +124,17 @@ function arrowStreamManifestKey(manifest: ArrowStreamManifest | undefined): stri
 function arrowStreamIdentityKey(manifest: ArrowStreamManifest): string | null {
   const first = manifest.chunks[0];
   return first ? `${first.url}\u0001${first.row_count ?? ""}` : null;
+}
+
+function arrowStreamSampleLabel(manifest: ArrowStreamManifest | undefined): string | null {
+  if (manifest?.complete === false || manifest?.summary?.sampled !== true) return null;
+  const included = manifest.summary.included_rows;
+  const total = manifest.summary.total_rows;
+  if (typeof included !== "number" || !Number.isFinite(included)) return "Head sample";
+  if (typeof total === "number" && Number.isFinite(total) && total > included) {
+    return `${included.toLocaleString()} of ${total.toLocaleString()} rows shown · head sample`;
+  }
+  return `${included.toLocaleString()} rows shown · head sample`;
 }
 
 /**
@@ -325,6 +344,10 @@ export function SiftTable({
   className,
   style,
 }: SiftTableProps) {
+  const dataSource = source?.kind === "table-data" ? source.data : data;
+  const urlSource = source?.kind === "url" ? source.url : url;
+  const manifestSource = source?.kind === "arrow-stream-manifest" ? source.manifest : undefined;
+  const sampleLabel = arrowStreamSampleLabel(manifestSource);
   const containerRef = useRef<HTMLDivElement>(null);
   const engineRef = useRef<TableEngine | null>(null);
   const engineDivRef = useRef<HTMLDivElement | null>(null);
@@ -334,7 +357,7 @@ export function SiftTable({
   const footerControlRootRef = useRef<Root | null>(null);
   const [status, setStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
-  const hasFooterControl = footerControl != null;
+  const hasFooterControl = footerControl != null || manifestSource != null;
 
   // Stable callback ref to avoid re-mounting engine when onChange identity changes
   const onChangeRef = useRef(onChange);
@@ -381,8 +404,20 @@ export function SiftTable({
     if (hasFooterControl) {
       getFooterControlElement();
     }
-    footerControlRootRef.current?.render(footerControl);
-  }, [footerControl, getFooterControlElement, hasFooterControl]);
+    footerControlRootRef.current?.render(
+      <>
+        {sampleLabel && (
+          <span
+            className="sift-sample-hint"
+            title="The automatic table display is capped for safety."
+          >
+            {sampleLabel}
+          </span>
+        )}
+        {footerControl}
+      </>,
+    );
+  }, [footerControl, getFooterControlElement, hasFooterControl, sampleLabel]);
 
   useEffect(() => {
     return () => {
@@ -400,9 +435,6 @@ export function SiftTable({
     };
   }, []);
 
-  const dataSource = source?.kind === "table-data" ? source.data : data;
-  const urlSource = source?.kind === "url" ? source.url : url;
-  const manifestSource = source?.kind === "arrow-stream-manifest" ? source.manifest : undefined;
   const manifestKey = arrowStreamManifestKey(manifestSource);
 
   // Mount engine when `data` prop is provided directly

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -228,7 +228,7 @@ def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
             return None
 
     try:
-        table = ds.with_format("arrow")[:]
+        table = ds.with_format("arrow")[:_ARROW_REPR_MAX_ROWS]
     except Exception as exc:  # noqa: BLE001
         log.debug("dataset logical Arrow materialization failed: %s", exc)
         try:
@@ -306,7 +306,9 @@ def _emit_arrow_stream(
     included_rows = sum(chunk.row_count for chunk in chunks)
     if total_rows is None:
         total_rows = included_rows
-    complete = stream_complete and included_rows == total_rows
+    sampled = not stream_complete or included_rows != total_rows
+    # Automatic reprs publish exactly one manifest. The chunk list is therefore
+    # final even when it intentionally represents only a bounded head.
 
     def _summary(included: int, sampled: bool) -> str:
         if summary_fn is not None:
@@ -330,14 +332,16 @@ def _emit_arrow_stream(
             included_rows=included_rows,
             record_batch_count=chunk.record_batch_count,
             summary_fn=_summary,
-            complete=complete,
+            complete=True,
+            sampled=sampled,
         )
 
     return _emit_arrow_stream_chunks(
         chunks,
         total_rows=total_rows,
         summary_fn=_summary,
-        complete=complete,
+        complete=True,
+        sampled=sampled,
     )
 
 
@@ -347,6 +351,7 @@ def _emit_arrow_stream_chunks(
     total_rows: int,
     summary_fn: Callable[[int, bool], str],
     complete: bool,
+    sampled: bool | None = None,
 ) -> dict:
     """Emit a multi-chunk Arrow stream manifest."""
     if not chunks:
@@ -356,6 +361,7 @@ def _emit_arrow_stream_chunks(
         total_rows=total_rows,
         included_rows=included_rows,
         complete=complete,
+        sampled=sampled,
     )
     sampled = summary_hints["sampled"]
     llm_text: str | None = None
@@ -469,6 +475,7 @@ def _emit_table_bytes(
     record_batch_count: int | None = None,
     summary_fn: Callable[[int, bool], str],
     complete: bool | None = None,
+    sampled: bool | None = None,
 ) -> dict:
     """Stash bytes, build the ref bundle, attach a summary.
 
@@ -481,6 +488,7 @@ def _emit_table_bytes(
         total_rows=total_rows,
         included_rows=included_rows,
         complete=complete,
+        sampled=sampled,
     )
     sampled = summary_hints["sampled"]
     llm_text: str | None = None

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -71,13 +71,15 @@ def build_arrow_stream_summary(
     total_rows: int | None,
     included_rows: int,
     complete: bool,
+    sampled: bool | None = None,
 ) -> dict[str, Any]:
-    """Build the shared row-summary fields for an Arrow stream manifest."""
-    sampled = total_rows is not None and included_rows != total_rows
+    """Build row-summary fields, with an explicit sampling override when known."""
+    if sampled is None:
+        sampled = (total_rows is not None and included_rows != total_rows) or not complete
     return {
         "total_rows": total_rows if total_rows is not None else included_rows,
         "included_rows": included_rows,
-        "sampled": sampled or not complete,
+        "sampled": sampled,
         "sample_strategy": "none" if complete and not sampled else "head",
     }
 

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -881,7 +881,7 @@ def test_large_arrow_table_emits_bounded_head_with_honest_manifest(monkeypatch):
 
     assert bundle is not None
     manifest = bundle[ARROW_STREAM_MANIFEST_MIME]
-    assert manifest["complete"] is False
+    assert manifest["complete"] is True
     assert manifest["summary"] == {
         "total_rows": 20,
         "included_rows": 2,
@@ -980,6 +980,35 @@ def test_unmeasurable_table_degrades_instead_of_raising(monkeypatch):
 
     bundle = _bootstrap._arrow_stream_mimebundle(table)
     assert bundle is not None
+    manifest = bundle[_format.ARROW_STREAM_MANIFEST_MIME]
+    assert manifest["complete"] is True
+    assert manifest["summary"]["sampled"] is False
+
+
+def test_bounded_unknown_length_stream_is_final_but_sampled(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+
+    table = pa.table({"value": list(range(20))})
+    monkeypatch.setattr(_bootstrap, "arrow_stream_row_count", lambda source: None)
+    monkeypatch.setattr(_bootstrap, "_bounded_arrow_table", lambda source, **limits: None)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MIN_ROWS", 2)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_BYTE_BUDGET", 1_000_000)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 5)
+
+    bundle = _bootstrap._arrow_stream_mimebundle(table)
+
+    assert bundle is not None
+    manifest = bundle[ARROW_STREAM_MANIFEST_MIME]
+    assert manifest["complete"] is True
+    assert manifest["summary"] == {
+        "total_rows": 5,
+        "included_rows": 5,
+        "sampled": True,
+        "sample_strategy": "head",
+    }
 
 
 def test_skinny_arrow_rows_clamp_down_to_max_rows(monkeypatch):
@@ -1180,6 +1209,42 @@ def test_dataset_mimebundle_applies_logical_indices_mapping():
         "included_rows": 3,
         "sampled": False,
         "sample_strategy": "none",
+    }
+
+
+def test_dataset_mimebundle_caps_rows_before_logical_arrow_materialization(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+
+    requested = []
+
+    class FakeDataset:
+        num_rows = 1_000_000
+        data = SimpleNamespace(table=object())
+
+        def with_format(self, format_name):
+            assert format_name == "arrow"
+            return self
+
+        def __getitem__(self, key):
+            requested.append(key)
+            return pa.table({"value": list(range(key.stop))})
+
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 5)
+    monkeypatch.setattr(_bootstrap, "summarize_dataset", lambda dataset: "dataset summary")
+
+    bundle = _bootstrap._dataset_mimebundle(FakeDataset())
+
+    assert bundle is not None
+    assert requested == [slice(None, 5, None)]
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["complete"] is True
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"] == {
+        "total_rows": 1_000_000,
+        "included_rows": 5,
+        "sampled": True,
+        "sample_strategy": "head",
     }
 
 

--- a/src/isolated-renderer/__tests__/sift-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/sift-renderer.test.tsx
@@ -15,7 +15,9 @@ const siftMocks = vi.hoisted(() => ({
 vi.mock("@nteract/sift", () => ({
   setWasmUrl: siftMocks.setWasmUrl,
   SiftFocusStatus: () => null,
-  SiftTable: () => <div data-testid="sift-table" />,
+  SiftTable: ({ source }: { source: unknown }) => (
+    <div data-testid="sift-table" data-source={JSON.stringify(source)} />
+  ),
 }));
 
 describe("Sift renderer plugin", () => {
@@ -167,5 +169,47 @@ describe("Sift renderer plugin", () => {
     } finally {
       HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
     }
+  });
+
+  it("passes capped-sample summary metadata through to Sift", () => {
+    let Renderer: ComponentType<RendererProps> | undefined;
+    install({
+      register: (_mimeTypes, component) => {
+        Renderer = component;
+      },
+      registerPattern: vi.fn(),
+      getHostContext: () => undefined,
+      subscribeHostContext: () => () => undefined,
+    });
+
+    expect(Renderer).toBeDefined();
+    render(
+      <Renderer
+        data={{
+          chunks: [{ url: "https://notebooks.example/blobs/capped-head", row_count: 50_000 }],
+          complete: true,
+          summary: {
+            total_rows: 100_000,
+            included_rows: 50_000,
+            sampled: true,
+            sample_strategy: "head",
+          },
+        }}
+        mimeType="application/vnd.nteract.arrow-stream-manifest+json"
+      />,
+    );
+
+    expect(JSON.parse(screen.getByTestId("sift-table").dataset.source ?? "null")).toMatchObject({
+      kind: "arrow-stream-manifest",
+      manifest: {
+        complete: true,
+        summary: {
+          total_rows: 100_000,
+          included_rows: 50_000,
+          sampled: true,
+          sample_strategy: "head",
+        },
+      },
+    });
   });
 });

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -46,6 +46,8 @@ interface RendererArrowStreamManifestChunk {
 
 interface RendererArrowStreamManifest {
   chunks?: unknown;
+  complete?: unknown;
+  summary?: unknown;
 }
 
 // --- WASM configuration ---
@@ -210,9 +212,21 @@ function tableManifestForData(data: unknown): ArrowStreamManifest | undefined {
     });
   }
   if (chunks.length === 0) return undefined;
+  const rawSummary = isRecord(manifest.summary) ? manifest.summary : undefined;
+  const summary = rawSummary
+    ? {
+        total_rows: typeof rawSummary.total_rows === "number" ? rawSummary.total_rows : undefined,
+        included_rows:
+          typeof rawSummary.included_rows === "number" ? rawSummary.included_rows : undefined,
+        sampled: typeof rawSummary.sampled === "boolean" ? rawSummary.sampled : undefined,
+        sample_strategy:
+          typeof rawSummary.sample_strategy === "string" ? rawSummary.sample_strategy : undefined,
+      }
+    : undefined;
   return {
     chunks,
-    complete: typeof data.complete === "boolean" ? data.complete : undefined,
+    complete: typeof manifest.complete === "boolean" ? manifest.complete : undefined,
+    summary,
   };
 }
 


### PR DESCRIPTION
## Summary

- treat a one-shot capped Arrow repr as a terminal manifest while retaining explicit head-sample metadata
- show the sampled row coverage in Sift's footer instead of leaving its streaming runner active
- cap Hugging Face Dataset logical slicing before Arrow materialization, preserving shuffled/selected order without requesting the whole dataset
- pass the completion and sampling metadata through the isolated renderer and document the lifecycle distinction

## Verification

- `cargo xtask lint --fix`
- launcher test suite: 121 passed, 4 skipped
- focused launcher/progressive tests: 50 passed
- Sift test suite: 194 passed
- frontend test suite: 2,841 passed, 6 skipped
- `pnpm --filter @nteract/sift build`
- `pnpm --filter @nteract/sift build:lib`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- Elements visual QA of the terminal head-sample state
