### PR TITLE
fix(mcp): negotiate MCP Apps through proxies

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -36,7 +36,7 @@ use rmcp::model::{
 use rmcp::schemars;
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler, ServiceExt};
-use runt_mcp_proxy::{McpProxy, ProxyConfig};
+use runt_mcp_proxy::{mcp_apps_extension_capabilities, McpProxy, ProxyConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::{mpsc, Notify, RwLock};
@@ -1861,6 +1861,7 @@ impl ServerHandler for Supervisor {
                 .enable_tool_list_changed()
                 .enable_resources()
                 .enable_resources_list_changed()
+                .enable_extensions_with(mcp_apps_extension_capabilities())
                 .build(),
         )
         .with_server_info(Implementation::new(
@@ -3275,6 +3276,18 @@ mod tests {
 
     fn root() -> PathBuf {
         PathBuf::from("/repo")
+    }
+
+    #[test]
+    fn supervisor_server_info_advertises_mcp_apps_extension() {
+        let (tool_list_changed_tx, _tool_list_changed_rx) = mpsc::channel(1);
+        let supervisor =
+            Supervisor::new_empty(root(), DevMode::Attach, root(), None, tool_list_changed_tx);
+        let info = supervisor.get_info();
+
+        assert!(info.capabilities.extensions.as_ref().is_some_and(
+            |extensions| extensions.contains_key(runt_mcp_proxy::MCP_APPS_EXTENSION_ID)
+        ));
     }
 
     // Path-classification: maps a touched file under the project root to

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -18,3 +18,17 @@ pub mod tools;
 pub mod version;
 
 pub use proxy::{McpProxy, ProxyConfig};
+
+/// MCP Apps extension identifier negotiated during the MCP initialize handshake.
+pub const MCP_APPS_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
+
+/// Capabilities shared by every client-facing nteract MCP proxy.
+///
+/// The proxy handles MCP App resources itself, so it must advertise this
+/// capability rather than relying on the lazily-started child server's
+/// initialize response, which is not visible to the upstream client.
+pub fn mcp_apps_extension_capabilities() -> rmcp::model::ExtensionCapabilities {
+    let mut extensions = rmcp::model::ExtensionCapabilities::new();
+    extensions.insert(MCP_APPS_EXTENSION_ID.to_string(), serde_json::Map::new());
+    extensions
+}

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -938,6 +938,7 @@ impl ServerHandler for McpProxy {
                 .enable_tool_list_changed()
                 .enable_resources()
                 .enable_resources_list_changed()
+                .enable_extensions_with(crate::mcp_apps_extension_capabilities())
                 .build(),
         )
         .with_server_info(Implementation::new(
@@ -1146,6 +1147,24 @@ mod tests {
     }
 
     // ── Proxy creation ────────────────────────────────────────────────
+
+    #[test]
+    fn proxy_server_info_advertises_mcp_apps_extension() {
+        let proxy = McpProxy::new(test_config(), None);
+        let info = proxy.get_info();
+
+        assert!(info
+            .capabilities
+            .extensions
+            .as_ref()
+            .is_some_and(|extensions| extensions.contains_key(crate::MCP_APPS_EXTENSION_ID)));
+
+        let wire = serde_json::to_value(info).expect("serialize server info");
+        assert_eq!(
+            wire.pointer("/capabilities/extensions/io.modelcontextprotocol~1ui"),
+            Some(&serde_json::json!({}))
+        );
+    }
 
     #[tokio::test]
     async fn proxy_starts_with_no_child() {

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -669,6 +669,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_output_resource_serializes_standard_mcp_apps_csp() {
+        let server = NteractMcp::new(
+            PathBuf::from("/tmp/missing.sock"),
+            Some("http://localhost:47820".into()),
+            None,
+        );
+
+        let result = read_resource(
+            &server,
+            &ReadResourceRequestParams::new(OUTPUT_RESOURCE_URI),
+        )
+        .await
+        .expect("read output resource");
+        let wire = serde_json::to_value(result).expect("serialize resource result");
+        let content = wire
+            .pointer("/contents/0")
+            .expect("serialized output resource content");
+
+        assert_eq!(
+            content.get("uri"),
+            Some(&serde_json::json!(OUTPUT_RESOURCE_URI))
+        );
+        assert_eq!(
+            content.get("mimeType"),
+            Some(&serde_json::json!(OUTPUT_MIME_TYPE))
+        );
+        assert_eq!(
+            content.pointer("/_meta/ui/csp"),
+            Some(&serde_json::json!({
+                "connectDomains": ["http://localhost:47820"],
+                "resourceDomains": ["http://localhost:47820"],
+                "frameDomains": ["http://localhost:47820"]
+            }))
+        );
+        assert!(content
+            .get("_meta")
+            .and_then(|meta| meta.get("openai/widgetCSP"))
+            .is_none());
+    }
+
+    #[tokio::test]
     async fn list_resources_includes_notebook_collection_resource() {
         let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None);
 


### PR DESCRIPTION
## Summary

- advertise the standard `io.modelcontextprotocol/ui` extension from the packaged MCP proxy
- advertise the same capability from the `nteract-dev` supervisor
- verify the serialized initialize response and host-visible `resources/read` CSP metadata

## Root cause

The inner `runt mcp` server advertised MCP Apps support, but the client-facing proxy performed its own initialize handshake without forwarding or declaring that extension. MCP Apps is opt-in and requires both sides to declare support, so hosts could fall back to compatibility behavior even though `ui://nteract/output.html` already used the standard MCP Apps resource contract.

## CSP audit

The existing resource metadata is already standards-shaped and remains unchanged:

- `connectDomains` permits blob, manifest, renderer asset, and WASM fetches
- `resourceDomains` permits directly loaded images and other static assets
- `frameDomains` permits the daemon-hosted `/output-frame` document

All four daemon routes (`/blob/*`, `/renderer-plugins/*`, `/plugins/*`, and `/output-frame`) share the exact `http://localhost:<daemon-port>` origin, so they do not require separate path entries. The app does not use a custom base URI, browser permissions, or redirect allowlists, so `baseUriDomains`, `permissions`, and the legacy `openai/widgetCSP` key are intentionally omitted.

## Verification

- `cargo test -p runt-mcp-proxy -p mcp-supervisor -p runt-mcp` (342 passed)
- `cargo clippy -p runt-mcp -p runt-mcp-proxy -p mcp-supervisor --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- built `nteract-mcp` and verified its stdio initialize response contains `capabilities.extensions["io.modelcontextprotocol/ui"]`