### PR TITLE
fix(outputs): make bounded table previews explicit

### DIFF
--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -1223,7 +1223,7 @@ export function OutputRenderersExample() {
               </div>
               <div className="mt-1 text-xs leading-5 text-fd-muted-foreground">
                 The manifest points at a docs-served Arrow IPC chunk and exercises SiftTable's
-                terminal head-sample state without daemon blob resolution.
+                terminal bounded-preview state without daemon blob resolution.
               </div>
             </div>
           </div>

--- a/docs/adr/arrow-c-stream-output-protocol.md
+++ b/docs/adr/arrow-c-stream-output-protocol.md
@@ -134,7 +134,10 @@ draining the stream, which is the cost the bounded head exists to avoid.
 Consumers use `complete` for loading state and `sampled` for dataset coverage.
 They should render "`included_rows` of `total_rows` shown" only when the known
 total exceeds the included count; a sampled manifest with equal counts should
-say that the shown row count is a head sample without claiming an exact total.
+say that it is showing the first `included_rows` with an unknown total. Product
+copy says "first rows" rather than "sample" because a deterministic head is not
+statistically representative. Sorts, filters, and summaries computed by the
+renderer must be scoped to the shown rows in the same surface.
 
 ## Decision 6: Vendor MIME is the incubation boundary
 

--- a/docs/memos/arrow-bounded-head-and-progressive-fetch.md
+++ b/docs/memos/arrow-bounded-head-and-progressive-fetch.md
@@ -144,11 +144,11 @@ With `MIN_ROWS = 100`, `byte_budget = 16 MiB`, and `MAX_ROWS = 50_000`, images
 clamp up to 100 rows and both text and skinny clamp down to 50,000.
 
 The Hugging Face `Dataset` adapter reads a small logical Arrow probe, estimates
-a byte-safe head, and only then requests the selected logical slice. This
-preserves selected/shuffled row order without first asking `datasets` to
-materialize `MAX_ROWS` blindly. The final Arrow serializer remeasures the
-result, so the probe is an early materialization bound rather than a replacement
-for the existing payload ceilings.
+the head, then widens the logical prefix geometrically and remeasures before
+each next step. This preserves selected/shuffled row order without leaping from
+eight rows straight to `MAX_ROWS` on one optimistic estimate. The final Arrow
+serializer remeasures the result, so iterative probing reduces intermediate
+materialization risk rather than replacing the existing payload ceilings.
 
 `MIN_ROWS` makes the byte budget soft, so it needs a hard ceiling above it or a
 5 MB/row video dataset would send 500 MB to honor the floor. `_MAX_PAYLOAD_BYTES`

--- a/docs/memos/arrow-bounded-head-and-progressive-fetch.md
+++ b/docs/memos/arrow-bounded-head-and-progressive-fetch.md
@@ -143,9 +143,12 @@ rows = clamp(byte_budget / bytes_per_row, MIN_ROWS, MAX_ROWS)
 With `MIN_ROWS = 100`, `byte_budget = 16 MiB`, and `MAX_ROWS = 50_000`, images
 clamp up to 100 rows and both text and skinny clamp down to 50,000.
 
-The Hugging Face `Dataset` adapter applies `MAX_ROWS` to the logical dataset
-slice before Arrow materialization. This preserves selected/shuffled row order
-without first asking `datasets` to materialize the entire logical dataset.
+The Hugging Face `Dataset` adapter reads a small logical Arrow probe, estimates
+a byte-safe head, and only then requests the selected logical slice. This
+preserves selected/shuffled row order without first asking `datasets` to
+materialize `MAX_ROWS` blindly. The final Arrow serializer remeasures the
+result, so the probe is an early materialization bound rather than a replacement
+for the existing payload ceilings.
 
 `MIN_ROWS` makes the byte budget soft, so it needs a hard ceiling above it or a
 5 MB/row video dataset would send 500 MB to honor the floor. `_MAX_PAYLOAD_BYTES`
@@ -158,8 +161,10 @@ renderer should not receive unbounded rows even when they are cheap.
 
 The renderer distinguishes "still arriving" from "capped here" using
 `complete`, and surfaces the independent sampling state from `summary` in the
-footer. A terminal capped head removes the streaming runner and says how many
-rows are shown.
+footer. A terminal capped head removes the streaming runner and says "Showing
+first …" with either a known total or "total unknown." It does not call the
+rows a sample, because a head preserves source order and is not statistically
+representative. The footer also states that table tools operate on shown rows.
 
 This trades a stability win for a capability regression: previously you
 eventually got all 3000 rows, and now you get the head with no path to more.
@@ -199,14 +204,17 @@ and fixed: a store surviving a source switch and being appended to after
 update recovered the stream, and column overrides silently dropped when they
 changed alongside manifest growth.
 
-With steps 1 and 2 in place, the producer can raise the initial budget and push
-follow-on chunks after first paint, which is the behavior
-`arrow-native-outputs.md` specified.
+Step 2 remains useful for the explicit `display_arrow_stream` helper and for a
+future source-backed continuation path. Automatic reprs do not use it to push
+the rest of a dataframe after first paint: that would defer the original
+unbounded materialization instead of preventing it.
 
-### Step 3: Demand-driven fetch
+### Step 3: Explicit continuation and predicate-aware fetch
 
-Not implemented. The shape is understood but the retention policy is not
-settled.
+Not implemented. Append-only manifests provide the renderer mechanism, but a
+product-safe continuation requires a session capability for the live source.
+The durable output remains the bounded preview; the capability is optional and
+expires with the kernel/output session.
 
 The transport question is answered by existing precedent. `NteractKernel`
 already extends `msg_types` with `nteract_bokeh_patch_request` and friends
@@ -227,15 +235,34 @@ No user-facing pin API is implied by that model.
 The genuine tension is that a pull handle is session-scoped while the manifest
 is content-addressed and durable by design. A saved notebook carries chunk
 hashes that outlive the kernel, so a reopened notebook has to degrade to the
-materialized head rather than appear broken. Whether the manifest should
-distinguish "this is all there is" from "this is all that is reachable right
-now" is the question to settle before the shape is fixed.
+materialized head rather than appear broken.
+
+There are two materially different continuation levels:
+
+1. **Bounded range continuation.** An explicit action requests the next
+   byte-bounded logical range and appends it. Existing sorts, filters, and
+   summaries still describe loaded rows only. This is useful but is not
+   predicate pushdown.
+2. **Predicate-aware exploration.** Sift sends a typed filter/sort projection
+   to the source handle; the kernel evaluates it against a stable source
+   snapshot and returns a bounded result window plus whatever total it can
+   compute cheaply. A predicate change may first narrow the loaded rows locally,
+   then request enough matching rows to refill the viewport. Scanning a large
+   source must remain cancellable and must not silently materialize all matches.
+
+The second level needs an adapter contract rather than JavaScript predicates:
+Arrow compute can cover a common subset, while pandas, Polars, Hugging Face
+Datasets, lazy frames, and single-pass readers differ in pushdown and replay
+capabilities. Until that contract exists, table tools remain explicitly scoped
+to shown rows.
 
 ## Consequences
 
 - Large automatic reprs no longer transfer unbounded bytes.
 - The `sampled` and `complete` fields carry real information.
 - `_MAX_PAYLOAD_BYTES` is load-bearing instead of dead.
+- Automatic dataframe output is a terminal, durable preview; it never starts an
+  unbounded background continuation.
 - Progressive display is now available to bare last-expression reprs, since
   `NteractShellDisplayHook` can stamp a `display_id` on the formatter's behalf.
   Nothing wires that up yet.
@@ -246,7 +273,8 @@ now" is the question to settle before the shape is fixed.
    New launcher config uses `NTERACT_ARROW_REPR_*`; whether the reserved comm
    namespace should follow is open, and renaming it carries a compatibility
    cost the new env vars did not.
-2. Step 3 retention, per above.
+2. Step 3 handle retention, predicate vocabulary, adapter capabilities, and
+   cancellation, per above.
 3. Whether `MIN_ROWS`, `byte_budget`, and `MAX_ROWS` should be configurable per
    host. Hosted viewers pay real network cost for a budget that is nearly free
    on a desktop loopback blob server.

--- a/docs/memos/arrow-bounded-head-and-progressive-fetch.md
+++ b/docs/memos/arrow-bounded-head-and-progressive-fetch.md
@@ -148,7 +148,10 @@ the head, then widens the logical prefix geometrically and remeasures before
 each next step. This preserves selected/shuffled row order without leaping from
 eight rows straight to `MAX_ROWS` on one optimistic estimate. The final Arrow
 serializer remeasures the result, so iterative probing reduces intermediate
-materialization risk rather than replacing the existing payload ceilings.
+materialization risk rather than replacing the existing payload ceilings. The
+growth limit is row-based: sharply non-stationary row weights can still
+overshoot the byte budget within one step, and repeated prefixes can request up
+to about 2.15 times the rows in the final prefix.
 
 `MIN_ROWS` makes the byte budget soft, so it needs a hard ceiling above it or a
 5 MB/row video dataset would send 500 MB to honor the floor. `_MAX_PAYLOAD_BYTES`

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -1125,12 +1125,17 @@
 
 .sift-footer-control {
   display: inline-flex;
+  flex: 0 1 auto;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+  max-width: 100%;
   margin-right: 6px;
 }
 
 .sift-preview-hint {
+  display: inline-block;
+  flex: 0 1 auto;
   min-width: 0;
   max-width: min(620px, 62vw);
   overflow: hidden;

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -1130,10 +1130,20 @@
   margin-right: 6px;
 }
 
-.sift-sample-hint {
+.sift-preview-hint {
+  min-width: 0;
+  max-width: min(620px, 62vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: var(--sift-muted);
   font: 500 11px/1.2 var(--sift-font);
   white-space: nowrap;
+}
+
+@media (max-width: 700px) {
+  .sift-preview-scope {
+    display: none;
+  }
 }
 
 .sift-focus-hint {

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -1123,7 +1123,7 @@
   display: inline;
 }
 
-.sift-footer-control {
+.sift-footer-slot {
   display: inline-flex;
   flex: 0 1 auto;
   align-items: center;
@@ -1131,6 +1131,12 @@
   min-width: 0;
   max-width: 100%;
   margin-right: 6px;
+}
+
+.sift-footer-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .sift-preview-hint {

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -282,7 +282,7 @@ describe("SiftTable", () => {
     vi.useFakeTimers();
   });
 
-  it("settles a terminal head sample and explains the display cap", async () => {
+  it("settles a bounded first-row preview and explains its table-tool scope", async () => {
     vi.useRealTimers();
     vi.stubGlobal("fetch", () =>
       Promise.resolve({
@@ -318,8 +318,52 @@ describe("SiftTable", () => {
     expect(container.querySelector(".sift-progress-bar")?.className).toContain(
       "sift-progress-bar-done",
     );
-    expect(container.querySelector(".sift-sample-hint")?.textContent).toBe(
-      "50,000 of 100,000 rows shown · head sample",
+    expect(container.querySelector(".sift-status-indicator")?.getAttribute("title")).toBe(
+      "Preview loaded",
+    );
+    const previewHint = container.querySelector(".sift-preview-hint");
+    expect(previewHint?.textContent).toBe(
+      "Showing first 50,000 of 100,000 rows · Table tools use shown rows",
+    );
+    expect(previewHint?.getAttribute("title")).toBe(
+      "Sorting, filtering, and column summaries use only the rows shown in this preview.",
+    );
+  });
+
+  it("does not invent a total for a bounded preview whose source length is unknown", async () => {
+    vi.useRealTimers();
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+      }),
+    );
+
+    const { container } = render(
+      <SiftTable
+        source={{
+          kind: "arrow-stream-manifest",
+          manifest: {
+            chunks: [{ url: "http://127.0.0.1:9000/blob/unknown-total", row_count: 50_000 }],
+            complete: true,
+            summary: {
+              total_rows: 50_000,
+              included_rows: 50_000,
+              sampled: true,
+              sample_strategy: "head",
+            },
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".sift-status-indicator")?.className).toContain(
+        "sift-status-ready",
+      );
+    });
+    expect(container.querySelector(".sift-preview-hint")?.textContent).toBe(
+      "Showing first 50,000 rows · total unknown · Table tools use shown rows",
     );
   });
 

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -318,10 +318,12 @@ describe("SiftTable", () => {
     expect(container.querySelector(".sift-progress-bar")?.className).toContain(
       "sift-progress-bar-done",
     );
+    expect(container.querySelector(".sift-footer-control")).not.toBeNull();
     expect(container.querySelector(".sift-status-indicator")?.getAttribute("title")).toBe(
       "Preview loaded",
     );
     const previewHint = container.querySelector(".sift-preview-hint");
+    expect(previewHint?.getAttribute("role")).toBe("note");
     expect(previewHint?.textContent).toBe(
       "Showing first 50,000 of 100,000 rows · Table tools use shown rows",
     );

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -318,7 +318,7 @@ describe("SiftTable", () => {
     expect(container.querySelector(".sift-progress-bar")?.className).toContain(
       "sift-progress-bar-done",
     );
-    expect(container.querySelector(".sift-footer-control")).not.toBeNull();
+    expect(container.querySelector(".sift-footer-slot")).not.toBeNull();
     expect(container.querySelector(".sift-status-indicator")?.getAttribute("title")).toBe(
       "Preview loaded",
     );

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -16,7 +16,7 @@
  * cleaning up on unmount.
  */
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
   applyColumnOverrides,
@@ -126,15 +126,36 @@ function arrowStreamIdentityKey(manifest: ArrowStreamManifest): string | null {
   return first ? `${first.url}\u0001${first.row_count ?? ""}` : null;
 }
 
-function arrowStreamSampleLabel(manifest: ArrowStreamManifest | undefined): string | null {
+type ArrowStreamPreviewNotice = {
+  label: string;
+  title: string;
+};
+
+function arrowStreamPreviewNotice(
+  manifest: ArrowStreamManifest | undefined,
+): ArrowStreamPreviewNotice | null {
   if (manifest?.complete === false || manifest?.summary?.sampled !== true) return null;
   const included = manifest.summary.included_rows;
   const total = manifest.summary.total_rows;
-  if (typeof included !== "number" || !Number.isFinite(included)) return "Head sample";
-  if (typeof total === "number" && Number.isFinite(total) && total > included) {
-    return `${included.toLocaleString()} of ${total.toLocaleString()} rows shown · head sample`;
+  const isHead = manifest.summary.sample_strategy === "head";
+  let label = "Showing a bounded preview";
+  if (typeof included === "number" && Number.isFinite(included)) {
+    const shown = included.toLocaleString();
+    if (typeof total === "number" && Number.isFinite(total) && total > included) {
+      label = isHead
+        ? `Showing first ${shown} of ${total.toLocaleString()} rows`
+        : `Showing ${shown} of ${total.toLocaleString()} rows`;
+    } else {
+      label = isHead
+        ? `Showing first ${shown} rows · total unknown`
+        : `Showing ${shown} rows · total unknown`;
+    }
   }
-  return `${included.toLocaleString()} rows shown · head sample`;
+
+  return {
+    label,
+    title: "Sorting, filtering, and column summaries use only the rows shown in this preview.",
+  };
 }
 
 /**
@@ -347,7 +368,8 @@ export function SiftTable({
   const dataSource = source?.kind === "table-data" ? source.data : data;
   const urlSource = source?.kind === "url" ? source.url : url;
   const manifestSource = source?.kind === "arrow-stream-manifest" ? source.manifest : undefined;
-  const sampleLabel = arrowStreamSampleLabel(manifestSource);
+  const previewNotice = useMemo(() => arrowStreamPreviewNotice(manifestSource), [manifestSource]);
+  const isBoundedPreview = previewNotice !== null;
   const containerRef = useRef<HTMLDivElement>(null);
   const engineRef = useRef<TableEngine | null>(null);
   const engineDivRef = useRef<HTMLDivElement | null>(null);
@@ -400,24 +422,34 @@ export function SiftTable({
     return engineDivRef.current;
   }, []);
 
+  const markPreviewLoaded = useCallback(() => {
+    if (!isBoundedPreview) return;
+    const indicator = engineDivRef.current?.querySelector<HTMLElement>(".sift-status-indicator");
+    if (indicator) indicator.title = "Preview loaded";
+  }, [isBoundedPreview]);
+
   useEffect(() => {
     if (hasFooterControl) {
       getFooterControlElement();
     }
     footerControlRootRef.current?.render(
       <>
-        {sampleLabel && (
+        {previewNotice && (
           <span
-            className="sift-sample-hint"
-            title="The automatic table display is capped for safety."
+            className="sift-preview-hint"
+            title={previewNotice.title}
+            aria-label={`${previewNotice.label}. ${previewNotice.title}`}
           >
-            {sampleLabel}
+            <span>{previewNotice.label}</span>
+            <span className="sift-preview-scope" aria-hidden="true">
+              {" · Table tools use shown rows"}
+            </span>
           </span>
         )}
         {footerControl}
       </>,
     );
-  }, [footerControl, getFooterControlElement, hasFooterControl, sampleLabel]);
+  }, [footerControl, getFooterControlElement, hasFooterControl, previewNotice]);
 
   useEffect(() => {
     return () => {
@@ -603,6 +635,7 @@ export function SiftTable({
         } else {
           engineRef.current?.setStreamingDone();
         }
+        markPreviewLoaded();
         emitLoadMilestone(startedAt, {
           source: "arrow-stream-manifest",
           phase: "streaming-complete",
@@ -762,6 +795,7 @@ export function SiftTable({
     getFooterControlElement,
     getEngineElement,
     emitLoadMilestone,
+    markPreviewLoaded,
   ]);
 
   // Load from URL when `url` prop is provided.

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -405,6 +405,7 @@ export function SiftTable({
     if (!hasFooterControl) return undefined;
     if (!footerControlRef.current) {
       footerControlRef.current = document.createElement("div");
+      footerControlRef.current.className = "sift-footer-control";
       footerControlRootRef.current = createRoot(footerControlRef.current);
     }
     return footerControlRef.current;
@@ -437,6 +438,7 @@ export function SiftTable({
         {previewNotice && (
           <span
             className="sift-preview-hint"
+            role="note"
             title={previewNotice.title}
             aria-label={`${previewNotice.label}. ${previewNotice.title}`}
           >

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -405,7 +405,7 @@ export function SiftTable({
     if (!hasFooterControl) return undefined;
     if (!footerControlRef.current) {
       footerControlRef.current = document.createElement("div");
-      footerControlRef.current.className = "sift-footer-control";
+      footerControlRef.current.className = "sift-footer-slot";
       footerControlRootRef.current = createRoot(footerControlRef.current);
     }
     return footerControlRef.current;

--- a/packages/sift/src/style.test.ts
+++ b/packages/sift/src/style.test.ts
@@ -14,4 +14,11 @@ describe("Sift stylesheet", () => {
       /\.sift-viewport::-webkit-scrollbar-corner\s*\{\s*background:\s*var\(--sift-bg\);\s*\}/,
     );
   });
+
+  it("gives truncated preview text a shrinkable block container", () => {
+    // Ellipsis does not apply to a plain inline span, even with overflow set.
+    expect(styleCss).toMatch(
+      /\.sift-preview-hint\s*\{[^}]*display:\s*inline-block;[^}]*text-overflow:\s*ellipsis;/s,
+    );
+  });
 });

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -497,17 +497,18 @@ IOPub message stream and can be reused by other large-output producers.
 ### First Paint Strategy
 
 Small tables should serialize once to Arrow IPC and emit a complete one-chunk
-manifest. Large eager dataframes should emit `df.head(n)` as the first Arrow IPC
-chunk, where `n` is chosen by byte budget, then continue producing chunks after
-the first display is visible. Arrow-native and streaming sources should publish
-the first available record batch or head chunk, then append later chunks as they
-arrive.
+manifest. Automatic display of a large eager dataframe should emit a terminal,
+byte-bounded `df.head(n)` preview, where `n` is chosen by byte budget. It must not
+continue materializing or transporting the rest of the source in the background.
+Arrow-native and streaming sources should likewise publish a bounded first
+record batch or head preview without implying that those rows are statistically
+representative.
 
 The sub-200 ms first-render target applies after the dataframe/source object is
-available and only to the head-sample path. pandas/polars cannot render before
-an already-blocking dataframe conversion completes. The complete progressive
-manifest and any coalesced artifact are follow-on work and must not block the
-initial display.
+available and only when a bounded head can be produced without forcing full
+conversion. pandas/polars cannot render before an already-blocking dataframe
+conversion completes. Explicit helpers may progressively publish a source when
+the user requests that work; automatic repr remains terminal and bounded.
 
 ### Display Update Flow
 
@@ -786,48 +787,62 @@ Acceptance:
 - A table can show the first chunk and grow as subsequent chunks arrive.
 - Existing row-group parquet loading is unaffected.
 
-### Phase 4: Python Progressive Producer
+### Phase 4: Explicit Python Progressive Producer
 
-Goal: Python can publish first page quickly, then append chunks.
+Goal: an explicit Python helper can publish a first page quickly, then append
+chunks, without changing the bounded behavior of automatic repr.
 
 Changes:
 
 - Add a chunk writer abstraction in `nteract_kernel_launcher`.
 - Use `display_id` and `update_display_data` for progressive manifest updates.
-- For pandas/polars eager dataframes, emit `df.head(n)` first, then chunk rows
-  after conversion for the remaining data.
+- Keep automatic pandas/polars reprs terminal and byte-bounded. An explicit
+  progressive helper may emit `df.head(n)` first, then chunk remaining rows.
 - For Arrow-native and PyCapsule-compatible sources, import a
   `RecordBatchReader`, then write the first record batch or bounded mini-stream
   chunk directly.
-- For large or lazy sources, publish completed mini-stream chunks as batches are
-  produced. Do not require a replayable source.
+- For large or lazy sources, the explicit helper may publish completed
+  mini-stream chunks as batches are produced. Do not require a replayable
+  source.
 
 Acceptance:
 
 - A large Arrow table displays first rows before the whole table is serialized.
-- For a table where full serialization takes more than 1 second, the head chunk
-  renders within 200 ms after the dataframe/source object is available when the
-  head-sample path can produce `df.head(n)` without forcing full conversion.
+- For a table where full serialization takes more than 1 second, the first rows
+  render within 200 ms after the dataframe/source object is available when a
+  bounded head can be produced without forcing full conversion.
 - Final manifest is complete and durable.
 - Vanilla notebook fallback remains simple and stable.
 
-### Phase 5: Viewport-Driven Fetch
+### Phase 5: Source-Backed Continuation
 
-Goal: Sift renders the first chunk immediately and fetches more data only as the
-user or operation needs it.
+Goal: let a user explicitly continue from a bounded preview or apply a
+source-side predicate while keeping the scope and cost of every operation
+honest.
 
 Changes:
 
-- Load chunk 0 immediately when the manifest arrives.
-- Fetch additional chunks as the viewport nears unloaded rows.
-- For full-table sort/filter/search/export, request all missing chunks unless a
-  coalesced artifact is already available.
+- Retain a session-scoped source handle with explicit close, expiry, and
+  cancellation behavior. The durable notebook output remains the bounded
+  preview and must not depend on that handle after the session ends.
+- Fetch byte-bounded ranges only after an explicit user action such as “load
+  more.” A range continuation is not predicate pushdown: table tools remain
+  scoped to the rows currently shown.
+- Define a typed filter/sort/projection vocabulary and adapter contract for
+  predicate-aware requests. Do not send arbitrary JavaScript predicates into
+  Python.
+- Never silently request all missing rows for a full-table operation. Run it at
+  the source when supported, ask for confirmation before materializing more, or
+  keep the operation explicitly preview-scoped.
 - Preserve loaded table state while new chunks append.
 
 Acceptance:
 
-- Scrolling beyond loaded rows fetches the next chunk without reloading chunk 0.
-- Full-table operations either load all chunks or use the coalesced artifact.
+- Reopened notebooks render the durable bounded preview without a broken
+  continuation control.
+- An explicit bounded continuation appends rows without reloading the preview.
+- Predicate-aware results identify whether counts are exact, approximate, or
+  unknown and can be cancelled.
 - A missing later chunk surfaces a recoverable table error and keeps loaded rows.
 
 ### Phase 6: Direct Daemon Blob Upload

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -78,6 +78,8 @@ _ARROW_REPR_BYTE_BUDGET = int(
     os.environ.get("NTERACT_ARROW_REPR_BYTE_BUDGET", str(16 * 1024 * 1024))
 )
 _ARROW_REPR_MAX_ROWS = int(os.environ.get("NTERACT_ARROW_REPR_MAX_ROWS", "50000"))
+# Deliberately small: enough rows to estimate variable-width data without
+# making the safety probe itself a meaningful materialization cost.
 _DATASET_ARROW_PROBE_ROWS = 8
 _PLOTLY_RENDERER_ENTRYPOINTS = frozenset(
     {"plotly.express", "plotly.graph_objects", "plotly.graph_objs"}
@@ -222,7 +224,9 @@ def _dataset_head_rows_from_probe(table: Any, *, total_rows: int) -> int:
     if not isinstance(probe_bytes, int) or probe_bytes < 0:
         return min(probe_rows, max_rows)
     if probe_bytes == 0:
-        return max_rows
+        # A zero-byte report cannot justify a larger request. Keep the probe;
+        # the final serializer will still determine whether it can be emitted.
+        return min(probe_rows, max_rows)
 
     bytes_per_row = max(1, (probe_bytes + probe_rows - 1) // probe_rows)
     budget_rows = _ARROW_REPR_BYTE_BUDGET // bytes_per_row

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -78,6 +78,7 @@ _ARROW_REPR_BYTE_BUDGET = int(
     os.environ.get("NTERACT_ARROW_REPR_BYTE_BUDGET", str(16 * 1024 * 1024))
 )
 _ARROW_REPR_MAX_ROWS = int(os.environ.get("NTERACT_ARROW_REPR_MAX_ROWS", "50000"))
+_DATASET_ARROW_PROBE_ROWS = 8
 _PLOTLY_RENDERER_ENTRYPOINTS = frozenset(
     {"plotly.express", "plotly.graph_objects", "plotly.graph_objs"}
 )
@@ -206,6 +207,33 @@ def _arrow_stream_mimebundle(source: Any, include=None, exclude=None) -> dict | 
     return _emit_arrow_stream(source)
 
 
+def _dataset_head_rows_from_probe(table: Any, *, total_rows: int) -> int:
+    """Choose a logical Dataset head before materializing a large Arrow batch."""
+    max_rows = max(0, min(total_rows, _ARROW_REPR_MAX_ROWS))
+    probe_rows = table.num_rows
+    if max_rows == 0 or probe_rows == 0:
+        return 0
+
+    try:
+        probe_bytes = table.nbytes
+    except Exception as exc:  # noqa: BLE001
+        log.debug("dataset Arrow probe measurement failed: %s", exc)
+        return min(probe_rows, max_rows)
+    if not isinstance(probe_bytes, int) or probe_bytes < 0:
+        return min(probe_rows, max_rows)
+    if probe_bytes == 0:
+        return max_rows
+
+    bytes_per_row = max(1, (probe_bytes + probe_rows - 1) // probe_rows)
+    budget_rows = _ARROW_REPR_BYTE_BUDGET // bytes_per_row
+    hard_rows = _MAX_PAYLOAD_BYTES // bytes_per_row
+    clamped_min_rows = min(_ARROW_REPR_MIN_ROWS, max_rows)
+    selected_rows = min(max_rows, max(clamped_min_rows, budget_rows))
+    # One row is the smallest useful request and is already represented in the
+    # probe. The downstream serializer can still reject a single oversized row.
+    return min(selected_rows, max(1, hard_rows))
+
+
 def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
     """Emit Arrow IPC bytes + HF features summary for a ``datasets.Dataset``.
 
@@ -227,8 +255,22 @@ def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
             log.debug("dataset mimebundle failed: %s", exc)
             return None
 
+    total_rows = getattr(ds, "num_rows", None)
+    if not isinstance(total_rows, int):
+        total_rows = None
+
     try:
-        table = ds.with_format("arrow")[:_ARROW_REPR_MAX_ROWS]
+        arrow_view = ds.with_format("arrow")
+        probe_stop = min(
+            total_rows if total_rows is not None else _ARROW_REPR_MAX_ROWS,
+            _ARROW_REPR_MAX_ROWS,
+            _DATASET_ARROW_PROBE_ROWS,
+        )
+        table = arrow_view[:probe_stop]
+        measured_total_rows = total_rows if total_rows is not None else table.num_rows
+        selected_rows = _dataset_head_rows_from_probe(table, total_rows=measured_total_rows)
+        if selected_rows > table.num_rows:
+            table = arrow_view[:selected_rows]
     except Exception as exc:  # noqa: BLE001
         log.debug("dataset logical Arrow materialization failed: %s", exc)
         try:
@@ -236,8 +278,7 @@ def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
         except Exception:  # noqa: BLE001
             return None
 
-    total_rows = getattr(ds, "num_rows", table.num_rows)
-    if not isinstance(total_rows, int):
+    if total_rows is None:
         total_rows = table.num_rows
     return _emit_arrow_table(table, total_rows=total_rows, summary_fn=summary)
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -82,7 +82,8 @@ _ARROW_REPR_MAX_ROWS = int(os.environ.get("NTERACT_ARROW_REPR_MAX_ROWS", "50000"
 # making the safety probe itself a meaningful materialization cost.
 _DATASET_ARROW_PROBE_ROWS = 8
 # Re-measure at each prefix instead of jumping from the probe straight to the
-# estimated head. Eight keeps the cumulative work close to the final prefix.
+# estimated head. Eight limits each unmeasured row-count increase; accumulated
+# prefix rows remain below about 2.15x the final requested prefix.
 _DATASET_ARROW_PROBE_GROWTH = 8
 _PLOTLY_RENDERER_ENTRYPOINTS = frozenset(
     {"plotly.express", "plotly.graph_objects", "plotly.graph_objs"}
@@ -260,7 +261,15 @@ def _dataset_logical_arrow_head(arrow_view: Any, *, total_rows: int) -> Any:
         if next_rows <= requested_rows:
             break
 
-        widened = arrow_view[:next_rows]
+        try:
+            widened = arrow_view[:next_rows]
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "dataset logical Arrow widening stopped at %s rows: %s",
+                table.num_rows,
+                exc,
+            )
+            break
         requested_rows = next_rows
         if widened.num_rows <= table.num_rows:
             break

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -81,6 +81,9 @@ _ARROW_REPR_MAX_ROWS = int(os.environ.get("NTERACT_ARROW_REPR_MAX_ROWS", "50000"
 # Deliberately small: enough rows to estimate variable-width data without
 # making the safety probe itself a meaningful materialization cost.
 _DATASET_ARROW_PROBE_ROWS = 8
+# Re-measure at each prefix instead of jumping from the probe straight to the
+# estimated head. Eight keeps the cumulative work close to the final prefix.
+_DATASET_ARROW_PROBE_GROWTH = 8
 _PLOTLY_RENDERER_ENTRYPOINTS = frozenset(
     {"plotly.express", "plotly.graph_objects", "plotly.graph_objs"}
 )
@@ -238,6 +241,34 @@ def _dataset_head_rows_from_probe(table: Any, *, total_rows: int) -> int:
     return min(selected_rows, max(1, hard_rows))
 
 
+def _dataset_logical_arrow_head(arrow_view: Any, *, total_rows: int) -> Any:
+    """Materialize an estimated Dataset head through geometric prefix growth."""
+    max_rows = max(0, min(total_rows, _ARROW_REPR_MAX_ROWS))
+    requested_rows = min(max_rows, _DATASET_ARROW_PROBE_ROWS)
+    table = arrow_view[:requested_rows]
+
+    while table.num_rows < max_rows:
+        selected_rows = _dataset_head_rows_from_probe(table, total_rows=total_rows)
+        if selected_rows <= table.num_rows:
+            break
+
+        next_rows = min(
+            selected_rows,
+            max_rows,
+            max(table.num_rows + 1, table.num_rows * _DATASET_ARROW_PROBE_GROWTH),
+        )
+        if next_rows <= requested_rows:
+            break
+
+        widened = arrow_view[:next_rows]
+        requested_rows = next_rows
+        if widened.num_rows <= table.num_rows:
+            break
+        table = widened
+
+    return table
+
+
 def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
     """Emit Arrow IPC bytes + HF features summary for a ``datasets.Dataset``.
 
@@ -265,16 +296,10 @@ def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
 
     try:
         arrow_view = ds.with_format("arrow")
-        probe_stop = min(
-            total_rows if total_rows is not None else _ARROW_REPR_MAX_ROWS,
-            _ARROW_REPR_MAX_ROWS,
-            _DATASET_ARROW_PROBE_ROWS,
+        table = _dataset_logical_arrow_head(
+            arrow_view,
+            total_rows=total_rows if total_rows is not None else _ARROW_REPR_MAX_ROWS,
         )
-        table = arrow_view[:probe_stop]
-        measured_total_rows = total_rows if total_rows is not None else table.num_rows
-        selected_rows = _dataset_head_rows_from_probe(table, total_rows=measured_total_rows)
-        if selected_rows > table.num_rows:
-            table = arrow_view[:selected_rows]
     except Exception as exc:  # noqa: BLE001
         log.debug("dataset logical Arrow materialization failed: %s", exc)
         try:

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -1361,6 +1361,45 @@ def test_dataset_mimebundle_geometrically_reaches_a_small_uniform_dataset(monkey
     }
 
 
+def test_dataset_mimebundle_keeps_last_good_prefix_when_widening_fails(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+
+    requested = []
+
+    class FakeDataset:
+        num_rows = 1_000
+        data = SimpleNamespace(table=object())
+
+        def with_format(self, format_name):
+            assert format_name == "arrow"
+            return self
+
+        def __getitem__(self, key):
+            requested.append(key)
+            if key.stop > _bootstrap._DATASET_ARROW_PROBE_ROWS:
+                raise RuntimeError("widening failed")
+            return pa.table({"value": list(range(key.stop))})
+
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_BYTE_BUDGET", 64 * 1_024)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 50_000)
+    monkeypatch.setattr(_bootstrap, "_MAX_PAYLOAD_BYTES", 128 * 1_024)
+    monkeypatch.setattr(_bootstrap, "summarize_dataset", lambda dataset: "dataset summary")
+
+    bundle = _bootstrap._dataset_mimebundle(FakeDataset())
+
+    assert bundle is not None
+    assert requested == [slice(None, 8, None), slice(None, 64, None)]
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"] == {
+        "total_rows": 1_000,
+        "included_rows": 8,
+        "sampled": True,
+        "sample_strategy": "head",
+    }
+
+
 @pytest.mark.parametrize("probe_bytes", [0, "invalid", RuntimeError("measurement failed")])
 def test_dataset_head_probe_keeps_bounded_rows_when_measurement_is_unusable(
     monkeypatch, probe_bytes

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -1286,6 +1286,26 @@ def test_dataset_mimebundle_probes_row_weight_before_materializing_logical_head(
     }
 
 
+@pytest.mark.parametrize("probe_bytes", [0, "invalid", RuntimeError("measurement failed")])
+def test_dataset_head_probe_keeps_bounded_rows_when_measurement_is_unusable(
+    monkeypatch, probe_bytes
+):
+    from nteract_kernel_launcher import _bootstrap
+
+    class Probe:
+        num_rows = 8
+
+        @property
+        def nbytes(self):
+            if isinstance(probe_bytes, Exception):
+                raise probe_bytes
+            return probe_bytes
+
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 50_000)
+
+    assert _bootstrap._dataset_head_rows_from_probe(Probe(), total_rows=3_000) == 8
+
+
 def test_dataset_mimebundle_falls_back_to_summary_when_no_table():
     """Streaming / iterable datasets have no ``.data.table``; the formatter
     must keep the legacy text-only behavior so it stays best-effort."""

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -1248,6 +1248,44 @@ def test_dataset_mimebundle_caps_rows_before_logical_arrow_materialization(monke
     }
 
 
+def test_dataset_mimebundle_probes_row_weight_before_materializing_logical_head(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+
+    requested = []
+
+    class FakeDataset:
+        num_rows = 3_000
+        data = SimpleNamespace(table=object())
+
+        def with_format(self, format_name):
+            assert format_name == "arrow"
+            return self
+
+        def __getitem__(self, key):
+            requested.append(key)
+            return pa.table({"payload": [b"x" * 16] * key.stop})
+
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MIN_ROWS", 4)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_BYTE_BUDGET", 64)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 50_000)
+    monkeypatch.setattr(_bootstrap, "_MAX_PAYLOAD_BYTES", 2_048)
+    monkeypatch.setattr(_bootstrap, "summarize_dataset", lambda dataset: "dataset summary")
+
+    bundle = _bootstrap._dataset_mimebundle(FakeDataset())
+
+    assert bundle is not None
+    assert requested == [slice(None, 8, None)]
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"] == {
+        "total_rows": 3_000,
+        "included_rows": 4,
+        "sampled": True,
+        "sample_strategy": "head",
+    }
+
+
 def test_dataset_mimebundle_falls_back_to_summary_when_no_table():
     """Streaming / iterable datasets have no ``.data.table``; the formatter
     must keep the legacy text-only behavior so it stays best-effort."""

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -1286,6 +1286,81 @@ def test_dataset_mimebundle_probes_row_weight_before_materializing_logical_head(
     }
 
 
+def test_dataset_mimebundle_remeasures_each_geometrically_widened_prefix(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap
+
+    requested = []
+
+    class FakeDataset:
+        num_rows = 50_000
+        data = SimpleNamespace(table=object())
+
+        def with_format(self, format_name):
+            assert format_name == "arrow"
+            return self
+
+        def __getitem__(self, key):
+            requested.append(key)
+            return pa.table(
+                {
+                    "payload": [
+                        b"x" if index < _bootstrap._DATASET_ARROW_PROBE_ROWS else b"x" * 1_024
+                        for index in range(key.stop)
+                    ]
+                }
+            )
+
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MIN_ROWS", 4)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_BYTE_BUDGET", 4_096)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 50_000)
+    monkeypatch.setattr(_bootstrap, "_MAX_PAYLOAD_BYTES", 8_192)
+    monkeypatch.setattr(_bootstrap, "summarize_dataset", lambda dataset: "dataset summary")
+
+    bundle = _bootstrap._dataset_mimebundle(FakeDataset())
+
+    assert bundle is not None
+    assert requested == [slice(None, 8, None), slice(None, 64, None)]
+
+
+def test_dataset_mimebundle_geometrically_reaches_a_small_uniform_dataset(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+
+    requested = []
+
+    class FakeDataset:
+        num_rows = 512
+        data = SimpleNamespace(table=object())
+
+        def with_format(self, format_name):
+            assert format_name == "arrow"
+            return self
+
+        def __getitem__(self, key):
+            requested.append(key)
+            return pa.table({"value": list(range(key.stop))})
+
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_BYTE_BUDGET", 64 * 1_024)
+    monkeypatch.setattr(_bootstrap, "_ARROW_REPR_MAX_ROWS", 50_000)
+    monkeypatch.setattr(_bootstrap, "_MAX_PAYLOAD_BYTES", 128 * 1_024)
+    monkeypatch.setattr(_bootstrap, "summarize_dataset", lambda dataset: "dataset summary")
+
+    bundle = _bootstrap._dataset_mimebundle(FakeDataset())
+
+    assert bundle is not None
+    assert requested == [slice(None, 8, None), slice(None, 64, None), slice(None, 512, None)]
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"] == {
+        "total_rows": 512,
+        "included_rows": 512,
+        "sampled": False,
+        "sample_strategy": "none",
+    }
+
+
 @pytest.mark.parametrize("probe_bytes", [0, "invalid", RuntimeError("measurement failed")])
 def test_dataset_head_probe_keeps_bounded_rows_when_measurement_is_unusable(
     monkeypatch, probe_bytes


### PR DESCRIPTION
## Summary

- describe capped table output as a bounded preview of the first rows, with known or unknown totals, instead of calling it a sample
- make the completion state honest: the runner settles, the status says "Preview loaded," and the footer states that sorting, filtering, and summaries use shown rows
- widen Hugging Face Dataset prefixes geometrically and remeasure each step, avoiding a single optimistic jump from an eight-row probe to as many as 50,000 heavy rows
- retain the last valid bounded prefix if a later widening request fails
- keep the disclosure shrinkable at practical notebook widths and expose its complete meaning as an assistive-technology note
- frame future "load more" and predicate-aware filtering as explicit, source-backed capabilities rather than automatic background fetching

## Product decision

Automatic dataframe display is a terminal, durable, memory-safe preview. It does not imply statistical representativeness and does not continue materializing the source after first paint.

A future continuation path should retain an optional session-scoped source handle. Simple range continuation can append another bounded window after an explicit action. Predicate-aware exploration needs a typed filter/sort/projection contract with source adapters, cancellation, and honest exact/approximate/unknown totals. Until then, table tools remain scoped to rows already shown.

## Verification

- `cargo xtask lint --fix`
- `uv run --project python/nteract-kernel-launcher --group dev pytest python/nteract-kernel-launcher/tests -q` — 132 passed
- `pnpm --filter @nteract/sift test -- --run` — 196 passed
- `pnpm --filter @nteract/sift build`
- `pnpm --filter @nteract/sift build:lib`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- Elements Chromium QA at 900, 700, 600, and 480 px viewport widths: the footer stays within its container and ellipsizes the visible disclosure
- Chromium accessibility snapshot exposes the complete preview scope as a named `note`
